### PR TITLE
chore: add npm start

### DIFF
--- a/packages/rest-api-client/package.json
+++ b/packages/rest-api-client/package.json
@@ -25,13 +25,14 @@
     "clean": "rimraf lib esm umd",
     "compile": "run-p -l compile:*",
     "compile:esm": "tsc -p tsconfig.esm.json",
-    "compile:cjs": "tsc -p tsconfig.json",
+    "compile:cjs": "tsc",
     "fix:lint": "npm run lint:eslint -- --fix",
     "fix:md": "prettier --write README.md 'docs/**/*.md'",
     "fix": "run-p fix:*",
     "lint:eslint": "eslint 'src/**/*.ts'",
     "lint:md": "prettier --check README.md 'docs/**/*.md'",
-    "lint:ts": "tsc --noEmit"
+    "lint:ts": "tsc --noEmit",
+    "start": "npm run compile:cjs -- --watch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR is to add an npm-scripts to create `lib/*.js` files with a watch mode.
This is useful for type checking, and executing a script in `examples/rest-api-client-demo`.
Because when we use `@kintone/rest-api-client` in other packages, `lib/*.js`files are used, so we have to compile to use the latest version of `@kintone/rest-api-client`.
