### PR TITLE
test(customize-uploader): disable jsdom for unit testing

### DIFF
--- a/packages/customize-uploader/jest.config.js
+++ b/packages/customize-uploader/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
-  testRegex: "/__tests__/.*\\.test\\.ts$"
+  testRegex: "/__tests__/.*\\.test\\.ts$",
+  testEnvironment: "node",
 };


### PR DESCRIPTION
`customize-uploader` doesn't need `jsdom`.
See #169 for the detail.