### PR TITLE
fix: type definition of Comment.id

### DIFF
--- a/packages/rest-api-client/src/client/RecordClient.ts
+++ b/packages/rest-api-client/src/client/RecordClient.ts
@@ -12,7 +12,7 @@ type Mention = {
 };
 
 type Comment = {
-  id: number;
+  id: string;
   text: string;
   createdAt: string;
   creator: {


### PR DESCRIPTION
In the response type of `getRecordComments()`, `Comment.id` should be `string`.