### PR TITLE
fix: consider when error.bulkRequestIndex = 0

### DIFF
--- a/packages/rest-api-client/src/KintoneAllRecordsError.ts
+++ b/packages/rest-api-client/src/KintoneAllRecordsError.ts
@@ -17,7 +17,7 @@ export class KintoneAllRecordsError extends Error {
     processedRecordsResult: object[],
     chunkLength: number
   ) {
-    if (error.bulkRequestIndex && error.errors) {
+    if (error.bulkRequestIndex !== undefined && error.errors) {
       const errorParseResult = KintoneAllRecordsError.parseErrorIndex(
         error.errors
       );

--- a/packages/rest-api-client/src/__tests__/KintoneAllRecordsError.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneAllRecordsError.test.ts
@@ -104,5 +104,40 @@ describe("KintoneAllRecordsError", () => {
           unprocessedRecords.length} records are processed successfully`
       );
     });
+    it("should set errorIndex even if bulkRequestIndex = 0", () => {
+      errorResponse = {
+        data: {
+          results: [
+            {
+              id: "some id",
+              code: "some code",
+              message: "some error message",
+              errors: {
+                [`records[${errorParseResult}].Customer`]: {
+                  messages: ["key is missing"]
+                }
+              }
+            },
+            {},
+            {}
+          ]
+        },
+        status: 500,
+        headers: {
+          "X-Some-Header": "error"
+        }
+      };
+      kintoneRestApiError = new KintoneRestAPIError(errorResponse);
+      kintoneAllRecordsError = new KintoneAllRecordsError(
+        processedRecordsResult,
+        unprocessedRecords,
+        kintoneRestApiError,
+        chunkLength
+      );
+
+      expect(kintoneAllRecordsError.errorIndex).toBe(
+        processedRecordsResult.length + errorParseResult
+      );
+    });
   });
 });


### PR DESCRIPTION
It seems `KintoneAllRecordsError.extractErrorIndex()` doesn't work correctly if `error.bulkRequestIndex = 0`.