### PR TITLE
fix: fix a order to check kintone/garoon object

### DIFF
--- a/packages/rest-api-client/src/platform/__tests__/browser.test.ts
+++ b/packages/rest-api-client/src/platform/__tests__/browser.test.ts
@@ -1,0 +1,37 @@
+import { getRequestToken } from "../browser";
+
+describe("getRequestToken()", () => {
+  let originalKintone: any;
+  let originalGaroon: any;
+  beforeEach(() => {
+    originalGaroon = global.garoon;
+    originalKintone = global.kintone;
+  });
+  afterEach(() => {
+    global.garoon = originalGaroon;
+    global.kintone = originalKintone;
+  });
+  it("should get a request token in kintone", async () => {
+    global.kintone = {
+      getRequestToken: () => "dummy request token from kintone",
+    };
+    const requestToken = await getRequestToken();
+    expect(requestToken).toBe("dummy request token from kintone");
+  });
+  it("should get a request token in garoon", async () => {
+    global.garoon = {
+      connect: {
+        kintone: {
+          getRequestToken: async () => "dummy request token from garoon",
+        },
+      },
+    };
+    const requestToken = await getRequestToken();
+    expect(requestToken).toBe("dummy request token from garoon");
+  });
+  it("should throw an error in other service", async () => {
+    await expect(getRequestToken()).rejects.toThrow(
+      "session authentication must specify a request token"
+    );
+  });
+});

--- a/packages/rest-api-client/src/platform/__tests__/browser.test.ts
+++ b/packages/rest-api-client/src/platform/__tests__/browser.test.ts
@@ -12,22 +12,24 @@ describe("getRequestToken()", () => {
     global.kintone = originalKintone;
   });
   it("should get a request token in kintone", async () => {
+    const TOKEN = "dummy request token from kintone";
     global.kintone = {
-      getRequestToken: () => "dummy request token from kintone",
+      getRequestToken: () => TOKEN,
     };
     const requestToken = await getRequestToken();
-    expect(requestToken).toBe("dummy request token from kintone");
+    expect(requestToken).toBe(TOKEN);
   });
   it("should get a request token in garoon", async () => {
+    const TOKEN = "dummy request token from garoon";
     global.garoon = {
       connect: {
         kintone: {
-          getRequestToken: async () => "dummy request token from garoon",
+          getRequestToken: async () => TOKEN,
         },
       },
     };
     const requestToken = await getRequestToken();
-    expect(requestToken).toBe("dummy request token from garoon");
+    expect(requestToken).toBe(TOKEN);
   });
   it("should throw an error in other service", async () => {
     await expect(getRequestToken()).rejects.toThrow(

--- a/packages/rest-api-client/src/platform/browser.ts
+++ b/packages/rest-api-client/src/platform/browser.ts
@@ -7,16 +7,16 @@ export const readFileFromPath = (filePath: string) => {
 
 export const getRequestToken = async () => {
   if (
-    kintone !== null &&
     typeof kintone === "object" &&
+    kintone !== null &&
     typeof kintone.getRequestToken === "function"
   ) {
     return kintone.getRequestToken();
   }
 
   if (
-    garoon !== null &&
     typeof garoon === "object" &&
+    garoon !== null &&
     typeof garoon.connect?.kintone?.getRequestToken === "function"
   ) {
     return garoon.connect.kintone.getRequestToken();

--- a/packages/rest-api-client/types/global/index.d.ts
+++ b/packages/rest-api-client/types/global/index.d.ts
@@ -13,6 +13,7 @@ declare const garoon: {
 declare module NodeJS {
   interface Global {
     kintone: typeof kintone;
+    garoon: typeof garoon;
     location: typeof location;
   }
 }


### PR DESCRIPTION
## Why

An error occurred while attempting to request except `GET` in a Garoon environment.
`kintone` object does not exist in a Garoon environment, so throws `ReferenceError`.

## What

The first thing, check a type of `kintone` (and `garoon`)  whether its type is `object`.

## How to test

`yarn run lint` && `yarn test`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
