### PR TITLE
fix: need to wait response to delete cursor in `getAllRecordsWithCursor`

### DIFF
--- a/packages/rest-api-client/src/client/RecordClient.ts
+++ b/packages/rest-api-client/src/client/RecordClient.ts
@@ -315,7 +315,7 @@ export class RecordClient {
     try {
       return await this.getAllRecordsRecursiveByCursor<T>(id, []);
     } catch (error) {
-      this.deleteCursor({ id });
+      await this.deleteCursor({ id });
       throw error;
     }
   }


### PR DESCRIPTION
## Why
In`RecordClient#getAllRecordsWithCursor()`, occurring an error  will not guarantee to delete the cursor.
If a process is killed unintentionally, the cursor has remained until the expiration.

## What
Change to throw exception after wait to delete the cursor if exception is throws in `RecordClient#getAllRecordsWithCursor()`.

## How to test
`yarn test` and `yarn lint`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
