### PR TITLE
fix(customize-uploader): wrong require file paths in bin/cli.js

### DIFF
--- a/packages/customize-uploader/bin/cli.js
+++ b/packages/customize-uploader/bin/cli.js
@@ -2,13 +2,13 @@
 
 const osLocale = require('os-locale');
 const meow = require('meow');
-const { run } = require('../dist/src/index');
-const { runInit } = require('../dist/src/init');
-const { runImport } = require('../dist/src/import');
-const { inquireInitParams } = require('../dist/src/initParams');
-const { inquireParams } = require('../dist/src/params');
-const { getDefaultLang } = require('../dist/src/lang');
-const { getMessage } = require('../dist/src/messages');
+const { run } = require('../dist/index');
+const { runInit } = require('../dist/init');
+const { runImport } = require('../dist/import');
+const { inquireInitParams } = require('../dist/initParams');
+const { inquireParams } = require('../dist/params');
+const { getDefaultLang } = require('../dist/lang');
+const { getMessage } = require('../dist/messages');
 
 const {
   HTTP_PROXY,

--- a/packages/customize-uploader/package.json
+++ b/packages/customize-uploader/package.json
@@ -5,7 +5,7 @@
   "bin": {
     "kintone-customize-uploader": "bin/cli.js"
   },
-  "main": "dist/src/index.js",
+  "main": "dist/index.js",
   "engines": {
     "node": ">=10"
   },


### PR DESCRIPTION
The current version of the `kintone-customize-uploader` command is broken due to the wrong require paths.
I'm not sure why it has happened.
But I want to fix this ASAP, so I've created a PR.