### PR TITLE
feat: add a version property into KintoneRestAPIClient

### DIFF
--- a/packages/rest-api-client/README.md
+++ b/packages/rest-api-client/README.md
@@ -71,6 +71,12 @@ client.record
   });
 ```
 
+## Global
+
+| Name    |  Type  |                    Description                     |
+| ------- | :----: | :------------------------------------------------: |
+| version | String | Provides the used version of KintoneRestAPIClient. |
+
 ## Parameters for `KintoneRestAPIClient`
 
 | Name                       |                               Type                               |          Required           | Description                                                                                                                                                                                                                                                                      |

--- a/packages/rest-api-client/src/KintoneRestAPIClient.ts
+++ b/packages/rest-api-client/src/KintoneRestAPIClient.ts
@@ -139,6 +139,10 @@ export class KintoneRestAPIClient {
     this.file = new FileClient(httpClient, guestSpaceId);
   }
 
+  public static get version() {
+    return platformDeps.getVersion();
+  }
+
   public getBaseUrl() {
     return this.baseUrl;
   }

--- a/packages/rest-api-client/src/__tests__/KintoneRestAPIClient.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneRestAPIClient.test.ts
@@ -56,6 +56,15 @@ describe("KintoneRestAPIClient", () => {
       });
     });
   });
+
+  describe("version", () => {
+    it("should provide this library version", () => {
+      expect(KintoneRestAPIClient.version).toBe(
+        require("../../package.json").version
+      );
+    });
+  });
+
   describe("errorResponseHandler", () => {
     class HttpClientErrorImpl<T> extends Error implements HttpClientError<T> {
       public response?: T;

--- a/packages/rest-api-client/src/platform/browser.ts
+++ b/packages/rest-api-client/src/platform/browser.ts
@@ -48,3 +48,7 @@ export const buildBaseUrl = (baseUrl?: string) => {
   const { host, protocol } = location!;
   return baseUrl ?? `${protocol}//${host}`;
 };
+
+export const getVersion = () => {
+  return PACKAGE_VERSION;
+};

--- a/packages/rest-api-client/src/platform/index.ts
+++ b/packages/rest-api-client/src/platform/index.ts
@@ -9,6 +9,7 @@ type PlatformDeps = {
   buildHeaders: () => Record<string, string>;
   buildFormDataValue: (data: unknown) => unknown;
   buildBaseUrl: (baseUrl?: string) => string;
+  getVersion: () => string;
 };
 
 export const platformDeps: PlatformDeps = {
@@ -33,6 +34,9 @@ export const platformDeps: PlatformDeps = {
   buildBaseUrl: () => {
     throw new Error("not implemented");
   },
+  getVersion: () => {
+    throw new Error("not implemented");
+  },
 };
 
 export const injectPlatformDeps = (deps: Partial<PlatformDeps>) => {
@@ -43,4 +47,5 @@ export const injectPlatformDeps = (deps: Partial<PlatformDeps>) => {
   platformDeps.buildHeaders = deps.buildHeaders!;
   platformDeps.buildFormDataValue = deps.buildFormDataValue!;
   platformDeps.buildBaseUrl = deps.buildBaseUrl!;
+  platformDeps.getVersion = deps.getVersion!;
 };

--- a/packages/rest-api-client/src/platform/node.ts
+++ b/packages/rest-api-client/src/platform/node.ts
@@ -67,3 +67,7 @@ export const buildBaseUrl = (baseUrl: string | undefined) => {
   }
   return baseUrl;
 };
+
+export const getVersion = () => {
+  return packageJson.version;
+};

--- a/packages/rest-api-client/types/global/index.d.ts
+++ b/packages/rest-api-client/types/global/index.d.ts
@@ -27,3 +27,5 @@ declare const location:
 declare class Blob {
   constructor(array: unknown[]);
 }
+
+declare const PACKAGE_VERSION: string;

--- a/packages/rest-api-client/webpack.config.js
+++ b/packages/rest-api-client/webpack.config.js
@@ -1,4 +1,6 @@
 const path = require("path");
+const webpack = require("webpack");
+const package = require("./package.json");
 
 module.exports = (_, argv) => ({
   entry: "./src/index.browser.ts",
@@ -26,5 +28,10 @@ module.exports = (_, argv) => ({
       },
     ],
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      PACKAGE_VERSION: JSON.stringify(package.version),
+    }),
+  ],
   devtool: argv.mode === "production" ? "" : "inline-cheap-source-map",
 });


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

I want to get the version of RestAPIClient even when use UMD builds.

This PR is based on #272 

## What

Add a version property as a static property.

```javascript
KintoneRestAPIClient.version
// "1.4.2"
```

## How to test

`yarn lint` && `yarn test`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
