### PR TITLE
chore: remove common devDependencies from manifest-validator

### DIFF
--- a/packages/plugin-manifest-validator/package.json
+++ b/packages/plugin-manifest-validator/package.json
@@ -27,14 +27,9 @@
     "bytes": "^3.1.0"
   },
   "devDependencies": {
-    "@cybozu/eslint-config": "^10.0.3",
-    "eslint": "^6.8.0",
     "intelli-espower-loader": "^1.0.1",
     "json-schema-to-typescript": "^9.1.0",
-    "npm-run-all": "^4.1.5",
-    "power-assert": "^1.6.1",
-    "prettier": "1.19.1",
-    "typescript": "^3.8.3"
+    "power-assert": "^1.6.1"
   },
   "homepage": "https://github.com/kintone/js-sdk/tree/master/packages/plugin-manifest-validator#readme",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8243,11 +8243,6 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
-
 prettier@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
@@ -10002,7 +9997,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.8.3, typescript@^3.9.3:
+typescript@^3.9.3:
   version "3.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
   integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

To reduce installed packages.

## What

<!-- What is a solution you want to add? -->

Removed packages defined in the root `package.json` from `package.json` of `plugin-manifest-validator` 

## How to test

<!-- How can we test this pull request? -->

`yarn test` and `yarn lint`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
