### PR TITLE
refactor: use `KintoneRequestConfigBuilder` in `MockClient`

### DIFF
--- a/packages/rest-api-client/src/client/__tests__/AppClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/AppClient.test.ts
@@ -2,6 +2,10 @@ import { MockClient } from "../../http/MockClient";
 import { AppClient } from "../AppClient";
 import { KintoneRequestConfigBuilder } from "../../KintoneRequestConfigBuilder";
 
+const errorResponseHandler = (error: Error) => {
+  throw error;
+};
+
 describe("AppClient", () => {
   let mockClient: MockClient;
   let appClient: AppClient;
@@ -114,7 +118,7 @@ describe("AppClient", () => {
       baseUrl: "https://example.cybozu.com",
       auth: { type: "apiToken", apiToken: "foo" },
     });
-    mockClient = new MockClient({ requestConfigBuilder });
+    mockClient = new MockClient({ requestConfigBuilder, errorResponseHandler });
     appClient = new AppClient(mockClient);
   });
   describe("getFormFields", () => {
@@ -863,7 +867,10 @@ describe("AppClient with guestSpaceId", () => {
       baseUrl: "https://example.cybozu.com",
       auth: { type: "session" },
     });
-    const mockClient = new MockClient({ requestConfigBuilder });
+    const mockClient = new MockClient({
+      requestConfigBuilder,
+      errorResponseHandler,
+    });
     const appClient = new AppClient(mockClient, GUEST_SPACE_ID);
     await appClient.getFormFields(params);
     expect(mockClient.getLogs()[0].path).toBe(

--- a/packages/rest-api-client/src/client/__tests__/AppClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/AppClient.test.ts
@@ -1,5 +1,6 @@
 import { MockClient } from "../../http/MockClient";
 import { AppClient } from "../AppClient";
+import { KintoneRequestConfigBuilder } from "../../KintoneRequestConfigBuilder";
 
 describe("AppClient", () => {
   let mockClient: MockClient;
@@ -109,7 +110,11 @@ describe("AppClient", () => {
   ];
 
   beforeEach(() => {
-    mockClient = new MockClient();
+    const requestConfigBuilder = new KintoneRequestConfigBuilder({
+      baseUrl: "https://example.cybozu.com",
+      auth: { type: "apiToken", apiToken: "foo" },
+    });
+    mockClient = new MockClient({ requestConfigBuilder });
     appClient = new AppClient(mockClient);
   });
   describe("getFormFields", () => {
@@ -854,7 +859,11 @@ describe("AppClient with guestSpaceId", () => {
     const GUEST_SPACE_ID = 2;
     const lang = "default";
     const params = { app: APP_ID, lang } as const;
-    const mockClient = new MockClient();
+    const requestConfigBuilder = new KintoneRequestConfigBuilder({
+      baseUrl: "https://example.cybozu.com",
+      auth: { type: "session" },
+    });
+    const mockClient = new MockClient({ requestConfigBuilder });
     const appClient = new AppClient(mockClient, GUEST_SPACE_ID);
     await appClient.getFormFields(params);
     expect(mockClient.getLogs()[0].path).toBe(

--- a/packages/rest-api-client/src/client/__tests__/AppClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/AppClient.test.ts
@@ -116,8 +116,8 @@ describe("AppClient", () => {
     const lang = "default";
     const params = { app: APP_ID, lang } as const;
     describe("without preview", () => {
-      beforeEach(() => {
-        appClient.getFormFields(params);
+      beforeEach(async () => {
+        await appClient.getFormFields(params);
       });
       it("should pass the path to the http client", () => {
         expect(mockClient.getLogs()[0].path).toBe("/k/v1/app/form/fields.json");
@@ -130,8 +130,8 @@ describe("AppClient", () => {
       });
     });
     describe("preview: true", () => {
-      beforeEach(() => {
-        appClient.getFormFields({ ...params, preview: true });
+      beforeEach(async () => {
+        await appClient.getFormFields({ ...params, preview: true });
       });
       it("should pass the path to the http client", () => {
         expect(mockClient.getLogs()[0].path).toBe(
@@ -149,8 +149,8 @@ describe("AppClient", () => {
 
   describe("addFormFields", () => {
     const params = { app: APP_ID, properties, revision: REVISION };
-    beforeEach(() => {
-      appClient.addFormFields(params);
+    beforeEach(async () => {
+      await appClient.addFormFields(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe(
@@ -167,8 +167,8 @@ describe("AppClient", () => {
 
   describe("updateFormFields", () => {
     const params = { app: APP_ID, properties, revision: REVISION };
-    beforeEach(() => {
-      appClient.updateFormFields(params);
+    beforeEach(async () => {
+      await appClient.updateFormFields(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe(
@@ -186,8 +186,8 @@ describe("AppClient", () => {
   describe("deleteFormFields", () => {
     const fields = ["fieldCode1", "fieldCode2"];
     const params = { app: APP_ID, fields, revision: REVISION };
-    beforeEach(() => {
-      appClient.deleteFormFields(params);
+    beforeEach(async () => {
+      await appClient.deleteFormFields(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe(
@@ -205,8 +205,8 @@ describe("AppClient", () => {
   describe("getFormLayout", () => {
     const params = { app: APP_ID };
     describe("without preview", () => {
-      beforeEach(() => {
-        appClient.getFormLayout(params);
+      beforeEach(async () => {
+        await appClient.getFormLayout(params);
       });
       it("should pass the path to the http client", () => {
         expect(mockClient.getLogs()[0].path).toBe("/k/v1/app/form/layout.json");
@@ -219,8 +219,8 @@ describe("AppClient", () => {
       });
     });
     describe("preview: true", () => {
-      beforeEach(() => {
-        appClient.getFormLayout({ ...params, preview: true });
+      beforeEach(async () => {
+        await appClient.getFormLayout({ ...params, preview: true });
       });
       it("should pass the path to the http client", () => {
         expect(mockClient.getLogs()[0].path).toBe(
@@ -239,8 +239,8 @@ describe("AppClient", () => {
   describe("updateFormLayout", () => {
     const params = { app: APP_ID, layout, revision: REVISION };
 
-    beforeEach(() => {
-      appClient.updateFormLayout(params);
+    beforeEach(async () => {
+      await appClient.updateFormLayout(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe(
@@ -259,8 +259,8 @@ describe("AppClient", () => {
     const lang = "default";
     const params = { app: APP_ID, lang } as const;
     describe("without preview", () => {
-      beforeEach(() => {
-        appClient.getViews(params);
+      beforeEach(async () => {
+        await appClient.getViews(params);
       });
       it("should pass the path to the http client", () => {
         expect(mockClient.getLogs()[0].path).toBe("/k/v1/app/views.json");
@@ -273,8 +273,8 @@ describe("AppClient", () => {
       });
     });
     describe("preview: true", () => {
-      beforeEach(() => {
-        appClient.getViews({ ...params, preview: true });
+      beforeEach(async () => {
+        await appClient.getViews({ ...params, preview: true });
       });
       it("should pass the path to the http client", () => {
         expect(mockClient.getLogs()[0].path).toBe(
@@ -292,8 +292,8 @@ describe("AppClient", () => {
 
   describe("updateViews", () => {
     const params = { app: APP_ID, views, revision: REVISION };
-    beforeEach(() => {
-      appClient.updateViews(params);
+    beforeEach(async () => {
+      await appClient.updateViews(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/preview/app/views.json");
@@ -310,8 +310,8 @@ describe("AppClient", () => {
     const params = {
       id: APP_ID,
     };
-    beforeEach(() => {
-      appClient.getApp(params);
+    beforeEach(async () => {
+      await appClient.getApp(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/app.json");
@@ -333,8 +333,8 @@ describe("AppClient", () => {
       limit: 100,
       offset: 30,
     };
-    beforeEach(() => {
-      appClient.getApps(params);
+    beforeEach(async () => {
+      await appClient.getApps(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/apps.json");
@@ -352,8 +352,8 @@ describe("AppClient", () => {
       const params = {
         name: "app",
       };
-      beforeEach(() => {
-        appClient.addApp(params);
+      beforeEach(async () => {
+        await appClient.addApp(params);
       });
       it("should pass the path to the http client", () => {
         expect(mockClient.getLogs()[0].path).toBe("/k/v1/preview/app.json");
@@ -371,9 +371,9 @@ describe("AppClient", () => {
         space: 10,
       };
       const defaultThread = 20;
-      beforeEach(() => {
+      beforeEach(async () => {
         mockClient.mockResponse({ defaultThread });
-        appClient.addApp(params);
+        await appClient.addApp(params);
       });
       it("should fetch the default thread of the space", () => {
         expect(mockClient.getLogs()[0].path).toBe("/k/v1/space.json");
@@ -395,8 +395,8 @@ describe("AppClient", () => {
     const lang = "default";
     const params = { app: APP_ID, lang } as const;
     describe("without preview", () => {
-      beforeEach(() => {
-        appClient.getProcessManagement(params);
+      beforeEach(async () => {
+        await appClient.getProcessManagement(params);
       });
       it("should pass the path to the http client", () => {
         expect(mockClient.getLogs()[0].path).toBe("/k/v1/app/status.json");
@@ -409,8 +409,8 @@ describe("AppClient", () => {
       });
     });
     describe("preview: true", () => {
-      beforeEach(() => {
-        appClient.getProcessManagement({ ...params, preview: true });
+      beforeEach(async () => {
+        await appClient.getProcessManagement({ ...params, preview: true });
       });
       it("should pass the path to the http client", () => {
         expect(mockClient.getLogs()[0].path).toBe(
@@ -434,8 +434,8 @@ describe("AppClient", () => {
       states,
       actions,
     };
-    beforeEach(() => {
-      appClient.updateProcessManagement(params);
+    beforeEach(async () => {
+      await appClient.updateProcessManagement(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe(
@@ -454,8 +454,8 @@ describe("AppClient", () => {
     const lang = "default";
     const params = { app: APP_ID, lang } as const;
     describe("without preview", () => {
-      beforeEach(() => {
-        appClient.getAppSettings(params);
+      beforeEach(async () => {
+        await appClient.getAppSettings(params);
       });
       it("should pass the path to the http client", () => {
         expect(mockClient.getLogs()[0].path).toBe("/k/v1/app/settings.json");
@@ -468,8 +468,8 @@ describe("AppClient", () => {
       });
     });
     describe("preview: true", () => {
-      beforeEach(() => {
-        appClient.getAppSettings({ ...params, preview: true });
+      beforeEach(async () => {
+        await appClient.getAppSettings({ ...params, preview: true });
       });
       it("should pass the path to the http client", () => {
         expect(mockClient.getLogs()[0].path).toBe(
@@ -499,8 +499,8 @@ describe("AppClient", () => {
       },
       theme: "WHITE" as const,
     };
-    beforeEach(() => {
-      appClient.updateAppSettings(params);
+    beforeEach(async () => {
+      await appClient.updateAppSettings(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe(
@@ -519,8 +519,8 @@ describe("AppClient", () => {
     const params = {
       apps: [APP_ID],
     };
-    beforeEach(() => {
-      appClient.getDeployStatus(params);
+    beforeEach(async () => {
+      await appClient.getDeployStatus(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe(
@@ -540,8 +540,8 @@ describe("AppClient", () => {
       apps: [{ app: APP_ID, revision: REVISION }],
       revert: true,
     };
-    beforeEach(() => {
-      appClient.deployApp(params);
+    beforeEach(async () => {
+      await appClient.deployApp(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe(
@@ -560,8 +560,8 @@ describe("AppClient", () => {
     const params = {
       app: APP_ID,
     };
-    beforeEach(() => {
-      appClient.getFieldAcl(params);
+    beforeEach(async () => {
+      await appClient.getFieldAcl(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/field/acl.json");
@@ -593,8 +593,8 @@ describe("AppClient", () => {
       ],
     };
 
-    beforeEach(() => {
-      appClient.updateFieldAcl(params);
+    beforeEach(async () => {
+      await appClient.updateFieldAcl(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/preview/field/acl.json");
@@ -614,8 +614,8 @@ describe("AppClient", () => {
       lang,
     } as const;
     describe("without preview", () => {
-      beforeEach(() => {
-        appClient.getRecordAcl(params);
+      beforeEach(async () => {
+        await appClient.getRecordAcl(params);
       });
       it("should pass the path to the http client", () => {
         expect(mockClient.getLogs()[0].path).toBe("/k/v1/record/acl.json");
@@ -628,8 +628,8 @@ describe("AppClient", () => {
       });
     });
     describe("preview: true", () => {
-      beforeEach(() => {
-        appClient.getRecordAcl({ ...params, preview: true });
+      beforeEach(async () => {
+        await appClient.getRecordAcl({ ...params, preview: true });
       });
       it("should pass the path to the http client", () => {
         expect(mockClient.getLogs()[0].path).toBe(
@@ -667,8 +667,8 @@ describe("AppClient", () => {
       ],
       revision: REVISION,
     };
-    beforeEach(() => {
-      appClient.updateRecordAcl(params);
+    beforeEach(async () => {
+      await appClient.updateRecordAcl(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe(
@@ -688,8 +688,8 @@ describe("AppClient", () => {
       app: APP_ID,
     };
     describe("without preview", () => {
-      beforeEach(() => {
-        appClient.getAppAcl(params);
+      beforeEach(async () => {
+        await appClient.getAppAcl(params);
       });
       it("should pass the path to the http client", () => {
         expect(mockClient.getLogs()[0].path).toBe("/k/v1/app/acl.json");
@@ -702,8 +702,8 @@ describe("AppClient", () => {
       });
     });
     describe("preview: true", () => {
-      beforeEach(() => {
-        appClient.getAppAcl({ ...params, preview: true });
+      beforeEach(async () => {
+        await appClient.getAppAcl({ ...params, preview: true });
       });
       it("should pass the path to the http client", () => {
         expect(mockClient.getLogs()[0].path).toBe("/k/v1/preview/app/acl.json");
@@ -736,8 +736,8 @@ describe("AppClient", () => {
         },
       ],
     };
-    beforeEach(() => {
-      appClient.updateAppAcl(params);
+    beforeEach(async () => {
+      await appClient.updateAppAcl(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/preview/app/acl.json");
@@ -755,8 +755,8 @@ describe("AppClient", () => {
       app: APP_ID,
       ids: [RECORD_ID],
     };
-    beforeEach(() => {
-      appClient.evaluateRecordsAcl(params);
+    beforeEach(async () => {
+      await appClient.evaluateRecordsAcl(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe(
@@ -774,8 +774,8 @@ describe("AppClient", () => {
   describe("getAppCustomize", () => {
     const params = { app: APP_ID };
     describe("without preview", () => {
-      beforeEach(() => {
-        appClient.getAppCustomize(params);
+      beforeEach(async () => {
+        await appClient.getAppCustomize(params);
       });
       it("should pass the path to the http client", () => {
         expect(mockClient.getLogs()[0].path).toBe("/k/v1/app/customize.json");
@@ -788,8 +788,8 @@ describe("AppClient", () => {
       });
     });
     describe("preview: true", () => {
-      beforeEach(() => {
-        appClient.getAppCustomize({ ...params, preview: true });
+      beforeEach(async () => {
+        await appClient.getAppCustomize({ ...params, preview: true });
       });
       it("should pass the path to the http client", () => {
         expect(mockClient.getLogs()[0].path).toBe(
@@ -830,8 +830,8 @@ describe("AppClient", () => {
       revision: REVISION,
     };
     describe("customize resources are specified", () => {
-      beforeEach(() => {
-        appClient.updateAppCustomize(params);
+      beforeEach(async () => {
+        await appClient.updateAppCustomize(params);
       });
       it("should pass the path to the http client", () => {
         expect(mockClient.getLogs()[0].path).toBe(
@@ -849,14 +849,14 @@ describe("AppClient", () => {
 });
 
 describe("AppClient with guestSpaceId", () => {
-  it("should pass the path to the http client", () => {
+  it("should pass the path to the http client", async () => {
     const APP_ID = 1;
     const GUEST_SPACE_ID = 2;
     const lang = "default";
     const params = { app: APP_ID, lang } as const;
     const mockClient = new MockClient();
     const appClient = new AppClient(mockClient, GUEST_SPACE_ID);
-    appClient.getFormFields(params);
+    await appClient.getFormFields(params);
     expect(mockClient.getLogs()[0].path).toBe(
       `/k/guest/${GUEST_SPACE_ID}/v1/app/form/fields.json`
     );

--- a/packages/rest-api-client/src/client/__tests__/BulkRequestClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/BulkRequestClient.test.ts
@@ -38,8 +38,8 @@ describe("BulkRequestClient", () => {
         },
       ],
     };
-    beforeEach(() => {
-      bulkRequestClient.send(params);
+    beforeEach(async () => {
+      await bulkRequestClient.send(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/bulkRequest.json");
@@ -94,8 +94,8 @@ describe("BulkRequestClient", () => {
       ],
     };
 
-    beforeEach(() => {
-      bulkRequestClient.send(params);
+    beforeEach(async () => {
+      await bulkRequestClient.send(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/bulkRequest.json");
@@ -118,7 +118,7 @@ describe("BulkRequestClient with guestSpaceId", () => {
     mockClient = new MockClient();
     bulkRequestClient = new BulkRequestClient(mockClient, GUEST_SPACE_ID);
   });
-  it("should pass the path to the http client", () => {
+  it("should pass the path to the http client", async () => {
     const params = {
       requests: [
         {
@@ -135,12 +135,12 @@ describe("BulkRequestClient with guestSpaceId", () => {
         },
       ],
     };
-    bulkRequestClient.send(params);
+    await bulkRequestClient.send(params);
     expect(mockClient.getLogs()[0].path).toBe(
       `/k/guest/${GUEST_SPACE_ID}/v1/bulkRequest.json`
     );
   });
-  it("should pass the path as a param with the guest space id to the http client", () => {
+  it("should pass the path as a param with the guest space id to the http client", async () => {
     const params = {
       requests: [
         {
@@ -157,7 +157,7 @@ describe("BulkRequestClient with guestSpaceId", () => {
         },
       ],
     };
-    bulkRequestClient.send(params);
+    await bulkRequestClient.send(params);
     expect(mockClient.getLogs()[0].params.requests[0].api).toEqual(
       `/k/guest/${GUEST_SPACE_ID}/v1/record.json`
     );

--- a/packages/rest-api-client/src/client/__tests__/BulkRequestClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/BulkRequestClient.test.ts
@@ -1,5 +1,6 @@
 import { MockClient } from "../../http/MockClient";
 import { BulkRequestClient } from "../BulkRequestClient";
+import { KintoneRequestConfigBuilder } from "../../KintoneRequestConfigBuilder";
 
 describe("BulkRequestClient", () => {
   let mockClient: MockClient;
@@ -14,7 +15,11 @@ describe("BulkRequestClient", () => {
   };
 
   beforeEach(() => {
-    mockClient = new MockClient();
+    const requestConfigBuilder = new KintoneRequestConfigBuilder({
+      baseUrl: "https://example.cybozu.com",
+      auth: { type: "apiToken", apiToken: "foo" },
+    });
+    mockClient = new MockClient({ requestConfigBuilder });
     bulkRequestClient = new BulkRequestClient(mockClient);
   });
   describe("send", () => {
@@ -115,7 +120,11 @@ describe("BulkRequestClient with guestSpaceId", () => {
   const APP_ID = 1;
   const GUEST_SPACE_ID = 2;
   beforeEach(() => {
-    mockClient = new MockClient();
+    const requestConfigBuilder = new KintoneRequestConfigBuilder({
+      baseUrl: "https://example.cybozu.com",
+      auth: { type: "apiToken", apiToken: "foo" },
+    });
+    mockClient = new MockClient({ requestConfigBuilder });
     bulkRequestClient = new BulkRequestClient(mockClient, GUEST_SPACE_ID);
   });
   it("should pass the path to the http client", async () => {

--- a/packages/rest-api-client/src/client/__tests__/BulkRequestClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/BulkRequestClient.test.ts
@@ -2,6 +2,9 @@ import { MockClient } from "../../http/MockClient";
 import { BulkRequestClient } from "../BulkRequestClient";
 import { KintoneRequestConfigBuilder } from "../../KintoneRequestConfigBuilder";
 
+const errorResponseHandler = (error: Error) => {
+  throw error;
+};
 describe("BulkRequestClient", () => {
   let mockClient: MockClient;
   let bulkRequestClient: BulkRequestClient;
@@ -19,7 +22,7 @@ describe("BulkRequestClient", () => {
       baseUrl: "https://example.cybozu.com",
       auth: { type: "apiToken", apiToken: "foo" },
     });
-    mockClient = new MockClient({ requestConfigBuilder });
+    mockClient = new MockClient({ requestConfigBuilder, errorResponseHandler });
     bulkRequestClient = new BulkRequestClient(mockClient);
   });
   describe("send", () => {
@@ -124,7 +127,7 @@ describe("BulkRequestClient with guestSpaceId", () => {
       baseUrl: "https://example.cybozu.com",
       auth: { type: "apiToken", apiToken: "foo" },
     });
-    mockClient = new MockClient({ requestConfigBuilder });
+    mockClient = new MockClient({ requestConfigBuilder, errorResponseHandler });
     bulkRequestClient = new BulkRequestClient(mockClient, GUEST_SPACE_ID);
   });
   it("should pass the path to the http client", async () => {

--- a/packages/rest-api-client/src/client/__tests__/File.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/File.test.ts
@@ -3,6 +3,8 @@ import { FileClient } from "../FileClient";
 import FormData from "form-data";
 import { injectPlatformDeps } from "../../platform";
 import * as browserDeps from "../../platform/browser";
+import * as nodeDeps from "../../platform/node";
+import { KintoneRequestConfigBuilder } from "../../KintoneRequestConfigBuilder";
 
 jest.mock("form-data");
 
@@ -10,7 +12,11 @@ describe("FileClient", () => {
   let mockClient: MockClient;
   let fileClient: FileClient;
   beforeEach(() => {
-    mockClient = new MockClient();
+    const requestConfigBuilder = new KintoneRequestConfigBuilder({
+      baseUrl: "https://example.cybozu.com",
+      auth: { type: "apiToken", apiToken: "foo" },
+    });
+    mockClient = new MockClient({ requestConfigBuilder });
     fileClient = new FileClient(mockClient);
   });
   describe("uploadFile", () => {
@@ -48,6 +54,7 @@ describe("FileClient", () => {
       };
       it("should pass file object includes name and data as a param to the http client", async () => {
         injectPlatformDeps({
+          ...nodeDeps,
           readFileFromPath: async (filePath: string) => ({
             name: filePath,
             data: "Hello!",
@@ -106,7 +113,11 @@ describe("FileClient with guestSpaceId", () => {
   let mockClient: MockClient;
   let fileClient: FileClient;
   beforeEach(async () => {
-    mockClient = new MockClient();
+    const requestConfigBuilder = new KintoneRequestConfigBuilder({
+      baseUrl: "https://example.cybozu.com",
+      auth: { type: "apiToken", apiToken: "foo" },
+    });
+    mockClient = new MockClient({ requestConfigBuilder });
     fileClient = new FileClient(mockClient, GUEST_SPACE_ID);
     await fileClient.uploadFile(params);
   });

--- a/packages/rest-api-client/src/client/__tests__/File.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/File.test.ts
@@ -8,6 +8,10 @@ import { KintoneRequestConfigBuilder } from "../../KintoneRequestConfigBuilder";
 
 jest.mock("form-data");
 
+const errorResponseHandler = (error: Error) => {
+  throw error;
+};
+
 describe("FileClient", () => {
   let mockClient: MockClient;
   let fileClient: FileClient;
@@ -16,7 +20,7 @@ describe("FileClient", () => {
       baseUrl: "https://example.cybozu.com",
       auth: { type: "apiToken", apiToken: "foo" },
     });
-    mockClient = new MockClient({ requestConfigBuilder });
+    mockClient = new MockClient({ requestConfigBuilder, errorResponseHandler });
     fileClient = new FileClient(mockClient);
   });
   describe("uploadFile", () => {
@@ -117,7 +121,7 @@ describe("FileClient with guestSpaceId", () => {
       baseUrl: "https://example.cybozu.com",
       auth: { type: "apiToken", apiToken: "foo" },
     });
-    mockClient = new MockClient({ requestConfigBuilder });
+    mockClient = new MockClient({ requestConfigBuilder, errorResponseHandler });
     fileClient = new FileClient(mockClient, GUEST_SPACE_ID);
     await fileClient.uploadFile(params);
   });

--- a/packages/rest-api-client/src/client/__tests__/File.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/File.test.ts
@@ -21,8 +21,8 @@ describe("FileClient", () => {
           data: "Hello!",
         },
       };
-      beforeEach(() => {
-        fileClient.uploadFile(params);
+      beforeEach(async () => {
+        await fileClient.uploadFile(params);
       });
       it("should pass the path to the http client", () => {
         expect(mockClient.getLogs()[0].path).toBe("/k/v1/file.json");
@@ -69,9 +69,9 @@ describe("FileClient", () => {
           path: "foo/bar/baz.txt",
         },
       };
-      it("should raise an error on a browser environment", () => {
+      it("should raise an error on a browser environment", async () => {
         injectPlatformDeps(browserDeps);
-        expect(fileClient.uploadFile(params)).rejects.toThrow(
+        await expect(fileClient.uploadFile(params)).rejects.toThrow(
           "uploadFile doesn't allow to accept a file path in Browser environment."
         );
       });
@@ -80,8 +80,8 @@ describe("FileClient", () => {
 
   describe("downloadFile", () => {
     const params = { fileKey: "some_file_key" };
-    beforeEach(() => {
-      fileClient.downloadFile(params);
+    beforeEach(async () => {
+      await fileClient.downloadFile(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/file.json");
@@ -105,10 +105,10 @@ describe("FileClient with guestSpaceId", () => {
   };
   let mockClient: MockClient;
   let fileClient: FileClient;
-  beforeEach(() => {
+  beforeEach(async () => {
     mockClient = new MockClient();
     fileClient = new FileClient(mockClient, GUEST_SPACE_ID);
-    fileClient.uploadFile(params);
+    await fileClient.uploadFile(params);
   });
   it("should pass the path to the http client", () => {
     expect(mockClient.getLogs()[0].path).toBe(

--- a/packages/rest-api-client/src/client/__tests__/RecordClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/RecordClient.test.ts
@@ -6,6 +6,9 @@ import { KintoneRestAPIError } from "../../KintoneRestAPIError";
 import { Record } from "../types";
 import { KintoneRequestConfigBuilder } from "../../KintoneRequestConfigBuilder";
 
+const errorResponseHandler = (error: Error) => {
+  throw error;
+};
 describe("RecordClient", () => {
   let mockClient: MockClient;
   let recordClient: RecordClient;
@@ -23,7 +26,7 @@ describe("RecordClient", () => {
       baseUrl: "https://example.cybozu.com",
       auth: { type: "apiToken", apiToken: "foo" },
     });
-    mockClient = new MockClient({ requestConfigBuilder });
+    mockClient = new MockClient({ requestConfigBuilder, errorResponseHandler });
     const bulkRequestClient = new BulkRequestClient(mockClient);
     recordClient = new RecordClient(mockClient, bulkRequestClient);
   });
@@ -1275,7 +1278,10 @@ describe("RecordClient with guestSpaceId", () => {
       baseUrl: "https://example.cybozu.com",
       auth: { type: "session" },
     });
-    const mockClient = new MockClient({ requestConfigBuilder });
+    const mockClient = new MockClient({
+      requestConfigBuilder,
+      errorResponseHandler,
+    });
     const bulkRequestClient = new BulkRequestClient(mockClient);
     const recordClient = new RecordClient(
       mockClient,

--- a/packages/rest-api-client/src/client/__tests__/RecordClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/RecordClient.test.ts
@@ -24,8 +24,8 @@ describe("RecordClient", () => {
   });
   describe("getRecord", () => {
     const params = { app: APP_ID, id: RECORD_ID };
-    beforeEach(() => {
-      recordClient.getRecord(params);
+    beforeEach(async () => {
+      await recordClient.getRecord(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/record.json");
@@ -40,8 +40,8 @@ describe("RecordClient", () => {
 
   describe("addRecord", () => {
     const params = { app: APP_ID, record };
-    beforeEach(() => {
-      recordClient.addRecord(params);
+    beforeEach(async () => {
+      await recordClient.addRecord(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/record.json");
@@ -61,8 +61,8 @@ describe("RecordClient", () => {
       record,
       revision: 5,
     };
-    beforeEach(() => {
-      recordClient.updateRecord(params);
+    beforeEach(async () => {
+      await recordClient.updateRecord(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/record.json");
@@ -205,8 +205,8 @@ describe("RecordClient", () => {
       query: `${fieldCode} = "foo"`,
       totalCount: true,
     };
-    beforeEach(() => {
-      recordClient.getRecords(params);
+    beforeEach(async () => {
+      await recordClient.getRecords(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/records.json");
@@ -256,8 +256,8 @@ describe("RecordClient", () => {
       app: APP_ID,
       records: [{ id: RECORD_ID, record, revision: 5 }],
     };
-    beforeEach(() => {
-      recordClient.updateRecords(params);
+    beforeEach(async () => {
+      await recordClient.updateRecords(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/records.json");
@@ -278,8 +278,8 @@ describe("RecordClient", () => {
       ids,
       revisions,
     };
-    beforeEach(() => {
-      recordClient.deleteRecords(params);
+    beforeEach(async () => {
+      await recordClient.deleteRecords(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/records.json");
@@ -299,8 +299,8 @@ describe("RecordClient", () => {
       query: `${fieldCode} = "foo"`,
       size: 10,
     };
-    beforeEach(() => {
-      recordClient.createCursor(params);
+    beforeEach(async () => {
+      await recordClient.createCursor(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/records/cursor.json");
@@ -317,8 +317,8 @@ describe("RecordClient", () => {
     const params = {
       id: "cursor id",
     };
-    beforeEach(() => {
-      recordClient.getRecordsByCursor(params);
+    beforeEach(async () => {
+      await recordClient.getRecordsByCursor(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/records/cursor.json");
@@ -335,8 +335,8 @@ describe("RecordClient", () => {
     const params = {
       id: "cursor id",
     };
-    beforeEach(() => {
-      recordClient.deleteCursor(params);
+    beforeEach(async () => {
+      await recordClient.deleteCursor(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/records/cursor.json");
@@ -622,24 +622,24 @@ describe("RecordClient", () => {
         recordClient.getAllRecordsWithCursor = withCursorMockFn;
         recordClient.getAllRecordsWithOffset = withOffsetMockFn;
       });
-      it("should call `getAllRecordsWithCursor` if `withCursor` is not specified", () => {
-        recordClient.getAllRecords({ ...params });
+      it("should call `getAllRecordsWithCursor` if `withCursor` is not specified", async () => {
+        await recordClient.getAllRecords({ ...params });
         expect(withCursorMockFn.mock.calls.length).toBe(1);
         expect(withCursorMockFn.mock.calls[0][0]).toStrictEqual({
           app: params.app,
           query: `${params.condition} order by ${params.orderBy}`,
         });
       });
-      it("should call `getAllRecordsWithCursor` if `withCursor` is true", () => {
-        recordClient.getAllRecords({ ...params, withCursor: true });
+      it("should call `getAllRecordsWithCursor` if `withCursor` is true", async () => {
+        await recordClient.getAllRecords({ ...params, withCursor: true });
         expect(withCursorMockFn.mock.calls.length).toBe(1);
         expect(withCursorMockFn.mock.calls[0][0]).toStrictEqual({
           app: params.app,
           query: `${params.condition} order by ${params.orderBy}`,
         });
       });
-      it("should call `getAllRecordsWithOffset` if `withCursor` is false", () => {
-        recordClient.getAllRecords({ ...params, withCursor: false });
+      it("should call `getAllRecordsWithOffset` if `withCursor` is false", async () => {
+        await recordClient.getAllRecords({ ...params, withCursor: false });
         expect(withOffsetMockFn.mock.calls.length).toBe(1);
         expect(withOffsetMockFn.mock.calls[0][0]).toStrictEqual(params);
       });
@@ -657,18 +657,18 @@ describe("RecordClient", () => {
         mockFn = jest.fn();
         recordClient.getAllRecordsWithId = mockFn;
       });
-      it("should call `getAllRecordsWithId` if `withCursor` is not specified", () => {
-        recordClient.getAllRecords(params);
+      it("should call `getAllRecordsWithId` if `withCursor` is not specified", async () => {
+        await recordClient.getAllRecords(params);
         expect(mockFn.mock.calls.length).toBe(1);
         expect(mockFn.mock.calls[0][0]).toStrictEqual(expected);
       });
-      it("should call `getAllRecordsWithId` if `withCursor` is true", () => {
-        recordClient.getAllRecords({ ...params, withCursor: true });
+      it("should call `getAllRecordsWithId` if `withCursor` is true", async () => {
+        await recordClient.getAllRecords({ ...params, withCursor: true });
         expect(mockFn.mock.calls.length).toBe(1);
         expect(mockFn.mock.calls[0][0]).toStrictEqual(expected);
       });
-      it("should call `getAllRecordsWithId` if `withCursor` is false", () => {
-        recordClient.getAllRecords({ ...params, withCursor: false });
+      it("should call `getAllRecordsWithId` if `withCursor` is false", async () => {
+        await recordClient.getAllRecords({ ...params, withCursor: false });
         expect(mockFn.mock.calls.length).toBe(1);
         expect(mockFn.mock.calls[0][0]).toStrictEqual(expected);
       });
@@ -683,18 +683,18 @@ describe("RecordClient", () => {
         mockFn = jest.fn();
         recordClient.getAllRecordsWithId = mockFn;
       });
-      it("should call `getAllRecordsWithId` if `withCursor` is not specified", () => {
-        recordClient.getAllRecords(params);
+      it("should call `getAllRecordsWithId` if `withCursor` is not specified", async () => {
+        await recordClient.getAllRecords(params);
         expect(mockFn.mock.calls.length).toBe(1);
         expect(mockFn.mock.calls[0][0]).toStrictEqual(params);
       });
-      it("should call `getAllRecordsWithId` if `withCursor` is true", () => {
-        recordClient.getAllRecords({ ...params, withCursor: true });
+      it("should call `getAllRecordsWithId` if `withCursor` is true", async () => {
+        await recordClient.getAllRecords({ ...params, withCursor: true });
         expect(mockFn.mock.calls.length).toBe(1);
         expect(mockFn.mock.calls[0][0]).toStrictEqual(params);
       });
-      it("should call `getAllRecordsWithId` if `withCursor` is false", () => {
-        recordClient.getAllRecords({ ...params, withCursor: false });
+      it("should call `getAllRecordsWithId` if `withCursor` is false", async () => {
+        await recordClient.getAllRecords({ ...params, withCursor: false });
         expect(mockFn.mock.calls.length).toBe(1);
         expect(mockFn.mock.calls[0][0]).toStrictEqual(params);
       });
@@ -844,7 +844,7 @@ describe("RecordClient", () => {
     });
 
     describe("parameter error", () => {
-      it("should raise an Error if `records` parameter is not an array", () => {
+      it("should raise an Error if `records` parameter is not an array", async () => {
         const invalidParams: any = {
           app: APP_ID,
           records: Array.from({ length: 3000 }, (_, index) => index + 1).map(
@@ -860,7 +860,7 @@ describe("RecordClient", () => {
             }
           ),
         };
-        expect(recordClient.addAllRecords(invalidParams)).rejects.toThrow(
+        await expect(recordClient.addAllRecords(invalidParams)).rejects.toThrow(
           "the `records` parameter must be an array of object."
         );
       });
@@ -1134,8 +1134,8 @@ describe("RecordClient", () => {
         ],
       },
     };
-    beforeEach(() => {
-      recordClient.addRecordComment(params);
+    beforeEach(async () => {
+      await recordClient.addRecordComment(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/record/comment.json");
@@ -1154,8 +1154,8 @@ describe("RecordClient", () => {
       record: RECORD_ID,
       comment: "1",
     };
-    beforeEach(() => {
-      recordClient.deleteRecordComment(params);
+    beforeEach(async () => {
+      await recordClient.deleteRecordComment(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/record/comment.json");
@@ -1176,8 +1176,8 @@ describe("RecordClient", () => {
       offset: 5,
       limit: 5,
     };
-    beforeEach(() => {
-      recordClient.getRecordComments(params);
+    beforeEach(async () => {
+      await recordClient.getRecordComments(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/record/comments.json");
@@ -1197,8 +1197,8 @@ describe("RecordClient", () => {
       assignees: ["user1"],
       revision: 10,
     };
-    beforeEach(() => {
-      recordClient.updateRecordAssignees(params);
+    beforeEach(async () => {
+      await recordClient.updateRecordAssignees(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/record/assignees.json");
@@ -1219,8 +1219,8 @@ describe("RecordClient", () => {
       id: RECORD_ID,
       revision: 10,
     };
-    beforeEach(() => {
-      recordClient.updateRecordStatus(params);
+    beforeEach(async () => {
+      await recordClient.updateRecordStatus(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/record/status.json");
@@ -1245,8 +1245,8 @@ describe("RecordClient", () => {
         },
       ],
     };
-    beforeEach(() => {
-      recordClient.updateRecordsStatus(params);
+    beforeEach(async () => {
+      await recordClient.updateRecordsStatus(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/records/status.json");
@@ -1261,7 +1261,7 @@ describe("RecordClient", () => {
 });
 
 describe("RecordClient with guestSpaceId", () => {
-  it("should pass the path to the http client", () => {
+  it("should pass the path to the http client", async () => {
     const APP_ID = 1;
     const RECORD_ID = 2;
     const GUEST_SPACE_ID = 3;
@@ -1274,7 +1274,7 @@ describe("RecordClient with guestSpaceId", () => {
       GUEST_SPACE_ID
     );
     const params = { app: APP_ID, id: RECORD_ID };
-    recordClient.getRecord(params);
+    await recordClient.getRecord(params);
     expect(mockClient.getLogs()[0].path).toBe(
       `/k/guest/${GUEST_SPACE_ID}/v1/record.json`
     );

--- a/packages/rest-api-client/src/client/__tests__/RecordClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/RecordClient.test.ts
@@ -4,6 +4,7 @@ import { MockClient } from "../../http/MockClient";
 import { KintoneAllRecordsError } from "../../KintoneAllRecordsError";
 import { KintoneRestAPIError } from "../../KintoneRestAPIError";
 import { Record } from "../types";
+import { KintoneRequestConfigBuilder } from "../../KintoneRequestConfigBuilder";
 
 describe("RecordClient", () => {
   let mockClient: MockClient;
@@ -18,7 +19,11 @@ describe("RecordClient", () => {
   };
 
   beforeEach(() => {
-    mockClient = new MockClient();
+    const requestConfigBuilder = new KintoneRequestConfigBuilder({
+      baseUrl: "https://example.cybozu.com",
+      auth: { type: "apiToken", apiToken: "foo" },
+    });
+    mockClient = new MockClient({ requestConfigBuilder });
     const bulkRequestClient = new BulkRequestClient(mockClient);
     recordClient = new RecordClient(mockClient, bulkRequestClient);
   });
@@ -1266,7 +1271,11 @@ describe("RecordClient with guestSpaceId", () => {
     const RECORD_ID = 2;
     const GUEST_SPACE_ID = 3;
 
-    const mockClient = new MockClient();
+    const requestConfigBuilder = new KintoneRequestConfigBuilder({
+      baseUrl: "https://example.cybozu.com",
+      auth: { type: "session" },
+    });
+    const mockClient = new MockClient({ requestConfigBuilder });
     const bulkRequestClient = new BulkRequestClient(mockClient);
     const recordClient = new RecordClient(
       mockClient,

--- a/packages/rest-api-client/src/http/MockClient.ts
+++ b/packages/rest-api-client/src/http/MockClient.ts
@@ -14,7 +14,7 @@ type Log = {
 };
 
 export class MockClient implements HttpClient {
-  private errorResponseHandler?: ErrorResponseHandler;
+  private errorResponseHandler: ErrorResponseHandler;
   private requestConfigBuilder: RequestConfigBuilder;
   logs: Log[];
   responses: object[];
@@ -23,7 +23,7 @@ export class MockClient implements HttpClient {
     errorResponseHandler,
     requestConfigBuilder,
   }: {
-    errorResponseHandler?: ErrorResponseHandler;
+    errorResponseHandler: ErrorResponseHandler;
     requestConfigBuilder: RequestConfigBuilder;
   }) {
     this.errorResponseHandler = errorResponseHandler;
@@ -38,7 +38,7 @@ export class MockClient implements HttpClient {
   private createResponse<T extends object>(): T {
     const response = this.responses.shift() || {};
     if (response instanceof Error) {
-      throw response;
+      this.errorResponseHandler(response);
     }
     return response as T;
   }

--- a/packages/rest-api-client/src/http/MockClient.ts
+++ b/packages/rest-api-client/src/http/MockClient.ts
@@ -1,4 +1,8 @@
-import { HttpClient } from "./HttpClientInterface";
+import {
+  HttpClient,
+  RequestConfigBuilder,
+  ErrorResponseHandler,
+} from "./HttpClientInterface";
 import FormData from "form-data";
 
 type Log = {
@@ -10,10 +14,20 @@ type Log = {
 };
 
 export class MockClient implements HttpClient {
+  private errorResponseHandler?: ErrorResponseHandler;
+  private requestConfigBuilder: RequestConfigBuilder;
   logs: Log[];
   responses: object[];
 
-  constructor() {
+  constructor({
+    errorResponseHandler,
+    requestConfigBuilder,
+  }: {
+    errorResponseHandler?: ErrorResponseHandler;
+    requestConfigBuilder: RequestConfigBuilder;
+  }) {
+    this.errorResponseHandler = errorResponseHandler;
+    this.requestConfigBuilder = requestConfigBuilder;
     this.logs = [];
     this.responses = [];
   }
@@ -29,37 +43,65 @@ export class MockClient implements HttpClient {
     return response as T;
   }
 
-  public async get<T extends object>(path: string, params: object): Promise<T> {
-    this.logs.push({ method: "get", path, params });
+  public async get<T extends object>(path: string, params: any): Promise<T> {
+    const requestConfig = await this.requestConfigBuilder.build(
+      "get",
+      path,
+      params
+    );
+    this.logs.push({ method: requestConfig.method, path, params });
     return this.createResponse<T>();
   }
-  public async getData(path: string, params: object): Promise<ArrayBuffer> {
-    this.logs.push({ method: "get", path, params });
+  public async getData(path: string, params: any): Promise<ArrayBuffer> {
+    const requestConfig = await this.requestConfigBuilder.build(
+      "get",
+      path,
+      params
+    );
+    this.logs.push({ method: requestConfig.method, path, params });
     return this.createResponse<ArrayBuffer>();
   }
-  public async post<T extends object>(
-    path: string,
-    params: object
-  ): Promise<T> {
-    this.logs.push({ method: "post", path, params });
+  public async post<T extends object>(path: string, params: any): Promise<T> {
+    const requestConfig = await this.requestConfigBuilder.build(
+      "post",
+      path,
+      params
+    );
+    this.logs.push({ method: requestConfig.method, path, params });
     return this.createResponse<T>();
   }
   public async postData<T extends object>(
     path: string,
     formData: FormData
   ): Promise<T> {
-    this.logs.push({ method: "post", path, params: { formData } });
+    const requestConfig = await this.requestConfigBuilder.build(
+      "post",
+      path,
+      formData
+    );
+    this.logs.push({
+      method: requestConfig.method,
+      path,
+      params: { formData },
+    });
     return this.createResponse<T>();
   }
-  public async put<T extends object>(path: string, params: object): Promise<T> {
-    this.logs.push({ method: "put", path, params });
+  public async put<T extends object>(path: string, params: any): Promise<T> {
+    const requestConfig = await this.requestConfigBuilder.build(
+      "put",
+      path,
+      params
+    );
+    this.logs.push({ method: requestConfig.method, path, params });
     return this.createResponse<T>();
   }
-  public async delete<T extends object>(
-    path: string,
-    params: object
-  ): Promise<T> {
-    this.logs.push({ method: "delete", path, params });
+  public async delete<T extends object>(path: string, params: any): Promise<T> {
+    const requestConfig = await this.requestConfigBuilder.build(
+      "delete",
+      path,
+      params
+    );
+    this.logs.push({ method: requestConfig.method, path, params });
     return this.createResponse<T>();
   }
   public getLogs(): Log[] {


### PR DESCRIPTION
## Why
`MockClient` has not used `KintoneRequestConfigBuilder` like as `AxiosClient`.

## What
- Change the interface of `MockClient` like as `AxiosClient`, and fix tests.

## How to test
`yarn test` and `yarn lint`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.