### PR TITLE
chore: fix the repository field of pacakge.json for monorepo support

### DIFF
--- a/packages/rest-api-client/package.json
+++ b/packages/rest-api-client/package.json
@@ -36,7 +36,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kintone/js-sdk.git"
+    "url": "git+https://github.com/kintone/js-sdk.git",
+    "directory": "packages/rest-api-client"
   },
   "files": [
     "esm",


### PR DESCRIPTION
We should specify the `repository.directory` field in the `package.json` each monorepo packages.

https://github.com/renovatebot/renovate/issues/2926#issuecomment-575094237

It's a recommended way of npm.
https://docs.npmjs.com/files/package.json#repository