### PR TITLE
feat: support `garoon.connect.kintone.getRequestToken()` of Garoon JavaScript API

### DIFF
--- a/packages/rest-api-client/README.md
+++ b/packages/rest-api-client/README.md
@@ -128,6 +128,8 @@ The client determines which method to use by passed parameters.
 Supported in browser environment only.
 If you omit `auth` parameter, the client uses Session authentication.
 
+Session authentication is available in Garoon customization.
+
 ## Error Handling
 
 See [Error Handling](docs/errorHandling.md)

--- a/packages/rest-api-client/src/KintoneRequestConfigBuilder.ts
+++ b/packages/rest-api-client/src/KintoneRequestConfigBuilder.ts
@@ -34,6 +34,8 @@ export class KintoneRequestConfigBuilder implements RequestConfigBuilder {
         password: string;
       };
   private proxy?: ProxyConfig;
+  private requestToken: string;
+
   constructor({
     baseUrl,
     auth,
@@ -60,6 +62,7 @@ export class KintoneRequestConfigBuilder implements RequestConfigBuilder {
     this.headers = this.buildHeaders(basicAuth);
     this.clientCertAuth = clientCertAuth;
     this.proxy = proxy;
+    this.requestToken = "";
   }
 
   public async build(
@@ -141,7 +144,7 @@ export class KintoneRequestConfigBuilder implements RequestConfigBuilder {
 
   private async buildData<T extends Data>(params: T): Promise<T> {
     if (this.auth.type === "session") {
-      const requestToken = await platformDeps.getRequestToken();
+      const requestToken = await this.getRequestToken();
       if (params instanceof FormData) {
         params.append("__REQUEST_TOKEN__", requestToken);
         return params;
@@ -192,5 +195,12 @@ export class KintoneRequestConfigBuilder implements RequestConfigBuilder {
         return { ...commonHeaders, "X-Requested-With": "XMLHttpRequest" };
       }
     }
+  }
+
+  private async getRequestToken(): Promise<string> {
+    if (this.requestToken === "") {
+      this.requestToken = await platformDeps.getRequestToken();
+    }
+    return this.requestToken;
   }
 }

--- a/packages/rest-api-client/src/KintoneRequestConfigBuilder.ts
+++ b/packages/rest-api-client/src/KintoneRequestConfigBuilder.ts
@@ -34,7 +34,7 @@ export class KintoneRequestConfigBuilder implements RequestConfigBuilder {
         password: string;
       };
   private proxy?: ProxyConfig;
-  private requestToken: string;
+  private requestToken: string | null;
 
   constructor({
     baseUrl,
@@ -62,7 +62,7 @@ export class KintoneRequestConfigBuilder implements RequestConfigBuilder {
     this.headers = this.buildHeaders(basicAuth);
     this.clientCertAuth = clientCertAuth;
     this.proxy = proxy;
-    this.requestToken = "";
+    this.requestToken = null;
   }
 
   public async build(
@@ -198,7 +198,7 @@ export class KintoneRequestConfigBuilder implements RequestConfigBuilder {
   }
 
   private async getRequestToken(): Promise<string> {
-    if (this.requestToken === "") {
+    if (this.requestToken === null) {
       this.requestToken = await platformDeps.getRequestToken();
     }
     return this.requestToken;

--- a/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
@@ -25,8 +25,8 @@ describe("KintoneRequestConfigBuilder in Node.js environment", () => {
       },
     });
   });
-  it("should build get method requestConfig", () => {
-    const requestConfig = kintoneRequestConfigBuilder.build(
+  it("should build get method requestConfig", async () => {
+    const requestConfig = await kintoneRequestConfigBuilder.build(
       "get",
       "/k/v1/record.json",
       { key: "value" }
@@ -41,9 +41,9 @@ describe("KintoneRequestConfigBuilder in Node.js environment", () => {
       },
     });
   });
-  it("should build post method requestConfig if the request URL is over the threshold", () => {
+  it("should build post method requestConfig if the request URL is over the threshold", async () => {
     const value = "a".repeat(4096);
-    const requestConfig = kintoneRequestConfigBuilder.build(
+    const requestConfig = await kintoneRequestConfigBuilder.build(
       "get",
       "/k/v1/record.json",
       { key: value }
@@ -60,8 +60,8 @@ describe("KintoneRequestConfigBuilder in Node.js environment", () => {
       data: { key: value },
     });
   });
-  it("should build get method requestConfig for data", () => {
-    const requestConfig = kintoneRequestConfigBuilder.build(
+  it("should build get method requestConfig for data", async () => {
+    const requestConfig = await kintoneRequestConfigBuilder.build(
       "get",
       "/k/v1/record.json",
       { key: "value" },
@@ -78,8 +78,8 @@ describe("KintoneRequestConfigBuilder in Node.js environment", () => {
       responseType: "arraybuffer",
     });
   });
-  it("should build post method requestConfig", () => {
-    const requestConfig = kintoneRequestConfigBuilder.build(
+  it("should build post method requestConfig", async () => {
+    const requestConfig = await kintoneRequestConfigBuilder.build(
       "post",
       "/k/v1/record.json",
       { key: "value" }
@@ -97,10 +97,10 @@ describe("KintoneRequestConfigBuilder in Node.js environment", () => {
       },
     });
   });
-  it("should build post method requestConfig for data", () => {
+  it("should build post method requestConfig for data", async () => {
     const formData = new FormData();
     formData.append("key", "value");
-    const requestConfig = kintoneRequestConfigBuilder.build(
+    const requestConfig = await kintoneRequestConfigBuilder.build(
       "post",
       "/k/v1/record.json",
       formData
@@ -118,8 +118,8 @@ describe("KintoneRequestConfigBuilder in Node.js environment", () => {
     });
     expect(data).toBeInstanceOf(FormData);
   });
-  it("should build put method requestConfig", () => {
-    const requestConfig = kintoneRequestConfigBuilder.build(
+  it("should build put method requestConfig", async () => {
+    const requestConfig = await kintoneRequestConfigBuilder.build(
       "put",
       "/k/v1/record.json",
       { key: "value" }
@@ -137,8 +137,8 @@ describe("KintoneRequestConfigBuilder in Node.js environment", () => {
       },
     });
   });
-  it("should build delete method requestConfig", () => {
-    const requestConfig = kintoneRequestConfigBuilder.build(
+  it("should build delete method requestConfig", async () => {
+    const requestConfig = await kintoneRequestConfigBuilder.build(
       "delete",
       "/k/v1/record.json",
       { key: "value" }
@@ -162,7 +162,7 @@ describe("KintoneRequestConfigBuilder in Browser environment", () => {
   beforeEach(() => {
     injectPlatformDeps({
       ...browserDeps,
-      getRequestToken: () => requestToken,
+      getRequestToken: async () => requestToken,
     });
 
     kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
@@ -172,8 +172,8 @@ describe("KintoneRequestConfigBuilder in Browser environment", () => {
       },
     });
   });
-  it("should build get method requestConfig", () => {
-    const requestConfig = kintoneRequestConfigBuilder.build(
+  it("should build get method requestConfig", async () => {
+    const requestConfig = await kintoneRequestConfigBuilder.build(
       "get",
       "/k/v1/record.json",
       { key: "value" }
@@ -187,9 +187,9 @@ describe("KintoneRequestConfigBuilder in Browser environment", () => {
       },
     });
   });
-  it("should build post method requestConfig if the request URL is over the threshold", () => {
+  it("should build post method requestConfig if the request URL is over the threshold", async () => {
     const value = "a".repeat(4096);
-    const requestConfig = kintoneRequestConfigBuilder.build(
+    const requestConfig = await kintoneRequestConfigBuilder.build(
       "get",
       "/k/v1/record.json",
       { key: value }
@@ -205,8 +205,8 @@ describe("KintoneRequestConfigBuilder in Browser environment", () => {
       data: { key: value, __REQUEST_TOKEN__: requestToken },
     });
   });
-  it("should build get method requestConfig for data", () => {
-    const requestConfig = kintoneRequestConfigBuilder.build(
+  it("should build get method requestConfig for data", async () => {
+    const requestConfig = await kintoneRequestConfigBuilder.build(
       "get",
       "/k/v1/record.json",
       { key: "value" },
@@ -222,8 +222,8 @@ describe("KintoneRequestConfigBuilder in Browser environment", () => {
       responseType: "arraybuffer",
     });
   });
-  it("should build post method requestConfig", () => {
-    const requestConfig = kintoneRequestConfigBuilder.build(
+  it("should build post method requestConfig", async () => {
+    const requestConfig = await kintoneRequestConfigBuilder.build(
       "post",
       "/k/v1/record.json",
       { key: "value" }
@@ -241,10 +241,10 @@ describe("KintoneRequestConfigBuilder in Browser environment", () => {
       },
     });
   });
-  it("should build post method requestConfig for data", () => {
+  it("should build post method requestConfig for data", async () => {
     const formData = new FormData();
     formData.append("key", "value");
-    const requestConfig = kintoneRequestConfigBuilder.build(
+    const requestConfig = await kintoneRequestConfigBuilder.build(
       "post",
       "/k/v1/record.json",
       formData
@@ -261,8 +261,8 @@ describe("KintoneRequestConfigBuilder in Browser environment", () => {
     });
     expect(data).toBeInstanceOf(FormData);
   });
-  it("should build put method requestConfig", () => {
-    const requestConfig = kintoneRequestConfigBuilder.build(
+  it("should build put method requestConfig", async () => {
+    const requestConfig = await kintoneRequestConfigBuilder.build(
       "put",
       "/k/v1/record.json",
       { key: "value" }
@@ -280,8 +280,8 @@ describe("KintoneRequestConfigBuilder in Browser environment", () => {
       },
     });
   });
-  it("should build delete method requestConfig", () => {
-    const requestConfig = kintoneRequestConfigBuilder.build(
+  it("should build delete method requestConfig", async () => {
+    const requestConfig = await kintoneRequestConfigBuilder.build(
       "delete",
       "/k/v1/record.json",
       { key: "value" }
@@ -298,7 +298,7 @@ describe("KintoneRequestConfigBuilder in Browser environment", () => {
 });
 
 describe("options", () => {
-  it("should build `requestConfig` having `proxy` property", () => {
+  it("should build `requestConfig` having `proxy` property", async () => {
     const baseUrl = "https://example.kintone.com";
     const apiToken = "apiToken";
     const headers = {
@@ -323,7 +323,7 @@ describe("options", () => {
       proxy,
     });
 
-    const requestConfig = kintoneRequestConfigBuilder.build(
+    const requestConfig = await kintoneRequestConfigBuilder.build(
       "get",
       "/k/v1/record.json",
       { key: "value" }
@@ -336,7 +336,7 @@ describe("options", () => {
     });
   });
 
-  it("should build `requestConfig` having `httpsAgent` property", () => {
+  it("should build `requestConfig` having `httpsAgent` property", async () => {
     const baseUrl = "https://example.kintone.com";
     const apiToken = "apiToken";
     const clientCertAuth = {
@@ -353,7 +353,7 @@ describe("options", () => {
       },
     });
 
-    const requestConfig = kintoneRequestConfigBuilder.build(
+    const requestConfig = await kintoneRequestConfigBuilder.build(
       "get",
       "/k/v1/record.json",
       { key: "value" }
@@ -365,7 +365,7 @@ describe("options", () => {
 describe("Headers", () => {
   const baseUrl = "https://example.com";
 
-  it("Password auth", () => {
+  it("Password auth", async () => {
     const USERNAME = "user";
     const PASSWORD = "password";
     const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
@@ -376,15 +376,18 @@ describe("Headers", () => {
         password: PASSWORD,
       },
     });
-    expect(
-      kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
-    ).toStrictEqual({
+    const requestConfig = await kintoneRequestConfigBuilder.build(
+      "get",
+      "/k/v1/record.json",
+      {}
+    );
+    expect(requestConfig.headers).toStrictEqual({
       "User-Agent": expectedUa,
       "X-Cybozu-Authorization": Base64.encode(`${USERNAME}:${PASSWORD}`),
     });
   });
 
-  it("ApiToken auth", () => {
+  it("ApiToken auth", async () => {
     const API_TOKEN = "ApiToken";
     const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
       baseUrl,
@@ -393,15 +396,18 @@ describe("Headers", () => {
         apiToken: API_TOKEN,
       },
     });
-    expect(
-      kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
-    ).toStrictEqual({
+    const requestConfig = await kintoneRequestConfigBuilder.build(
+      "get",
+      "/k/v1/record.json",
+      {}
+    );
+    expect(requestConfig.headers).toStrictEqual({
       "User-Agent": expectedUa,
       "X-Cybozu-API-Token": API_TOKEN,
     });
   });
 
-  it("ApiToken auth using multiple tokens as comma-separated string", () => {
+  it("ApiToken auth using multiple tokens as comma-separated string", async () => {
     const API_TOKEN1 = "ApiToken1";
     const API_TOKEN2 = "ApiToken2";
     const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
@@ -411,15 +417,18 @@ describe("Headers", () => {
         apiToken: `${API_TOKEN1},${API_TOKEN2}`,
       },
     });
-    expect(
-      kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
-    ).toStrictEqual({
+    const requestConfig = await kintoneRequestConfigBuilder.build(
+      "get",
+      "/k/v1/record.json",
+      {}
+    );
+    expect(requestConfig.headers).toStrictEqual({
       "User-Agent": expectedUa,
       "X-Cybozu-API-Token": `${API_TOKEN1},${API_TOKEN2}`,
     });
   });
 
-  it("ApiToken auth using multiple tokens as array", () => {
+  it("ApiToken auth using multiple tokens as array", async () => {
     const API_TOKEN1 = "ApiToken1";
     const API_TOKEN2 = "ApiToken2";
     const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
@@ -429,30 +438,36 @@ describe("Headers", () => {
         apiToken: [API_TOKEN1, API_TOKEN2],
       },
     });
-    expect(
-      kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
-    ).toStrictEqual({
+    const requestConfig = await kintoneRequestConfigBuilder.build(
+      "get",
+      "/k/v1/record.json",
+      {}
+    );
+    expect(requestConfig.headers).toStrictEqual({
       "User-Agent": expectedUa,
       "X-Cybozu-API-Token": `${API_TOKEN1},${API_TOKEN2}`,
     });
   });
 
-  it("Session auth", () => {
+  it("Session auth", async () => {
     const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
       baseUrl,
       auth: {
         type: "session",
       },
     });
-    expect(
-      kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
-    ).toStrictEqual({
+    const requestConfig = await kintoneRequestConfigBuilder.build(
+      "get",
+      "/k/v1/record.json",
+      {}
+    );
+    expect(requestConfig.headers).toStrictEqual({
       "User-Agent": expectedUa,
       "X-Requested-With": "XMLHttpRequest",
     });
   });
 
-  it("OAuth token auth", () => {
+  it("OAuth token auth", async () => {
     const oAuthToken = "oauth-token";
     const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
       baseUrl,
@@ -461,15 +476,18 @@ describe("Headers", () => {
         oAuthToken,
       },
     });
-    expect(
-      kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
-    ).toStrictEqual({
+    const requestConfig = await kintoneRequestConfigBuilder.build(
+      "get",
+      "/k/v1/record.json",
+      {}
+    );
+    expect(requestConfig.headers).toStrictEqual({
       Authorization: `Bearer ${oAuthToken}`,
       "User-Agent": expectedUa,
     });
   });
 
-  it("Basic auth", () => {
+  it("Basic auth", async () => {
     const basicAuth = { username: "user", password: "password" };
     const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
       baseUrl,
@@ -478,16 +496,19 @@ describe("Headers", () => {
         type: "session",
       },
     });
-    expect(
-      kintoneRequestConfigBuilder.build("get", "/k/v1/record.json", {}).headers
-    ).toStrictEqual({
+    const requestConfig = await kintoneRequestConfigBuilder.build(
+      "get",
+      "/k/v1/record.json",
+      {}
+    );
+    expect(requestConfig.headers).toStrictEqual({
       Authorization: `Basic ${Base64.encode("user:password")}`,
       "User-Agent": expectedUa,
       "X-Requested-With": "XMLHttpRequest",
     });
   });
 
-  it("should not include User-Agent for browser enviroment", () => {
+  it("should not include User-Agent for browser enviroment", async () => {
     injectPlatformDeps(browserDeps);
     const kintoneRequestConfigBuilder = new KintoneRequestConfigBuilder({
       baseUrl,
@@ -495,11 +516,11 @@ describe("Headers", () => {
         type: "session",
       },
     });
-    const headers = kintoneRequestConfigBuilder.build(
+    const requestConfig = await kintoneRequestConfigBuilder.build(
       "get",
       "/k/v1/record.json",
       {}
-    ).headers;
-    expect(headers["User-Agent"]).toBeUndefined();
+    );
+    expect(requestConfig.headers["User-Agent"]).toBeUndefined();
   });
 });

--- a/packages/rest-api-client/src/http/AxiosClient.ts
+++ b/packages/rest-api-client/src/http/AxiosClient.ts
@@ -23,24 +23,37 @@ export class AxiosClient implements HttpClient {
   }
 
   public async get(path: string, params: any) {
-    const requestConfig = this.requestConfigBuilder.build("get", path, params);
+    const requestConfig = await this.requestConfigBuilder.build(
+      "get",
+      path,
+      params
+    );
     return this.sendRequest(requestConfig);
   }
 
   public async getData(path: string, params: any) {
-    const requestConfig = this.requestConfigBuilder.build("get", path, params, {
-      responseType: "arraybuffer",
-    });
+    const requestConfig = await this.requestConfigBuilder.build(
+      "get",
+      path,
+      params,
+      {
+        responseType: "arraybuffer",
+      }
+    );
     return this.sendRequest(requestConfig);
   }
 
   public async post(path: string, params: any) {
-    const requestConfig = this.requestConfigBuilder.build("post", path, params);
+    const requestConfig = await this.requestConfigBuilder.build(
+      "post",
+      path,
+      params
+    );
     return this.sendRequest(requestConfig);
   }
 
   public async postData(path: string, formData: FormData) {
-    const requestConfig = this.requestConfigBuilder.build(
+    const requestConfig = await this.requestConfigBuilder.build(
       "post",
       path,
       formData
@@ -49,12 +62,16 @@ export class AxiosClient implements HttpClient {
   }
 
   public async put(path: string, params: any) {
-    const requestConfig = this.requestConfigBuilder.build("put", path, params);
+    const requestConfig = await this.requestConfigBuilder.build(
+      "put",
+      path,
+      params
+    );
     return this.sendRequest(requestConfig);
   }
 
   public async delete(path: string, params: any) {
-    const requestConfig = this.requestConfigBuilder.build(
+    const requestConfig = await this.requestConfigBuilder.build(
       "delete",
       path,
       params

--- a/packages/rest-api-client/src/http/HttpClientInterface.ts
+++ b/packages/rest-api-client/src/http/HttpClientInterface.ts
@@ -47,5 +47,5 @@ export interface RequestConfigBuilder {
     path: string,
     params: Params | FormData,
     options?: { responseType: "arraybuffer" }
-  ) => RequestConfig;
+  ) => Promise<RequestConfig>;
 }

--- a/packages/rest-api-client/src/platform/browser.ts
+++ b/packages/rest-api-client/src/platform/browser.ts
@@ -7,6 +7,7 @@ export const readFileFromPath = (filePath: string) => {
 
 export const getRequestToken = async () => {
   if (
+    kintone !== null &&
     typeof kintone === "object" &&
     typeof kintone.getRequestToken === "function"
   ) {
@@ -14,10 +15,9 @@ export const getRequestToken = async () => {
   }
 
   if (
+    garoon !== null &&
     typeof garoon === "object" &&
-    typeof garoon.connect === "object" &&
-    typeof garoon.connect.kintone === "object" &&
-    typeof garoon.connect.kintone.getRequestToken === "function"
+    typeof garoon.connect?.kintone?.getRequestToken === "function"
   ) {
     return garoon.connect.kintone.getRequestToken();
   }

--- a/packages/rest-api-client/src/platform/browser.ts
+++ b/packages/rest-api-client/src/platform/browser.ts
@@ -5,14 +5,24 @@ export const readFileFromPath = (filePath: string) => {
   throw new UnsupportedPlatformError("Browser");
 };
 
-export const getRequestToken = () => {
+export const getRequestToken = async () => {
   if (
-    typeof kintone === "undefined" ||
-    typeof kintone.getRequestToken !== "function"
+    typeof kintone === "object" &&
+    typeof kintone.getRequestToken === "function"
   ) {
-    throw new Error("session authentication must specify a request token");
+    return kintone.getRequestToken();
   }
-  return kintone.getRequestToken();
+
+  if (
+    typeof garoon === "object" &&
+    typeof garoon.connect === "object" &&
+    typeof garoon.connect.kintone === "object" &&
+    typeof garoon.connect.kintone.getRequestToken === "function"
+  ) {
+    return garoon.connect.kintone.getRequestToken();
+  }
+
+  throw new Error("session authentication must specify a request token");
 };
 
 export const getDefaultAuth = (): DiscriminatedAuth => {

--- a/packages/rest-api-client/src/platform/index.ts
+++ b/packages/rest-api-client/src/platform/index.ts
@@ -3,7 +3,7 @@ type PlatformDeps = {
   readFileFromPath: (
     filePath: string
   ) => Promise<{ name: string; data: unknown }>;
-  getRequestToken: () => string;
+  getRequestToken: () => Promise<string>;
   getDefaultAuth: () => DiscriminatedAuth;
   buildPlatformDependentConfig: (params: object) => object;
   buildHeaders: () => Record<string, string>;

--- a/packages/rest-api-client/types/global/index.d.ts
+++ b/packages/rest-api-client/types/global/index.d.ts
@@ -2,6 +2,14 @@ declare const kintone: {
   getRequestToken(): string;
 };
 
+declare const garoon: {
+  connect: {
+    kintone: {
+      getRequestToken(): Promise<string>;
+    };
+  };
+};
+
 declare module NodeJS {
   interface Global {
     kintone: typeof kintone;


### PR DESCRIPTION
I would like to use this SDK in Garoon JavaScript customize.
But now, it's not supported to send request with request token getting by Garoon JavaScript API.

So I made this PR to support it.
Please review and merge!!!

cf. [kintone連携用トークンを取得する - cybozu developer network](https://developer.cybozu.io/hc/ja/articles/115005294843-kintone%E9%80%A3%E6%90%BA%E7%94%A8%E3%83%88%E3%83%BC%E3%82%AF%E3%83%B3%E3%82%92%E5%8F%96%E5%BE%97%E3%81%99%E3%82%8B)