### PR TITLE
chore: add useWorkspaces option into lerna.json

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,6 @@
 {
   "npmClient": "yarn",
+  "useWorkspaces": true,
   "packages": [
     "packages/*"
   ],


### PR DESCRIPTION
This would fix the issue https://github.com/kintone/js-sdk/pull/90#issuecomment-593561340.
The option affects `lerna bootstrap` command only, so I guess Renovate uses `lerna bootstrap` command internally.

https://github.com/lerna/lerna/blob/92f3c6691b8dd87227e85acdefef66662d49340d/commands/bootstrap/README.md#--use-workspaces