### PR TITLE
test(rest-api-client): disable jsdom for unit testing

### DIFF
--- a/packages/rest-api-client/jest.config.js
+++ b/packages/rest-api-client/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
   rootDir: "src",
   setupFilesAfterEnv: ["<rootDir>/__tests__/setup.ts"],
   testPathIgnorePatterns: ["node_modules", "<rootDir>/__tests__/setup.ts"],
+  testEnvironment: "node",
 };

--- a/packages/rest-api-client/src/__tests__/KintoneRestAPIClient.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneRestAPIClient.test.ts
@@ -12,21 +12,14 @@ import { ErrorResponse, HttpClientError } from "../http/HttpClientInterface";
 describe("KintoneRestAPIClient", () => {
   describe("constructor", () => {
     let originalKintone: any;
-    let originalLocation: any;
     beforeEach(() => {
       originalKintone = global.kintone;
-      originalLocation = Object.getOwnPropertyDescriptor(global, "location");
-      Object.defineProperty(global, "location", {
-        writable: true,
-      });
       global.kintone = {
         getRequestToken: () => "dummy request token",
       };
     });
     afterEach(() => {
       global.kintone = originalKintone;
-      // Enable to update the location object to mock
-      Object.defineProperty(global, "location", originalLocation);
     });
     describe("Header", () => {
       const baseUrl = "https://example.com";


### PR DESCRIPTION
This is a part of #168 
Jest's default test environment is `jsdom`.
https://jestjs.io/docs/en/configuration#testenvironment-string

`rest-api-client` doesn't need `jsdom` as a unit test environment, so I disable the setting.
I've also removed a setup code depending on `jsdom`.

