### PR TITLE
chore: canonicalize kintone/js-sdk-ja URL

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
 contact_links:
     - name: 🇯🇵 日本語はこちら
-      url: https://github.com/kintone/js-sdk-ja/
+      url: https://github.com/kintone/js-sdk-ja
       about: 日本語でのバグ報告・機能提案はこちら


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
Current url for Japanese people is not canonical.

<!-- Why do you want the feature and why does it make sense for the package? -->

## What

Remove the trailed slash.

<!-- What is a solution you want to add? -->