### PR TITLE
refactor: attach type of Layout to method argument

### DIFF
--- a/packages/rest-api-client/src/client/AppClient.ts
+++ b/packages/rest-api-client/src/client/AppClient.ts
@@ -92,7 +92,7 @@ export class AppClient {
 
   public updateFormLayout(params: {
     app: AppID;
-    layout: object[];
+    layout: Layout;
     revision?: Revision;
   }): Promise<{ revision: string }> {
     const path = this.buildPathWithGuestSpaceId({

--- a/packages/rest-api-client/src/client/AppClient.ts
+++ b/packages/rest-api-client/src/client/AppClient.ts
@@ -22,7 +22,6 @@ import {
 
 type RowLayoutForParameter = {
   type: "ROW";
-  code?: string;
   fields: Array<{ [key: string]: unknown }>;
 };
 type SubtableLayoutForParameter = {

--- a/packages/rest-api-client/src/client/AppClient.ts
+++ b/packages/rest-api-client/src/client/AppClient.ts
@@ -23,21 +23,20 @@ import {
 type RowLayoutForParameter = {
   type: "ROW";
   code?: string;
-  fields: object[];
+  fields: Array<{ [key: string]: unknown }>;
 };
-
+type SubtableLayoutForParameter = {
+  type: "SUBTABLE";
+  code: string;
+  fields: Array<{ [key: string]: unknown }>;
+};
+type GroupLayoutForParameter = {
+  type: "GROUP";
+  code: string;
+  layout: RowLayoutForParameter[];
+};
 type LayoutForParameter = Array<
-  | RowLayoutForParameter
-  | {
-      type: "SUBTABLE";
-      code: string;
-      fields: object[];
-    }
-  | {
-      type: "GROUP";
-      code: string;
-      layout: RowLayoutForParameter[];
-    }
+  RowLayoutForParameter | SubtableLayoutForParameter | GroupLayoutForParameter
 >;
 
 export class AppClient {

--- a/packages/rest-api-client/src/client/AppClient.ts
+++ b/packages/rest-api-client/src/client/AppClient.ts
@@ -20,6 +20,26 @@ import {
   AppCustomize,
 } from "./types";
 
+type RowLayoutForParameter = {
+  type: "ROW";
+  code?: string;
+  fields: object[];
+};
+
+type LayoutForParameter = Array<
+  | RowLayoutForParameter
+  | {
+      type: "SUBTABLE";
+      code: string;
+      fields: object[];
+    }
+  | {
+      type: "GROUP";
+      code: string;
+      layout: RowLayoutForParameter[];
+    }
+>;
+
 export class AppClient {
   private client: HttpClient;
   private guestSpaceId?: number | string;
@@ -92,7 +112,7 @@ export class AppClient {
 
   public updateFormLayout(params: {
     app: AppID;
-    layout: Layout;
+    layout: LayoutForParameter;
     revision?: Revision;
   }): Promise<{ revision: string }> {
     const path = this.buildPathWithGuestSpaceId({

--- a/packages/rest-api-client/src/client/__tests__/AppClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/AppClient.test.ts
@@ -18,21 +18,21 @@ describe("AppClient", () => {
 
   const layout = [
     {
-      type: "ROW",
+      type: "ROW" as const,
       fields: [
         {
-          type: "SINGLE_LINE_TEXT",
+          type: "SINGLE_LINE_TEXT" as const,
           code: "fieldCode1",
           size: { width: "100" },
         },
       ],
     },
     {
-      type: "SUBTABLE",
+      type: "SUBTABLE" as const,
       code: "tableFieldCode",
       fields: [
         {
-          type: "MULTI_LINE_TEXT",
+          type: "MULTI_LINE_TEXT" as const,
           code: "fieldCode2",
           size: { width: "150", innerHeight: "200" },
         },

--- a/packages/rest-api-client/src/client/__tests__/AppClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/AppClient.test.ts
@@ -21,9 +21,19 @@ describe("AppClient", () => {
       type: "ROW" as const,
       fields: [
         {
-          type: "SINGLE_LINE_TEXT" as const,
+          type: "SINGLE_LINE_TEXT",
           code: "fieldCode1",
           size: { width: "100" },
+        },
+        {
+          type: "LABEL",
+          label: "label1",
+          size: { width: "100" },
+        },
+        {
+          type: "SPACER",
+          elementId: "space",
+          size: { width: "100", height: "50" },
         },
       ],
     },
@@ -32,9 +42,27 @@ describe("AppClient", () => {
       code: "tableFieldCode",
       fields: [
         {
-          type: "MULTI_LINE_TEXT" as const,
+          type: "MULTI_LINE_TEXT",
           code: "fieldCode2",
           size: { width: "150", innerHeight: "200" },
+        },
+      ],
+    },
+    {
+      type: "GROUP" as const,
+      code: "fieldCode3",
+      layout: [
+        {
+          type: "ROW" as const,
+          fields: [
+            {
+              type: "NUMBER",
+              code: "fieldCode3_1",
+              size: {
+                width: 200,
+              },
+            },
+          ],
         },
       ],
     },


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
checks type of Layout when the method argument takes `layout`.

## What

- attach `LayoutForParaemeter` type to the method's parameter.
- fix test and add layout variation.

<!-- What is a solution you want to add? -->


## How to test

`yarn test`

<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
