### PR TITLE
chore: add clean npm-script

### DIFF
--- a/packages/customize-uploader/package.json
+++ b/packages/customize-uploader/package.json
@@ -10,11 +10,12 @@
     "node": ">=10"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "npm run clean && tsc",
     "lint": "run-p lint:*",
     "prerelease": "npm-run-all -p lint test -s build",
     "test": "jest --rootDir src",
     "test:ci": "jest --rootDir src --runInBand",
+    "clean": "rimraf dist",
     "start": "tsc -w",
     "lint:tsc": "tsc --noEmit",
     "lint:eslint": "eslint --ext .ts src"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
We don't want to publish the previous build assets to npm because it causes an unintentional behavior.

## What

<!-- What is a solution you want to add? -->
I've added `clean` npm-scripts into `customize-uploader` as well as `rest-api-client` does.

## How to test

<!-- How can we test this pull request? -->

`yarn build`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
