### PR TITLE
refactor: move functions which create request config to KintoneRequestConfigBuilder

### DIFF
--- a/packages/rest-api-client/.eslintrc.js
+++ b/packages/rest-api-client/.eslintrc.js
@@ -1,8 +1,3 @@
 module.exports = {
   extends: "@cybozu/eslint-config/presets/node-typescript-prettier",
-  "rules": {
-    "node/no-missing-import": ["error", {
-      "allowModules": ["type-fest"]
-    }]
-  }
 };

--- a/packages/rest-api-client/.eslintrc.js
+++ b/packages/rest-api-client/.eslintrc.js
@@ -1,3 +1,8 @@
 module.exports = {
-  extends: "@cybozu/eslint-config/presets/node-typescript-prettier"
+  extends: "@cybozu/eslint-config/presets/node-typescript-prettier",
+  "rules": {
+    "node/no-missing-import": ["error", {
+      "allowModules": ["type-fest"]
+    }]
+  }
 };

--- a/packages/rest-api-client/src/KintoneRequestConfigBuilder.ts
+++ b/packages/rest-api-client/src/KintoneRequestConfigBuilder.ts
@@ -132,10 +132,6 @@ export class KintoneRequestConfigBuilder implements RequestConfigBuilder {
     }
   }
 
-  // FIXME: this doesn't add this.params on the query
-  // because this.params is for __REQUEST_TOKEN__.
-  // But it depends on what this.params includes.
-  // we should consider to rename this.params.
   private buildRequestUrl(path: string, params: Data): string {
     return `${this.baseUrl}${path}?${qs.stringify(params)}`;
   }
@@ -152,7 +148,6 @@ export class KintoneRequestConfigBuilder implements RequestConfigBuilder {
         ...params,
       };
     }
-    // This params are always sent as a request body.
     return params;
   }
 

