### PR TITLE
Make `auth` optional

### DIFF
--- a/packages/rest-api-client/README.md
+++ b/packages/rest-api-client/README.md
@@ -21,8 +21,8 @@ const client = new KintoneRestAPIClient({
   auth: { username: "username", password: "password" }
   // Use API Token authentication
   // auth: { apiToken: "API_TOKEN" }
-  // Use session authentication (in browser only)
-  // auth: {}
+
+  // Use session authentication if `auth` is omitted (in browser only)
 });
 
 client.record

--- a/packages/rest-api-client/src/KintoneRestAPIClient.ts
+++ b/packages/rest-api-client/src/KintoneRestAPIClient.ts
@@ -51,10 +51,10 @@ export class KintoneRestAPIClient {
 
   constructor({
     host,
-    auth: partialAuth
+    auth: partialAuth = {}
   }: {
     host: string;
-    auth: PartialAuth;
+    auth?: PartialAuth;
   }) {
     const auth = this.buildAuth(partialAuth);
     const params = this.buildParams(auth);

--- a/packages/rest-api-client/src/__tests__/KintoneAPIClient.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneAPIClient.test.ts
@@ -67,6 +67,12 @@ describe("KintoneRestAPIClient", () => {
           "X-Requested-With": "XMLHttpRequest"
         });
       });
+      it("should use Session auth if auth param is not specified", () => {
+        const client = new KintoneRestAPIClient({ host });
+        expect(client.getHeaders()).toEqual({
+          "X-Requested-With": "XMLHttpRequest"
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
It would be better in the browser environment if we can omit `auth` param when creating APIClient object.