### PR TITLE
chore: fix not to run duplicate GitHub Actions for a PR from kintone/…

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,10 @@
 
 name: lint
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,10 @@
 
 name: test
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
When we create a PR from this repository, not forked repository, The same GitHub Actions are run for the `push` and `pull` events.

## What

<!-- What is a solution you want to add? -->

I've fixed to run GitHub Actions with the `push` event for the `master` branch.

## How to test

<!-- How can we test this pull request? -->

See the result of GitHub Actions.

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `yarn lint` and `yarn test` on the root directory.