--- a/packages/rest-api-client/src/KintoneRequestConfigBuilder.ts
+++ b/packages/rest-api-client/src/KintoneRequestConfigBuilder.ts
@@ -143,24 +143,15 @@ export class KintoneRequestConfigBuilder implements RequestConfigBuilder {
 
   private buildData<T extends Data>(params: T): T {
     if (this.auth.type === "session") {
-      try {
-        const requestToken = platformDeps.getRequestToken();
-        if (params instanceof FormData) {
-          params.append("__REQUEST_TOKEN__", requestToken);
-          return params;
-        }
-        return {
-          __REQUEST_TOKEN__: requestToken,
-          ...params,
-        };
-      } catch (e) {
-        if (e instanceof UnsupportedPlatformError) {
-          throw new Error(
-            `session authentication is not supported in ${e.platform} environment.`
-          );
-        }
-        throw e;
+      const requestToken = platformDeps.getRequestToken();
+      if (params instanceof FormData) {
+        params.append("__REQUEST_TOKEN__", requestToken);
+        return params;
       }
+      return {
+        __REQUEST_TOKEN__: requestToken,
+        ...params,
+      };
     }
     // This params are always sent as a request body.
     return params;

--- a/packages/rest-api-client/src/KintoneRequestConfigBuilder.ts
+++ b/packages/rest-api-client/src/KintoneRequestConfigBuilder.ts
@@ -11,7 +11,6 @@ import {
 } from "./http/HttpClientInterface";
 import {
   KintoneAuthHeader,
-  HTTPClientParams,
   Auth,
   ApiTokenAuth,
   PasswordAuth,
@@ -145,17 +144,6 @@ export class KintoneRequestConfigBuilder implements RequestConfigBuilder {
     }
   }
 
-  getHeaders() {
-    return this.headers;
-  }
-
-  setHeaders(headers: KintoneAuthHeader) {
-    this.headers = headers;
-  }
-
-  setRequestToken(requestToken: string) {
-    this.requestToken = requestToken;
-  }
   // FIXME: this doesn't add this.params on the query
   // because this.params is for __REQUEST_TOKEN__.
   // But it depends on what this.params includes.

--- a/packages/rest-api-client/src/KintoneRequestConfigBuilder.ts
+++ b/packages/rest-api-client/src/KintoneRequestConfigBuilder.ts
@@ -15,7 +15,6 @@ import {
   DiscriminatedAuth,
 } from "./KintoneRestAPIClient";
 import { platformDeps } from "./platform/";
-import { UnsupportedPlatformError } from "./platform/UnsupportedPlatformError";
 
 type Data = Params | FormData;
 

--- a/packages/rest-api-client/src/KintoneRequestConfigBuilder.ts
+++ b/packages/rest-api-client/src/KintoneRequestConfigBuilder.ts
@@ -11,21 +11,11 @@ import {
 } from "./http/HttpClientInterface";
 import {
   KintoneAuthHeader,
-  Auth,
-  ApiTokenAuth,
-  PasswordAuth,
-  SessionAuth,
-  OAuthTokenAuth,
   BasicAuth,
+  DiscriminatedAuth,
 } from "./KintoneRestAPIClient";
 import { platformDeps } from "./platform/";
 import { UnsupportedPlatformError } from "./platform/UnsupportedPlatformError";
-
-type DiscriminatedAuth =
-  | ApiTokenAuth
-  | PasswordAuth
-  | SessionAuth
-  | OAuthTokenAuth;
 
 type Data = Params | FormData;
 
@@ -53,7 +43,7 @@ export class KintoneRequestConfigBuilder implements RequestConfigBuilder {
     proxy,
   }: {
     baseUrl: string;
-    auth?: Auth;
+    auth: DiscriminatedAuth;
     basicAuth?: BasicAuth;
     clientCertAuth?:
       | {
@@ -67,11 +57,12 @@ export class KintoneRequestConfigBuilder implements RequestConfigBuilder {
     proxy?: ProxyConfig;
   }) {
     this.baseUrl = baseUrl;
-    this.auth = buildDiscriminatedAuth(auth ?? {});
+    this.auth = auth;
     this.headers = this.buildHeaders(basicAuth);
     this.clientCertAuth = clientCertAuth;
     this.proxy = proxy;
   }
+
   public build(
     method: HttpMethod,
     path: string,
@@ -207,19 +198,4 @@ export class KintoneRequestConfigBuilder implements RequestConfigBuilder {
       }
     }
   }
-}
-
-function buildDiscriminatedAuth(auth: Auth): DiscriminatedAuth {
-  if ("username" in auth) {
-    return { type: "password", ...auth };
-  }
-  if ("apiToken" in auth) {
-    return { type: "apiToken", ...auth };
-  }
-  if ("oAuthToken" in auth) {
-    return { type: "oAuthToken", ...auth };
-  }
-  return {
-    type: "session",
-  };
 }

--- a/packages/rest-api-client/src/KintoneRestAPIClient.ts
+++ b/packages/rest-api-client/src/KintoneRestAPIClient.ts
@@ -16,10 +16,6 @@ import { KintoneRequestConfigBuilder } from "./KintoneRequestConfigBuilder";
 import { platformDeps } from "./platform/index";
 import { UnsupportedPlatformError } from "./platform/UnsupportedPlatformError";
 
-export type HTTPClientParams = {
-  __REQUEST_TOKEN__?: string;
-};
-
 export type DiscriminatedAuth =
   | ApiTokenAuth
   | PasswordAuth

--- a/packages/rest-api-client/src/KintoneRestAPIClient.ts
+++ b/packages/rest-api-client/src/KintoneRestAPIClient.ts
@@ -1,4 +1,3 @@
-import { SetRequired } from "type-fest";
 import { BulkRequestClient, EndpointName } from "./client/BulkRequestClient";
 import { AppClient } from "./client/AppClient";
 import { RecordClient } from "./client/RecordClient";
@@ -163,7 +162,9 @@ export class KintoneRestAPIClient {
 
 function assertsOptions(
   options: Options
-): asserts options is SetRequired<Options, "baseUrl"> {
+): asserts options is Options & {
+  baseUrl: string;
+} {
   if (typeof options.baseUrl !== "string") {
     throw new Error("in Node.js environment, baseUrl is required");
   }

--- a/packages/rest-api-client/src/KintoneRestAPIClient.ts
+++ b/packages/rest-api-client/src/KintoneRestAPIClient.ts
@@ -108,7 +108,6 @@ export class KintoneRestAPIClient {
   app: AppClient;
   file: FileClient;
   private bulkRequest_: BulkRequestClient;
-  private headers: KintoneAuthHeader;
   private baseUrl?: string;
 
   constructor(options: Options = {}) {
@@ -119,7 +118,6 @@ export class KintoneRestAPIClient {
       errorResponseHandler,
       requestConfigBuilder,
     });
-    this.headers = requestConfigBuilder.getHeaders();
     const { guestSpaceId } = options;
 
     this.bulkRequest_ = new BulkRequestClient(httpClient, guestSpaceId);
@@ -130,10 +128,6 @@ export class KintoneRestAPIClient {
 
   public getBaseUrl() {
     return this.baseUrl;
-  }
-
-  public getHeaders() {
-    return this.headers;
   }
 
   public bulkRequest(params: {

--- a/packages/rest-api-client/src/KintoneRestAPIClient.ts
+++ b/packages/rest-api-client/src/KintoneRestAPIClient.ts
@@ -32,22 +32,22 @@ export type Auth =
   | Omit<SessionAuth, "type">
   | Omit<OAuthTokenAuth, "type">;
 
-export type ApiTokenAuth = {
+type ApiTokenAuth = {
   type: "apiToken";
   apiToken: string | string[];
 };
 
-export type PasswordAuth = {
+type PasswordAuth = {
   type: "password";
   username: string;
   password: string;
 };
 
-export type SessionAuth = {
+type SessionAuth = {
   type: "session";
 };
 
-export type OAuthTokenAuth = {
+type OAuthTokenAuth = {
   type: "oAuthToken";
   oAuthToken: string;
 };

--- a/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
@@ -6,9 +6,7 @@ import * as nodeDeps from "../platform/node";
 
 describe("KintoneRequestConfigBuilder", () => {
   const baseUrl = "https://example.kintone.com";
-  const headers = {
-    "X-Cybozu-API-Token": "foo",
-  };
+  const apiToken = "apiToken";
   const requestToken = "foo-bar";
   const params = {
     __REQUEST_TOKEN__: requestToken,
@@ -17,10 +15,11 @@ describe("KintoneRequestConfigBuilder", () => {
   beforeEach(() => {
     kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
       baseUrl,
+      auth: {
+        apiToken,
+      },
       ...params,
     });
-    kintoneRequestConfigBuilder.setHeaders(headers);
-    kintoneRequestConfigBuilder.setRequestToken(requestToken);
   });
   it("should build get method requestConfig", () => {
     const requestConfig = kintoneRequestConfigBuilder.build(
@@ -31,10 +30,12 @@ describe("KintoneRequestConfigBuilder", () => {
     expect(requestConfig).toEqual({
       method: "get",
       url: `${baseUrl}/k/v1/record.json?key=value`,
-      headers,
+      headers: {
+        "X-Cybozu-API-Token": apiToken,
+      },
     });
   });
-  it("should build post method requestConfig if the request URL is over the threshold", () => {
+  it.skip("should build post method requestConfig if the request URL is over the threshold", () => {
     const value = "a".repeat(4096);
     const requestConfig = kintoneRequestConfigBuilder.build(
       "get",
@@ -44,7 +45,10 @@ describe("KintoneRequestConfigBuilder", () => {
     expect(requestConfig).toEqual({
       method: "post",
       url: `${baseUrl}/k/v1/record.json`,
-      headers: { ...headers, "X-HTTP-Method-Override": "GET" },
+      headers: {
+        "X-Cybozu-API-Token": apiToken,
+        "X-HTTP-Method-Override": "GET",
+      },
       data: { ...params, key: value },
     });
   });
@@ -58,11 +62,13 @@ describe("KintoneRequestConfigBuilder", () => {
     expect(requestConfig).toEqual({
       method: "get",
       url: `${baseUrl}/k/v1/record.json?key=value`,
-      headers,
+      headers: {
+        "X-Cybozu-API-Token": apiToken,
+      },
       responseType: "arraybuffer",
     });
   });
-  it("should build post method requestConfig", () => {
+  it.skip("should build post method requestConfig", () => {
     const requestConfig = kintoneRequestConfigBuilder.build(
       "post",
       "/k/v1/record.json",
@@ -71,11 +77,13 @@ describe("KintoneRequestConfigBuilder", () => {
     expect(requestConfig).toEqual({
       method: "post",
       url: `${baseUrl}/k/v1/record.json`,
+      headers: {
+        "X-Cybozu-API-Token": apiToken,
+      },
       data: {
         ...params,
         key: "value",
       },
-      headers,
     });
   });
   it("should build post method requestConfig for data", () => {
@@ -91,13 +99,13 @@ describe("KintoneRequestConfigBuilder", () => {
       method: "post",
       url: `${baseUrl}/k/v1/record.json`,
       headers: {
-        ...headers,
+        "X-Cybozu-API-Token": apiToken,
         ...formData.getHeaders(),
       },
     });
     expect(data).toBeInstanceOf(FormData);
   });
-  it("should build put method requestConfig", () => {
+  it.skip("should build put method requestConfig", () => {
     const requestConfig = kintoneRequestConfigBuilder.build(
       "put",
       "/k/v1/record.json",
@@ -106,14 +114,16 @@ describe("KintoneRequestConfigBuilder", () => {
     expect(requestConfig).toEqual({
       method: "put",
       url: `${baseUrl}/k/v1/record.json`,
+      headers: {
+        "X-Cybozu-API-Token": apiToken,
+      },
       data: {
         ...params,
         key: "value",
       },
-      headers,
     });
   });
-  it("should build delete method requestConfig", () => {
+  it.skip("should build delete method requestConfig", () => {
     const requestConfig = kintoneRequestConfigBuilder.build(
       "delete",
       "/k/v1/record.json",
@@ -122,7 +132,9 @@ describe("KintoneRequestConfigBuilder", () => {
     expect(requestConfig).toEqual({
       method: "delete",
       url: `${baseUrl}/k/v1/record.json?__REQUEST_TOKEN__=foo-bar&key=value`,
-      headers,
+      headers: {
+        "X-Cybozu-API-Token": apiToken,
+      },
     });
   });
 });
@@ -130,8 +142,9 @@ describe("KintoneRequestConfigBuilder", () => {
 describe("options", () => {
   it("should build `requestConfig` having `proxy` property", () => {
     const baseUrl = "https://example.kintone.com";
+    const apiToken = "apiToken";
     const headers = {
-      "X-Cybozu-API-Token": "foo",
+      "X-Cybozu-API-Token": apiToken,
     };
     const requestToken = "foo-bar";
     const proxy = {
@@ -145,10 +158,11 @@ describe("options", () => {
 
     const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
       baseUrl,
+      auth: {
+        apiToken,
+      },
       proxy,
     });
-    kintoneRequestConfigBuilder.setHeaders(headers);
-    kintoneRequestConfigBuilder.setRequestToken(requestToken);
 
     const requestConfig = kintoneRequestConfigBuilder.build(
       "get",
@@ -174,7 +188,6 @@ describe("options", () => {
       baseUrl,
       clientCertAuth,
     });
-    kintoneRequestConfigBuilder.setRequestToken("foo-bar");
 
     const requestConfig = kintoneRequestConfigBuilder.build(
       "get",

--- a/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
@@ -164,7 +164,7 @@ describe("options", () => {
       "/k/v1/record.json",
       { key: "value" }
     );
-    expect(requestConfig).toEqual({
+    expect(requestConfig).toStrictEqual({
       method: "get",
       url: `${baseUrl}/k/v1/record.json?key=value`,
       headers,
@@ -214,7 +214,7 @@ describe("Headers", () => {
     });
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
-    ).toEqual({
+    ).toStrictEqual({
       "X-Cybozu-Authorization": Base64.encode(`${USERNAME}:${PASSWORD}`),
     });
   });
@@ -230,7 +230,7 @@ describe("Headers", () => {
     });
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
-    ).toEqual({
+    ).toStrictEqual({
       "X-Cybozu-API-Token": API_TOKEN,
     });
   });
@@ -247,7 +247,7 @@ describe("Headers", () => {
     });
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
-    ).toEqual({
+    ).toStrictEqual({
       "X-Cybozu-API-Token": `${API_TOKEN1},${API_TOKEN2}`,
     });
   });
@@ -264,7 +264,7 @@ describe("Headers", () => {
     });
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
-    ).toEqual({
+    ).toStrictEqual({
       "X-Cybozu-API-Token": `${API_TOKEN1},${API_TOKEN2}`,
     });
   });
@@ -278,7 +278,7 @@ describe("Headers", () => {
     });
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
-    ).toEqual({
+    ).toStrictEqual({
       "X-Requested-With": "XMLHttpRequest",
     });
   });
@@ -294,7 +294,7 @@ describe("Headers", () => {
     });
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
-    ).toEqual({
+    ).toStrictEqual({
       Authorization: `Bearer ${oAuthToken}`,
     });
   });
@@ -310,7 +310,7 @@ describe("Headers", () => {
     });
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
-    ).toEqual({
+    ).toStrictEqual({
       Authorization: `Basic ${Base64.encode("user:password")}`,
       "X-Requested-With": "XMLHttpRequest",
     });

--- a/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
@@ -4,10 +4,6 @@ import FormData from "form-data";
 describe("KintoneRequestConfigBuilder", () => {
   const baseUrl = "https://example.kintone.com";
   const apiToken = "apiToken";
-  const requestToken = "foo-bar";
-  const params = {
-    __REQUEST_TOKEN__: requestToken,
-  };
   let kintoneRequestConfigBuilder: KintoneRequestConfigBuilder;
   beforeEach(() => {
     kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
@@ -16,7 +12,6 @@ describe("KintoneRequestConfigBuilder", () => {
         type: "apiToken",
         apiToken,
       },
-      ...params,
     });
   });
   it("should build get method requestConfig", () => {
@@ -146,7 +141,6 @@ describe("options", () => {
     const headers = {
       "X-Cybozu-API-Token": apiToken,
     };
-    const requestToken = "foo-bar";
     const proxy = {
       host: "localhost",
       port: 8000,

--- a/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
@@ -35,21 +35,22 @@ describe("KintoneRequestConfigBuilder", () => {
       },
     });
   });
-  it.skip("should build post method requestConfig if the request URL is over the threshold", () => {
+  it("should build post method requestConfig if the request URL is over the threshold", () => {
     const value = "a".repeat(4096);
     const requestConfig = kintoneRequestConfigBuilder.build(
       "get",
       "/k/v1/record.json",
       { key: value }
     );
-    expect(requestConfig).toEqual({
+    expect(requestConfig).toStrictEqual({
       method: "post",
+      proxy: undefined,
       url: `${baseUrl}/k/v1/record.json`,
       headers: {
         "X-Cybozu-API-Token": apiToken,
         "X-HTTP-Method-Override": "GET",
       },
-      data: { ...params, key: value },
+      data: { key: value },
     });
   });
   it("should build get method requestConfig for data", () => {
@@ -68,20 +69,20 @@ describe("KintoneRequestConfigBuilder", () => {
       responseType: "arraybuffer",
     });
   });
-  it.skip("should build post method requestConfig", () => {
+  it("should build post method requestConfig", () => {
     const requestConfig = kintoneRequestConfigBuilder.build(
       "post",
       "/k/v1/record.json",
       { key: "value" }
     );
-    expect(requestConfig).toEqual({
+    expect(requestConfig).toStrictEqual({
       method: "post",
+      proxy: undefined,
       url: `${baseUrl}/k/v1/record.json`,
       headers: {
         "X-Cybozu-API-Token": apiToken,
       },
       data: {
-        ...params,
         key: "value",
       },
     });
@@ -105,33 +106,34 @@ describe("KintoneRequestConfigBuilder", () => {
     });
     expect(data).toBeInstanceOf(FormData);
   });
-  it.skip("should build put method requestConfig", () => {
+  it("should build put method requestConfig", () => {
     const requestConfig = kintoneRequestConfigBuilder.build(
       "put",
       "/k/v1/record.json",
       { key: "value" }
     );
-    expect(requestConfig).toEqual({
+    expect(requestConfig).toStrictEqual({
       method: "put",
+      proxy: undefined,
       url: `${baseUrl}/k/v1/record.json`,
       headers: {
         "X-Cybozu-API-Token": apiToken,
       },
       data: {
-        ...params,
         key: "value",
       },
     });
   });
-  it.skip("should build delete method requestConfig", () => {
+  it("should build delete method requestConfig", () => {
     const requestConfig = kintoneRequestConfigBuilder.build(
       "delete",
       "/k/v1/record.json",
       { key: "value" }
     );
-    expect(requestConfig).toEqual({
+    expect(requestConfig).toStrictEqual({
       method: "delete",
-      url: `${baseUrl}/k/v1/record.json?__REQUEST_TOKEN__=foo-bar&key=value`,
+      proxy: undefined,
+      url: `${baseUrl}/k/v1/record.json?key=value`,
       headers: {
         "X-Cybozu-API-Token": apiToken,
       },
@@ -298,9 +300,9 @@ describe("Headers", () => {
     const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
       baseUrl,
     });
-    expect(
-      kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {})
-    ).toThrow(
+    expect(() => {
+      kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {});
+    }).toThrow(
       "session authentication is not supported in Node.js environment."
     );
   });

--- a/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
@@ -6,16 +6,18 @@ describe("KintoneRequestConfigBuilder", () => {
   const headers = {
     "X-Cybozu-API-Token": "foo",
   };
+  const requestToken = "foo-bar";
   const params = {
-    __REQUEST_TOKEN__: "foo-bar",
+    __REQUEST_TOKEN__: requestToken,
   };
   let kintoneRequestConfigBuilder: KintoneRequestConfigBuilder;
   beforeEach(() => {
-    kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder(
+    kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
       baseUrl,
-      headers,
-      params
-    );
+      ...params,
+    });
+    kintoneRequestConfigBuilder.setHeaders(headers);
+    kintoneRequestConfigBuilder.setRequestToken(requestToken);
   });
   it("should build get method requestConfig", () => {
     const requestConfig = kintoneRequestConfigBuilder.build(
@@ -128,9 +130,7 @@ describe("options", () => {
     const headers = {
       "X-Cybozu-API-Token": "foo",
     };
-    const params = {
-      __REQUEST_TOKEN__: "foo-bar",
-    };
+    const requestToken = "foo-bar";
     const proxy = {
       host: "localhost",
       port: 8000,
@@ -140,12 +140,12 @@ describe("options", () => {
       },
     };
 
-    const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder(
+    const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
       baseUrl,
-      headers,
-      params,
-      { proxy }
-    );
+      proxy,
+    });
+    kintoneRequestConfigBuilder.setHeaders(headers);
+    kintoneRequestConfigBuilder.setRequestToken(requestToken);
 
     const requestConfig = kintoneRequestConfigBuilder.build(
       "get",
@@ -162,23 +162,16 @@ describe("options", () => {
 
   it("should build `requestConfig` having `httpsAgent` property", () => {
     const baseUrl = "https://example.kintone.com";
-    const headers = {
-      "X-Cybozu-API-Token": "foo",
-    };
-    const params = {
-      __REQUEST_TOKEN__: "foo-bar",
-    };
     const clientCertAuth = {
       pfx: Buffer.alloc(0),
       password: "password",
     };
 
-    const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder(
+    const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
       baseUrl,
-      headers,
-      params,
-      { clientCertAuth }
-    );
+      clientCertAuth,
+    });
+    kintoneRequestConfigBuilder.setRequestToken("foo-bar");
 
     const requestConfig = kintoneRequestConfigBuilder.build(
       "get",

--- a/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
@@ -10,6 +10,8 @@ const osName = os.type();
 const packageName = packageJson.name;
 const packageVersion = packageJson.version;
 
+const expectedUa = `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`;
+
 describe("KintoneRequestConfigBuilder in Node.js environment", () => {
   const baseUrl = "https://example.kintone.com";
   const apiToken = "apiToken";
@@ -34,7 +36,7 @@ describe("KintoneRequestConfigBuilder in Node.js environment", () => {
       proxy: undefined,
       url: `${baseUrl}/k/v1/record.json?key=value`,
       headers: {
-        "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
+        "User-Agent": expectedUa,
         "X-Cybozu-API-Token": apiToken,
       },
     });
@@ -51,7 +53,7 @@ describe("KintoneRequestConfigBuilder in Node.js environment", () => {
       proxy: undefined,
       url: `${baseUrl}/k/v1/record.json`,
       headers: {
-        "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
+        "User-Agent": expectedUa,
         "X-Cybozu-API-Token": apiToken,
         "X-HTTP-Method-Override": "GET",
       },
@@ -70,7 +72,7 @@ describe("KintoneRequestConfigBuilder in Node.js environment", () => {
       proxy: undefined,
       url: `${baseUrl}/k/v1/record.json?key=value`,
       headers: {
-        "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
+        "User-Agent": expectedUa,
         "X-Cybozu-API-Token": apiToken,
       },
       responseType: "arraybuffer",
@@ -87,7 +89,7 @@ describe("KintoneRequestConfigBuilder in Node.js environment", () => {
       proxy: undefined,
       url: `${baseUrl}/k/v1/record.json`,
       headers: {
-        "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
+        "User-Agent": expectedUa,
         "X-Cybozu-API-Token": apiToken,
       },
       data: {
@@ -109,7 +111,7 @@ describe("KintoneRequestConfigBuilder in Node.js environment", () => {
       proxy: undefined,
       url: `${baseUrl}/k/v1/record.json`,
       headers: {
-        "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
+        "User-Agent": expectedUa,
         "X-Cybozu-API-Token": apiToken,
         ...formData.getHeaders(),
       },
@@ -127,7 +129,7 @@ describe("KintoneRequestConfigBuilder in Node.js environment", () => {
       proxy: undefined,
       url: `${baseUrl}/k/v1/record.json`,
       headers: {
-        "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
+        "User-Agent": expectedUa,
         "X-Cybozu-API-Token": apiToken,
       },
       data: {
@@ -146,7 +148,7 @@ describe("KintoneRequestConfigBuilder in Node.js environment", () => {
       proxy: undefined,
       url: `${baseUrl}/k/v1/record.json?key=value`,
       headers: {
-        "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
+        "User-Agent": expectedUa,
         "X-Cybozu-API-Token": apiToken,
       },
     });
@@ -301,7 +303,7 @@ describe("options", () => {
     const apiToken = "apiToken";
     const headers = {
       "X-Cybozu-API-Token": apiToken,
-      "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
+      "User-Agent": expectedUa,
     };
     const proxy = {
       host: "localhost",
@@ -377,7 +379,7 @@ describe("Headers", () => {
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
     ).toStrictEqual({
-      "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
+      "User-Agent": expectedUa,
       "X-Cybozu-Authorization": Base64.encode(`${USERNAME}:${PASSWORD}`),
     });
   });
@@ -394,7 +396,7 @@ describe("Headers", () => {
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
     ).toStrictEqual({
-      "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
+      "User-Agent": expectedUa,
       "X-Cybozu-API-Token": API_TOKEN,
     });
   });
@@ -412,7 +414,7 @@ describe("Headers", () => {
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
     ).toStrictEqual({
-      "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
+      "User-Agent": expectedUa,
       "X-Cybozu-API-Token": `${API_TOKEN1},${API_TOKEN2}`,
     });
   });
@@ -430,7 +432,7 @@ describe("Headers", () => {
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
     ).toStrictEqual({
-      "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
+      "User-Agent": expectedUa,
       "X-Cybozu-API-Token": `${API_TOKEN1},${API_TOKEN2}`,
     });
   });
@@ -445,7 +447,7 @@ describe("Headers", () => {
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
     ).toStrictEqual({
-      "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
+      "User-Agent": expectedUa,
       "X-Requested-With": "XMLHttpRequest",
     });
   });
@@ -463,7 +465,7 @@ describe("Headers", () => {
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
     ).toStrictEqual({
       Authorization: `Bearer ${oAuthToken}`,
-      "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
+      "User-Agent": expectedUa,
     });
   });
 
@@ -480,36 +482,13 @@ describe("Headers", () => {
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
     ).toStrictEqual({
       Authorization: `Basic ${Base64.encode("user:password")}`,
-      "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
+      "User-Agent": expectedUa,
       "X-Requested-With": "XMLHttpRequest",
     });
-  });
-  it("should include OS name, OS version, package name, and pacakge version in User-Agent for Node.js enviroment", () => {
-    const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
-      baseUrl,
-      auth: {
-        type: "password",
-        username: "user",
-        password: "password",
-      },
-    });
-
-    const headers = kintoneRequestConfigBuilder.build(
-      "get",
-      "/k/v1/record.json",
-      {}
-    ).headers;
-
-    expect(headers["User-Agent"]).toBe(
-      `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`
-    );
   });
 
   it("should not include User-Agent for browser enviroment", () => {
     injectPlatformDeps(browserDeps);
-    global.location = {
-      origin: "https://example.com",
-    };
     const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
       baseUrl,
       auth: {

--- a/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
@@ -1,9 +1,6 @@
 import { KintoneRequestConfigBuilder } from "../KintoneRequestConfigBuilder";
 import FormData from "form-data";
 
-import { injectPlatformDeps } from "../platform";
-import * as nodeDeps from "../platform/node";
-
 describe("KintoneRequestConfigBuilder", () => {
   const baseUrl = "https://example.kintone.com";
   const apiToken = "apiToken";

--- a/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
@@ -2,6 +2,13 @@ import { KintoneRequestConfigBuilder } from "../KintoneRequestConfigBuilder";
 import FormData from "form-data";
 import { injectPlatformDeps } from "../platform";
 import * as browserDeps from "../platform/browser";
+import os from "os";
+
+const packageJson = require("../../package.json");
+const nodeVersion = process.version;
+const osName = os.type();
+const packageName = packageJson.name;
+const packageVersion = packageJson.version;
 
 describe("KintoneRequestConfigBuilder in Node.js environment", () => {
   const baseUrl = "https://example.kintone.com";
@@ -27,6 +34,7 @@ describe("KintoneRequestConfigBuilder in Node.js environment", () => {
       proxy: undefined,
       url: `${baseUrl}/k/v1/record.json?key=value`,
       headers: {
+        "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
         "X-Cybozu-API-Token": apiToken,
       },
     });
@@ -43,6 +51,7 @@ describe("KintoneRequestConfigBuilder in Node.js environment", () => {
       proxy: undefined,
       url: `${baseUrl}/k/v1/record.json`,
       headers: {
+        "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
         "X-Cybozu-API-Token": apiToken,
         "X-HTTP-Method-Override": "GET",
       },
@@ -61,6 +70,7 @@ describe("KintoneRequestConfigBuilder in Node.js environment", () => {
       proxy: undefined,
       url: `${baseUrl}/k/v1/record.json?key=value`,
       headers: {
+        "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
         "X-Cybozu-API-Token": apiToken,
       },
       responseType: "arraybuffer",
@@ -77,6 +87,7 @@ describe("KintoneRequestConfigBuilder in Node.js environment", () => {
       proxy: undefined,
       url: `${baseUrl}/k/v1/record.json`,
       headers: {
+        "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
         "X-Cybozu-API-Token": apiToken,
       },
       data: {
@@ -98,6 +109,7 @@ describe("KintoneRequestConfigBuilder in Node.js environment", () => {
       proxy: undefined,
       url: `${baseUrl}/k/v1/record.json`,
       headers: {
+        "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
         "X-Cybozu-API-Token": apiToken,
         ...formData.getHeaders(),
       },
@@ -115,6 +127,7 @@ describe("KintoneRequestConfigBuilder in Node.js environment", () => {
       proxy: undefined,
       url: `${baseUrl}/k/v1/record.json`,
       headers: {
+        "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
         "X-Cybozu-API-Token": apiToken,
       },
       data: {
@@ -133,6 +146,7 @@ describe("KintoneRequestConfigBuilder in Node.js environment", () => {
       proxy: undefined,
       url: `${baseUrl}/k/v1/record.json?key=value`,
       headers: {
+        "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
         "X-Cybozu-API-Token": apiToken,
       },
     });
@@ -287,6 +301,7 @@ describe("options", () => {
     const apiToken = "apiToken";
     const headers = {
       "X-Cybozu-API-Token": apiToken,
+      "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
     };
     const proxy = {
       host: "localhost",
@@ -362,6 +377,7 @@ describe("Headers", () => {
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
     ).toStrictEqual({
+      "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
       "X-Cybozu-Authorization": Base64.encode(`${USERNAME}:${PASSWORD}`),
     });
   });
@@ -378,6 +394,7 @@ describe("Headers", () => {
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
     ).toStrictEqual({
+      "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
       "X-Cybozu-API-Token": API_TOKEN,
     });
   });
@@ -395,6 +412,7 @@ describe("Headers", () => {
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
     ).toStrictEqual({
+      "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
       "X-Cybozu-API-Token": `${API_TOKEN1},${API_TOKEN2}`,
     });
   });
@@ -412,6 +430,7 @@ describe("Headers", () => {
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
     ).toStrictEqual({
+      "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
       "X-Cybozu-API-Token": `${API_TOKEN1},${API_TOKEN2}`,
     });
   });
@@ -426,6 +445,7 @@ describe("Headers", () => {
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
     ).toStrictEqual({
+      "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
       "X-Requested-With": "XMLHttpRequest",
     });
   });
@@ -443,6 +463,7 @@ describe("Headers", () => {
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
     ).toStrictEqual({
       Authorization: `Bearer ${oAuthToken}`,
+      "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
     });
   });
 
@@ -459,7 +480,47 @@ describe("Headers", () => {
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
     ).toStrictEqual({
       Authorization: `Basic ${Base64.encode("user:password")}`,
+      "User-Agent": `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`,
       "X-Requested-With": "XMLHttpRequest",
     });
+  });
+  it("should include OS name, OS version, package name, and pacakge version in User-Agent for Node.js enviroment", () => {
+    const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
+      baseUrl,
+      auth: {
+        type: "password",
+        username: "user",
+        password: "password",
+      },
+    });
+
+    const headers = kintoneRequestConfigBuilder.build(
+      "get",
+      "/k/v1/record.json",
+      {}
+    ).headers;
+
+    expect(headers["User-Agent"]).toBe(
+      `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`
+    );
+  });
+
+  it("should not include User-Agent for browser enviroment", () => {
+    injectPlatformDeps(browserDeps);
+    global.location = {
+      origin: "https://example.com",
+    };
+    const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
+      baseUrl,
+      auth: {
+        type: "session",
+      },
+    });
+    const headers = kintoneRequestConfigBuilder.build(
+      "get",
+      "/k/v1/record.json",
+      {}
+    ).headers;
+    expect(headers["User-Agent"]).toBeUndefined();
   });
 });

--- a/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
@@ -1,6 +1,9 @@
 import { KintoneRequestConfigBuilder } from "../KintoneRequestConfigBuilder";
 import FormData from "form-data";
 
+import { injectPlatformDeps } from "../platform";
+import * as nodeDeps from "../platform/node";
+
 describe("KintoneRequestConfigBuilder", () => {
   const baseUrl = "https://example.kintone.com";
   const headers = {
@@ -179,5 +182,140 @@ describe("options", () => {
       { key: "value" }
     );
     expect(requestConfig).toHaveProperty("httpsAgent");
+  });
+});
+
+describe("Headers", () => {
+  const baseUrl = "https://example.com";
+
+  it("Password auth", () => {
+    const USERNAME = "user";
+    const PASSWORD = "password";
+    const auth = {
+      username: USERNAME,
+      password: PASSWORD,
+    };
+    const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
+      baseUrl,
+      auth,
+    });
+    expect(
+      kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
+    ).toEqual({
+      "X-Cybozu-Authorization": Base64.encode(`${USERNAME}:${PASSWORD}`),
+    });
+  });
+
+  it("ApiToken auth", () => {
+    const API_TOKEN = "ApiToken";
+    const auth = {
+      apiToken: API_TOKEN,
+    };
+    const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
+      baseUrl,
+      auth,
+    });
+    expect(
+      kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
+    ).toEqual({
+      "X-Cybozu-API-Token": API_TOKEN,
+    });
+  });
+
+  it("ApiToken auth using multiple tokens as comma-separated string", () => {
+    const API_TOKEN1 = "ApiToken1";
+    const API_TOKEN2 = "ApiToken2";
+    const auth = {
+      apiToken: `${API_TOKEN1},${API_TOKEN2}`,
+    };
+    const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
+      baseUrl,
+      auth,
+    });
+    expect(
+      kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
+    ).toEqual({
+      "X-Cybozu-API-Token": `${API_TOKEN1},${API_TOKEN2}`,
+    });
+  });
+
+  it("ApiToken auth using multiple tokens as array", () => {
+    const API_TOKEN1 = "ApiToken1";
+    const API_TOKEN2 = "ApiToken2";
+    const auth = {
+      apiToken: [API_TOKEN1, API_TOKEN2],
+    };
+    const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
+      baseUrl,
+      auth,
+    });
+    expect(
+      kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
+    ).toEqual({
+      "X-Cybozu-API-Token": `${API_TOKEN1},${API_TOKEN2}`,
+    });
+  });
+
+  it("Session auth", () => {
+    const auth = {};
+    const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
+      baseUrl,
+      auth,
+    });
+    expect(
+      kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
+    ).toEqual({
+      "X-Requested-With": "XMLHttpRequest",
+    });
+  });
+
+  it("should use Session auth if auth param is not specified", () => {
+    const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
+      baseUrl,
+    });
+    expect(
+      kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
+    ).toEqual({
+      "X-Requested-With": "XMLHttpRequest",
+    });
+  });
+
+  it.skip("should raise an error if trying to use session auth in Node.js environment", () => {
+    injectPlatformDeps(nodeDeps);
+    const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
+      baseUrl,
+    });
+    expect(
+      kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {})
+    ).toThrow(
+      "session authentication is not supported in Node.js environment."
+    );
+  });
+
+  it("OAuth token auth", () => {
+    const auth = { oAuthToken: "oauth-token" };
+    const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
+      baseUrl,
+      auth,
+    });
+    expect(
+      kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
+    ).toEqual({
+      Authorization: `Bearer ${auth.oAuthToken}`,
+    });
+  });
+
+  it("Basic auth", () => {
+    const basicAuth = { username: "user", password: "password" };
+    const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
+      baseUrl,
+      basicAuth,
+    });
+    expect(
+      kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
+    ).toEqual({
+      Authorization: `Basic ${Base64.encode("user:password")}`,
+      "X-Requested-With": "XMLHttpRequest",
+    });
   });
 });

--- a/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
@@ -16,6 +16,7 @@ describe("KintoneRequestConfigBuilder", () => {
     kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
       baseUrl,
       auth: {
+        type: "apiToken",
         apiToken,
       },
       ...params,
@@ -161,6 +162,7 @@ describe("options", () => {
     const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
       baseUrl,
       auth: {
+        type: "apiToken",
         apiToken,
       },
       proxy,
@@ -181,6 +183,7 @@ describe("options", () => {
 
   it("should build `requestConfig` having `httpsAgent` property", () => {
     const baseUrl = "https://example.kintone.com";
+    const apiToken = "apiToken";
     const clientCertAuth = {
       pfx: Buffer.alloc(0),
       password: "password",
@@ -189,6 +192,10 @@ describe("options", () => {
     const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
       baseUrl,
       clientCertAuth,
+      auth: {
+        type: "apiToken",
+        apiToken,
+      },
     });
 
     const requestConfig = kintoneRequestConfigBuilder.build(
@@ -206,13 +213,13 @@ describe("Headers", () => {
   it("Password auth", () => {
     const USERNAME = "user";
     const PASSWORD = "password";
-    const auth = {
-      username: USERNAME,
-      password: PASSWORD,
-    };
     const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
       baseUrl,
-      auth,
+      auth: {
+        type: "password",
+        username: USERNAME,
+        password: PASSWORD,
+      },
     });
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
@@ -223,12 +230,12 @@ describe("Headers", () => {
 
   it("ApiToken auth", () => {
     const API_TOKEN = "ApiToken";
-    const auth = {
-      apiToken: API_TOKEN,
-    };
     const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
       baseUrl,
-      auth,
+      auth: {
+        type: "apiToken",
+        apiToken: API_TOKEN,
+      },
     });
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
@@ -240,12 +247,12 @@ describe("Headers", () => {
   it("ApiToken auth using multiple tokens as comma-separated string", () => {
     const API_TOKEN1 = "ApiToken1";
     const API_TOKEN2 = "ApiToken2";
-    const auth = {
-      apiToken: `${API_TOKEN1},${API_TOKEN2}`,
-    };
     const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
       baseUrl,
-      auth,
+      auth: {
+        type: "apiToken",
+        apiToken: `${API_TOKEN1},${API_TOKEN2}`,
+      },
     });
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
@@ -257,12 +264,12 @@ describe("Headers", () => {
   it("ApiToken auth using multiple tokens as array", () => {
     const API_TOKEN1 = "ApiToken1";
     const API_TOKEN2 = "ApiToken2";
-    const auth = {
-      apiToken: [API_TOKEN1, API_TOKEN2],
-    };
     const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
       baseUrl,
-      auth,
+      auth: {
+        type: "apiToken",
+        apiToken: [API_TOKEN1, API_TOKEN2],
+      },
     });
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
@@ -272,51 +279,32 @@ describe("Headers", () => {
   });
 
   it("Session auth", () => {
-    const auth = {};
     const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
       baseUrl,
-      auth,
+      auth: {
+        type: "session",
+      },
     });
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
     ).toEqual({
       "X-Requested-With": "XMLHttpRequest",
     });
-  });
-
-  it("should use Session auth if auth param is not specified", () => {
-    const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
-      baseUrl,
-    });
-    expect(
-      kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
-    ).toEqual({
-      "X-Requested-With": "XMLHttpRequest",
-    });
-  });
-
-  it.skip("should raise an error if trying to use session auth in Node.js environment", () => {
-    injectPlatformDeps(nodeDeps);
-    const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
-      baseUrl,
-    });
-    expect(() => {
-      kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {});
-    }).toThrow(
-      "session authentication is not supported in Node.js environment."
-    );
   });
 
   it("OAuth token auth", () => {
-    const auth = { oAuthToken: "oauth-token" };
+    const oAuthToken = "oauth-token";
     const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
       baseUrl,
-      auth,
+      auth: {
+        type: "oAuthToken",
+        oAuthToken,
+      },
     });
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
     ).toEqual({
-      Authorization: `Bearer ${auth.oAuthToken}`,
+      Authorization: `Bearer ${oAuthToken}`,
     });
   });
 
@@ -325,6 +313,9 @@ describe("Headers", () => {
     const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
       baseUrl,
       basicAuth,
+      auth: {
+        type: "session",
+      },
     });
     expect(
       kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers

--- a/packages/rest-api-client/src/__tests__/KintoneRestAPIClient.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneRestAPIClient.test.ts
@@ -7,9 +7,6 @@ import * as browserDeps from "../platform/browser";
 import * as nodeDeps from "../platform/node";
 import { KintoneRestAPIError } from "../KintoneRestAPIError";
 import { ErrorResponse, HttpClientError } from "../http/HttpClientInterface";
-import os from "os";
-
-const packageJson = require("../../package.json");
 
 describe("KintoneRestAPIClient", () => {
   describe("constructor", () => {

--- a/packages/rest-api-client/src/__tests__/KintoneRestAPIClient.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneRestAPIClient.test.ts
@@ -29,109 +29,6 @@ describe("KintoneRestAPIClient", () => {
       beforeEach(() => {
         injectPlatformDeps(browserDeps);
       });
-      it("ApiToken auth", () => {
-        const API_TOKEN = "ApiToken";
-        const auth = {
-          apiToken: API_TOKEN,
-        };
-        const client = new KintoneRestAPIClient({ baseUrl, auth });
-        expect(client.getHeaders()).toEqual({
-          "X-Cybozu-API-Token": API_TOKEN,
-        });
-      });
-      it("ApiToken auth using multiple tokens as comma-separated string", () => {
-        const API_TOKEN1 = "ApiToken1";
-        const API_TOKEN2 = "ApiToken2";
-        const auth = {
-          apiToken: `${API_TOKEN1},${API_TOKEN2}`,
-        };
-        const client = new KintoneRestAPIClient({ baseUrl, auth });
-        expect(client.getHeaders()).toEqual({
-          "X-Cybozu-API-Token": `${API_TOKEN1},${API_TOKEN2}`,
-        });
-      });
-      it("ApiToken auth using multiple tokens as array", () => {
-        const API_TOKEN1 = "ApiToken1";
-        const API_TOKEN2 = "ApiToken2";
-        const auth = {
-          apiToken: [API_TOKEN1, API_TOKEN2],
-        };
-        const client = new KintoneRestAPIClient({ baseUrl, auth });
-        expect(client.getHeaders()).toEqual({
-          "X-Cybozu-API-Token": `${API_TOKEN1},${API_TOKEN2}`,
-        });
-      });
-      it("Password  auth", () => {
-        const USERNAME = "user";
-        const PASSWORD = "password";
-        const auth = {
-          username: USERNAME,
-          password: PASSWORD,
-        };
-        const client = new KintoneRestAPIClient({ baseUrl, auth });
-        expect(client.getHeaders()).toEqual({
-          "X-Cybozu-Authorization": Base64.encode(`${USERNAME}:${PASSWORD}`),
-        });
-      });
-      it("Session auth", () => {
-        const auth = {};
-        const client = new KintoneRestAPIClient({ baseUrl, auth });
-        expect(client.getHeaders()).toEqual({
-          "X-Requested-With": "XMLHttpRequest",
-        });
-      });
-      it("OAuth token auth", () => {
-        const auth = { oAuthToken: "oauth-token" };
-        const client = new KintoneRestAPIClient({ baseUrl, auth });
-        expect(client.getHeaders()).toEqual({
-          Authorization: `Bearer ${auth.oAuthToken}`,
-        });
-      });
-      it("Basic auth", () => {
-        const basicAuth = { username: "user", password: "password" };
-        const client = new KintoneRestAPIClient({ baseUrl, basicAuth });
-        expect(client.getHeaders()).toEqual({
-          Authorization: `Basic ${Base64.encode("user:password")}`,
-          "X-Requested-With": "XMLHttpRequest",
-        });
-      });
-      it("should use Session auth if auth param is not specified", () => {
-        const client = new KintoneRestAPIClient({ baseUrl });
-        expect(client.getHeaders()).toEqual({
-          "X-Requested-With": "XMLHttpRequest",
-        });
-      });
-      it("should include OS name, OS version, package name, and pacakge version in User-Agent for Node.js enviroment", () => {
-        injectPlatformDeps(nodeDeps);
-        const USERNAME = "user";
-        const PASSWORD = "password";
-        const auth = {
-          username: USERNAME,
-          password: PASSWORD,
-        };
-        const client = new KintoneRestAPIClient({ baseUrl, auth });
-        const headers = client.getHeaders() as Record<string, string>;
-        const ua = headers["User-Agent"];
-
-        const nodeVersion = process.version;
-        const osName = os.type();
-        const packageName = packageJson.name;
-        const packageVersion = packageJson.version;
-
-        expect(ua).toBe(
-          `Node.js/${nodeVersion}(${osName}) ${packageName}@${packageVersion}`
-        );
-      });
-
-      it("should not include User-Agent for browser enviroment", () => {
-        global.location = {
-          origin: "https://example.com",
-        };
-        const client = new KintoneRestAPIClient();
-        const headers = client.getHeaders() as Record<string, string>;
-        const ua = headers["User-Agent"];
-        expect(ua).toBeUndefined();
-      });
 
       it("should use location.origin in browser environment if baseUrl param is not specified", () => {
         global.location = {
@@ -151,12 +48,6 @@ describe("KintoneRestAPIClient", () => {
         };
         expect(() => new KintoneRestAPIClient({ auth })).toThrow(
           "in Node.js environment, baseUrl is required"
-        );
-      });
-      it("should raise an error in Node.js enviroment if use session auth", () => {
-        injectPlatformDeps(nodeDeps);
-        expect(() => new KintoneRestAPIClient({ baseUrl })).toThrow(
-          "session authentication is not supported in Node.js environment."
         );
       });
     });

--- a/packages/rest-api-client/src/__tests__/KintoneRestAPIClient.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneRestAPIClient.test.ts
@@ -2,7 +2,6 @@ import {
   KintoneRestAPIClient,
   errorResponseHandler,
 } from "../KintoneRestAPIClient";
-import { Base64 } from "js-base64";
 import { injectPlatformDeps } from "../platform";
 import * as browserDeps from "../platform/browser";
 import * as nodeDeps from "../platform/node";
@@ -48,6 +47,16 @@ describe("KintoneRestAPIClient", () => {
         };
         expect(() => new KintoneRestAPIClient({ auth })).toThrow(
           "in Node.js environment, baseUrl is required"
+        );
+      });
+      it("should raise an error if trying to use session auth in Node.js environment", () => {
+        injectPlatformDeps(nodeDeps);
+        expect(() => {
+          new KintoneRestAPIClient({
+            baseUrl,
+          });
+        }).toThrow(
+          "session authentication is not supported in Node.js environment."
         );
       });
     });

--- a/packages/rest-api-client/src/platform/browser.ts
+++ b/packages/rest-api-client/src/platform/browser.ts
@@ -1,4 +1,5 @@
 import { UnsupportedPlatformError } from "./UnsupportedPlatformError";
+import { DiscriminatedAuth } from "../KintoneRestAPIClient";
 
 export const readFileFromPath = (filePath: string) => {
   throw new UnsupportedPlatformError("Browser");
@@ -14,7 +15,7 @@ export const getRequestToken = () => {
   return kintone.getRequestToken();
 };
 
-export const getDefaultAuth = () => {
+export const getDefaultAuth = (): DiscriminatedAuth => {
   return {
     type: "session",
   };

--- a/packages/rest-api-client/src/platform/browser.ts
+++ b/packages/rest-api-client/src/platform/browser.ts
@@ -14,6 +14,12 @@ export const getRequestToken = () => {
   return kintone.getRequestToken();
 };
 
+export const getDefaultAuth = () => {
+  return {
+    type: "session",
+  };
+};
+
 export const buildPlatformDependentConfig = () => {
   return {};
 };

--- a/packages/rest-api-client/src/platform/index.ts
+++ b/packages/rest-api-client/src/platform/index.ts
@@ -1,8 +1,10 @@
+import { DiscriminatedAuth } from "./../KintoneRestAPIClient";
 type PlatformDeps = {
   readFileFromPath: (
     filePath: string
   ) => Promise<{ name: string; data: unknown }>;
   getRequestToken: () => string;
+  getDefaultAuth: () => DiscriminatedAuth;
   buildPlatformDependentConfig: (params: object) => object;
   buildHeaders: () => Record<string, string>;
 };
@@ -12,6 +14,9 @@ export const platformDeps: PlatformDeps = {
     throw new Error("not implemented");
   },
   getRequestToken: () => {
+    throw new Error("not implemented");
+  },
+  getDefaultAuth: () => {
     throw new Error("not implemented");
   },
   buildPlatformDependentConfig: () => {
@@ -25,6 +30,7 @@ export const platformDeps: PlatformDeps = {
 export const injectPlatformDeps = (deps: Partial<PlatformDeps>) => {
   platformDeps.readFileFromPath = deps.readFileFromPath!;
   platformDeps.getRequestToken = deps.getRequestToken!;
+  platformDeps.getDefaultAuth = deps.getDefaultAuth!;
   platformDeps.buildPlatformDependentConfig = deps.buildPlatformDependentConfig!;
   platformDeps.buildHeaders = deps.buildHeaders!;
 };

--- a/packages/rest-api-client/src/platform/node.ts
+++ b/packages/rest-api-client/src/platform/node.ts
@@ -18,6 +18,10 @@ export const getRequestToken = () => {
   throw new UnsupportedPlatformError("Node.js");
 };
 
+export const getDefaultAuth = () => {
+  throw new UnsupportedPlatformError("Node.js");
+};
+
 export const buildPlatformDependentConfig = (params: {
   clientCertAuth?:
     | {


### PR DESCRIPTION
move 'buildAuth', 'buildHeader', 'buildParams' from KintoneRestAPIClient
to KintoneRequestConfigBuilder.