### PR TITLE
build: use paths compiler option to run scripts without compiling

### DIFF
--- a/examples/rest-api-client-demo/README.md
+++ b/examples/rest-api-client-demo/README.md
@@ -33,7 +33,7 @@ We have an app ID in `customize-manifest.json`, so you have to update the app ID
 ### Run a script with `ts-node`
 
 ```
-% npx ts-node src/run-node.ts record getRecord
+% yarn script record getRecord
 ```
 
 ### Upload scripts to your Kintone environment

--- a/examples/rest-api-client-demo/README.md
+++ b/examples/rest-api-client-demo/README.md
@@ -33,7 +33,7 @@ We have an app ID in `customize-manifest.json`, so you have to update the app ID
 ### Run a script with `ts-node`
 
 ```
-% yarn script record getRecord
+% yarn run-script record getRecord
 ```
 
 ### Upload scripts to your Kintone environment

--- a/examples/rest-api-client-demo/package.json
+++ b/examples/rest-api-client-demo/package.json
@@ -21,7 +21,7 @@
     "lint": "run-p -l lint:*",
     "deploy": "rimraf scripts/dist && run-s webpack upload",
     "upload": "kintone-customize-uploader customize-manifest.json",
-    "script": "ts-node -r tsconfig-paths/register src/run-node.ts",
+    "run-script": "ts-node -r tsconfig-paths/register src/run-node.ts",
     "webpack": "webpack"
   },
   "bugs": {

--- a/examples/rest-api-client-demo/package.json
+++ b/examples/rest-api-client-demo/package.json
@@ -21,6 +21,7 @@
     "lint": "run-p -l lint:*",
     "deploy": "rimraf scripts/dist && run-s webpack upload",
     "upload": "kintone-customize-uploader customize-manifest.json",
+    "script": "ts-node -r tsconfig-paths/register src/run-node.ts",
     "webpack": "webpack"
   },
   "bugs": {
@@ -35,6 +36,7 @@
   "devDependencies": {
     "@kintone/customize-uploader": "3.0.3",
     "ts-node": "^8.8.2",
+    "tsconfig-paths": "^3.9.0",
     "webpack": "^4.42.1",
     "webpack-cli": "^3.3.11"
   }

--- a/examples/rest-api-client-demo/tsconfig.json
+++ b/examples/rest-api-client-demo/tsconfig.json
@@ -40,8 +40,10 @@
 
     /* Module Resolution Options */
     "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "baseUrl": "../../",                       /* Base directory to resolve non-absolute module names. */
+    "paths": {
+      "@kintone/rest-api-client": ["packages/rest-api-client/src"]
+    },                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     "typeRoots": [
       "node_modules/@types",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2039,6 +2039,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -9310,6 +9315,16 @@ ts-node@^8.8.2:
     make-error "^1.1.1"
     source-map-support "^0.5.6"
     yn "3.1.1"
+
+tsconfig-paths@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
+  integrity sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.0"
+    strip-bom "^3.0.0"
 
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.1"


### PR DESCRIPTION
After #177  had been merged, we need to compile `rest-api-client` to run scripts in `rest-api-client-demo`.
In order to fix this, I've created a PR #182, but we still need to compile with this PR.
It's cumbersome, so I take another option, which is a way to use the `paths` compiler option.

In this PR, we can run scripts as `yarn script record getRecord` regardless of compiling `rest-api-client`, which is the same experience before #177.