### PR TITLE
refactor: add buildBaseUrl as a platform deps

### DIFF
--- a/packages/rest-api-client/src/KintoneRestAPIClient.ts
+++ b/packages/rest-api-client/src/KintoneRestAPIClient.ts
@@ -89,19 +89,6 @@ export const errorResponseHandler = (
   throw new KintoneRestAPIError({ data, ...rest });
 };
 
-// asserts syntax fails with arrow functions.
-// see https://github.com/microsoft/TypeScript/issues/33602
-type AssertsOptions = (
-  options: Options
-) => asserts options is Options & {
-  baseUrl: string;
-};
-const assertsOptions: AssertsOptions = (options) => {
-  if (typeof options.baseUrl !== "string") {
-    throw new Error("in Node.js environment, baseUrl is required");
-  }
-};
-
 const buildDiscriminatedAuth = (auth: Auth): DiscriminatedAuth => {
   if ("username" in auth) {
     return { type: "password", ...auth };
@@ -132,12 +119,12 @@ export class KintoneRestAPIClient {
   private baseUrl?: string;
 
   constructor(options: Options = {}) {
-    options.baseUrl = this.baseUrl = options.baseUrl ?? location?.origin;
-    assertsOptions(options);
+    this.baseUrl = platformDeps.buildBaseUrl(options.baseUrl);
 
     const auth = buildDiscriminatedAuth(options.auth ?? {});
     const requestConfigBuilder = new KintoneRequestConfigBuilder({
       ...options,
+      baseUrl: this.baseUrl,
       auth,
     });
     const httpClient = new DefaultHttpClient({

--- a/packages/rest-api-client/src/__tests__/KintoneRestAPIClient.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneRestAPIClient.test.ts
@@ -4,38 +4,36 @@ import {
 } from "../KintoneRestAPIClient";
 import { injectPlatformDeps } from "../platform";
 import * as browserDeps from "../platform/browser";
-import * as nodeDeps from "../platform/node";
 import { KintoneRestAPIError } from "../KintoneRestAPIError";
 import { ErrorResponse, HttpClientError } from "../http/HttpClientInterface";
 
 describe("KintoneRestAPIClient", () => {
   describe("constructor", () => {
     let originalKintone: any;
+    let originalLocation: any;
     beforeEach(() => {
       originalKintone = global.kintone;
+      originalLocation = global.location;
       global.kintone = {
         getRequestToken: () => "dummy request token",
+      };
+      global.location = {
+        origin: "https://example.com",
       };
     });
     afterEach(() => {
       global.kintone = originalKintone;
+      global.location = originalLocation;
     });
     describe("Header", () => {
       const baseUrl = "https://example.com";
-      beforeEach(() => {
-        injectPlatformDeps(browserDeps);
-      });
-
       it("should use location.origin in browser environment if baseUrl param is not specified", () => {
-        global.location = {
-          origin: "https://example.com",
-        };
+        injectPlatformDeps(browserDeps);
         const client = new KintoneRestAPIClient();
         expect(client.getBaseUrl()).toBe("https://example.com");
       });
 
       it("should raise an error in Node.js environment if baseUrl param is not specified", () => {
-        global.location = undefined;
         const USERNAME = "user";
         const PASSWORD = "password";
         const auth = {
@@ -47,7 +45,6 @@ describe("KintoneRestAPIClient", () => {
         );
       });
       it("should raise an error if trying to use session auth in Node.js environment", () => {
-        injectPlatformDeps(nodeDeps);
         expect(() => {
           new KintoneRestAPIClient({
             baseUrl,

--- a/packages/rest-api-client/src/platform/browser.ts
+++ b/packages/rest-api-client/src/platform/browser.ts
@@ -42,3 +42,8 @@ export const buildHeaders = () => {
 export const buildFormDataValue = (data: unknown) => {
   return new Blob([data]);
 };
+
+export const buildBaseUrl = (baseUrl?: string) => {
+  // We assume that location always exists in a browser environment
+  return baseUrl ?? location!.origin;
+};

--- a/packages/rest-api-client/src/platform/index.ts
+++ b/packages/rest-api-client/src/platform/index.ts
@@ -8,6 +8,7 @@ type PlatformDeps = {
   buildPlatformDependentConfig: (params: object) => object;
   buildHeaders: () => Record<string, string>;
   buildFormDataValue: (data: unknown) => unknown;
+  buildBaseUrl: (baseUrl?: string) => string;
 };
 
 export const platformDeps: PlatformDeps = {
@@ -29,6 +30,9 @@ export const platformDeps: PlatformDeps = {
   buildFormDataValue: () => {
     throw new Error("not implemented");
   },
+  buildBaseUrl: () => {
+    throw new Error("not implemented");
+  },
 };
 
 export const injectPlatformDeps = (deps: Partial<PlatformDeps>) => {
@@ -38,4 +42,5 @@ export const injectPlatformDeps = (deps: Partial<PlatformDeps>) => {
   platformDeps.buildPlatformDependentConfig = deps.buildPlatformDependentConfig!;
   platformDeps.buildHeaders = deps.buildHeaders!;
   platformDeps.buildFormDataValue = deps.buildFormDataValue!;
+  platformDeps.buildBaseUrl = deps.buildBaseUrl!;
 };

--- a/packages/rest-api-client/src/platform/node.ts
+++ b/packages/rest-api-client/src/platform/node.ts
@@ -60,3 +60,10 @@ export const buildHeaders = () => {
 export const buildFormDataValue = (data: unknown) => {
   return data;
 };
+
+export const buildBaseUrl = (baseUrl: string | undefined) => {
+  if (typeof baseUrl === "undefined") {
+    throw new Error("in Node.js environment, baseUrl is required");
+  }
+  return baseUrl;
+};


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
RestAPIClient gets a `baseUrl` from `location.origin` in a browser environment if `baseUrl` is not specified, which is a function depends on a browser environment.

## What

<!-- What is a solution you want to add? -->
I've extracted the function as a platform dependency.

## How to test

<!-- How can we test this pull request? -->

`yarn lint` && `yarn test`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
