### PR TITLE
style: apply prettier to `@kintone/rest-api-client`

### DIFF
--- a/packages/rest-api-client/babel.config.js
+++ b/packages/rest-api-client/babel.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   presets: [
     ["@babel/preset-env", { targets: { node: "current" } }],
-    "@babel/preset-typescript"
-  ]
+    "@babel/preset-typescript",
+  ],
 };

--- a/packages/rest-api-client/webpack.config.js
+++ b/packages/rest-api-client/webpack.config.js
@@ -9,10 +9,10 @@ module.exports = (_, argv) => ({
     library: "KintoneRestAPIClient",
     filename: `KintoneRestAPIClient${
       argv.mode === "production" ? ".min" : ""
-    }.js`
+    }.js`,
   },
   resolve: {
-    extensions: [".ts", ".js"]
+    extensions: [".ts", ".js"],
   },
   module: {
     rules: [
@@ -21,10 +21,10 @@ module.exports = (_, argv) => ({
         loader: "ts-loader",
         options: {
           configFile: "tsconfig.json",
-          transpileOnly: true
-        }
-      }
-    ]
+          transpileOnly: true,
+        },
+      },
+    ],
   },
-  devtool: argv.mode === "production" ? "" : "inline-cheap-source-map"
+  devtool: argv.mode === "production" ? "" : "inline-cheap-source-map",
 });


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

In Prettier v2.0, default value of `trailingComma` became `true`.
ref. https://prettier.io/blog/2020/03/21/2.0.0.html

## What

Apply Prettier to  javascript files about configuration in `@kintone/rest-api-client`.


## How to test

`yarn lint` && `yarn test`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
