### PR TITLE
fix: use location.{protocol, host} instead of location.origin

### DIFF
--- a/packages/rest-api-client/src/__tests__/KintoneRestAPIClient.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneRestAPIClient.test.ts
@@ -18,7 +18,8 @@ describe("KintoneRestAPIClient", () => {
         getRequestToken: () => "dummy request token",
       };
       global.location = {
-        origin: "https://example.com",
+        host: "example.com",
+        protocol: "https:",
       };
     });
     afterEach(() => {
@@ -27,7 +28,7 @@ describe("KintoneRestAPIClient", () => {
     });
     describe("Header", () => {
       const baseUrl = "https://example.com";
-      it("should use location.origin in browser environment if baseUrl param is not specified", () => {
+      it("should use a location object in browser environment if baseUrl param is not specified", () => {
         injectPlatformDeps(browserDeps);
         const client = new KintoneRestAPIClient();
         expect(client.getBaseUrl()).toBe("https://example.com");

--- a/packages/rest-api-client/src/platform/browser.ts
+++ b/packages/rest-api-client/src/platform/browser.ts
@@ -45,5 +45,6 @@ export const buildFormDataValue = (data: unknown) => {
 
 export const buildBaseUrl = (baseUrl?: string) => {
   // We assume that location always exists in a browser environment
-  return baseUrl ?? location!.origin;
+  const { host, protocol } = location!;
+  return baseUrl ?? `${protocol}//${host}`;
 };

--- a/packages/rest-api-client/types/global/index.d.ts
+++ b/packages/rest-api-client/types/global/index.d.ts
@@ -19,7 +19,8 @@ declare module NodeJS {
 
 declare const location:
   | {
-      origin: string;
+      host: string;
+      protocol: string;
     }
   | undefined;
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

IE11 doesn't provide `location.origin` in some cases.

https://stackoverflow.com/questions/32722032/how-does-ie11-populate-window-location-origin

## What

<!-- What is a solution you want to add? -->

use `location.protocol` and `location.host` instead of `location.origin`

## How to test

`yarn test` and `yarn lint`

<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
