### PR TITLE
chore: drop support Node v8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.12.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/packages/rest-api-client/package.json
+++ b/packages/rest-api-client/package.json
@@ -53,6 +53,9 @@
     "url": "https://github.com/kintone/js-sdk/issues"
   },
   "homepage": "https://github.com/kintone/js-sdk/tree/master/packages/rest-api-client#readme",
+  "engines": {
+    "node": ">=10.0.0"
+  },
   "devDependencies": {
     "@kintone/customize-uploader": "^2.0.6",
     "@types/core-js": "^2.5.2",


### PR DESCRIPTION
BREAKING CHANGE: no longer support Node v8