### PR TITLE
refactor: replace request-promise with @kitnone/rest-api-client

### DIFF
--- a/packages/customize-uploader/package.json
+++ b/packages/customize-uploader/package.json
@@ -41,18 +41,16 @@
   "devDependencies": {
     "@types/inquirer": "7.3.1",
     "@types/mkdirp": "^1.0.1",
-    "@types/request-promise": "^4.1.46",
     "@types/rimraf": "^3.0.0",
     "ts-node": "^9.0.0"
   },
   "dependencies": {
+    "@kintone/rest-api-client": "^1.5.0",
     "chokidar": "^3.4.2",
     "inquirer": "^7.3.3",
     "meow": "^7.1.1",
     "mkdirp": "^1.0.4",
     "os-locale": "^5.0.0",
-    "request": "^2.88.2",
-    "request-promise": "^4.2.6",
     "rimraf": "^3.0.2"
   }
 }

--- a/packages/customize-uploader/src/KintoneApiClient.ts
+++ b/packages/customize-uploader/src/KintoneApiClient.ts
@@ -1,19 +1,5 @@
-import fs from "fs";
-import request from "request-promise";
+import { KintoneRestAPIClient } from "@kintone/rest-api-client";
 import { isUrlString, wait } from "./util";
-
-interface RequestOption {
-  method: string;
-  url: string;
-  headers: {
-    [propName: string]: any;
-  };
-  body: object | string | null;
-  formData?: object;
-  proxy?: string;
-  tunnel?: boolean;
-  resolveWithFullResponse: boolean;
-}
 
 export interface Option {
   proxy: string;
@@ -28,9 +14,7 @@ export interface RequestParams {
 }
 
 export default class KintoneApiClient {
-  private auth: string;
-  private basicAuth: string | null;
-  private kintoneUrl: string;
+  private restApiClient: KintoneRestAPIClient;
   public constructor(
     username: string,
     password: string,
@@ -39,33 +23,34 @@ export default class KintoneApiClient {
     domain: string,
     public options: Option
   ) {
-    this.auth = this.getBase64EncodedCredentials(username, password);
-    this.basicAuth =
-      basicAuthUsername && basicAuthPassword
-        ? this.getBasicAuthorization(basicAuthUsername, basicAuthPassword)
-        : null;
-    this.kintoneUrl =
+    const kintoneUrl =
       domain.indexOf("https://") > -1 ? domain : `https://${domain}`;
-  }
-
-  public uploadFile(filePath: string, contentType: string) {
-    return this.sendRequest({
-      method: "POST",
-      path: "/k/v1/file.json",
-      body: {
-        file: {
-          value: fs.createReadStream(filePath, "utf8"),
-          options: { contentType },
-        },
+    let basicAuth;
+    if (basicAuthUsername && basicAuthPassword) {
+      basicAuth = {
+        username: basicAuthUsername,
+        password: basicAuthPassword,
+      };
+    }
+    this.restApiClient = new KintoneRestAPIClient({
+      baseUrl: kintoneUrl,
+      auth: { username, password },
+      basicAuth,
+      featureFlags: {
+        enableAbortSearchError: false,
       },
-      contentType: "multipart/form-data",
     });
   }
 
-  public async prepareCustomizeFile(
-    fileOrUrl: string,
-    contentType: string
-  ): Promise<any> {
+  public uploadFile(filePath: string) {
+    return this.restApiClient.file.uploadFile({
+      file: {
+        path: filePath,
+      },
+    });
+  }
+
+  public async prepareCustomizeFile(fileOrUrl: string): Promise<any> {
     const isUrl = isUrlString(fileOrUrl);
     if (isUrl) {
       return {
@@ -73,7 +58,7 @@ export default class KintoneApiClient {
         url: fileOrUrl,
       };
     }
-    const { fileKey } = await this.uploadFile(fileOrUrl, contentType);
+    const { fileKey } = await this.uploadFile(fileOrUrl);
     return {
       type: "FILE",
       file: {
@@ -82,31 +67,23 @@ export default class KintoneApiClient {
     };
   }
 
-  public updateCustomizeSetting(setting: any) {
-    return this.sendRequest({
-      method: "PUT",
-      path: "/k/v1/preview/app/customize.json",
-      body: setting,
-    });
+  public updateCustomizeSetting(params: any) {
+    return this.restApiClient.app.updateAppCustomize(params);
   }
 
   public deploySetting(appId: string) {
-    return this.sendRequest({
-      method: "POST",
-      path: "/k/v1/preview/app/deploy.json",
-      body: { apps: [{ app: appId }] },
+    return this.restApiClient.app.deployApp({
+      apps: [{ app: appId }],
     });
   }
 
   public async waitFinishingDeploy(appId: string, callback: () => void) {
     let deployed = false;
     while (!deployed) {
-      const resp = await this.sendRequest({
-        method: "GET",
-        path: "/k/v1/preview/app/deploy.json",
-        body: { apps: [appId] },
+      const resp = await this.restApiClient.app.getDeployStatus({
+        apps: [appId],
       });
-      const successedApps: [any] = resp.apps;
+      const successedApps = resp.apps;
       const successedAppsLength = successedApps.filter((r) => {
         return r.status === "SUCCESS";
       }).length;
@@ -119,83 +96,16 @@ export default class KintoneApiClient {
     deployed = true;
   }
 
-  public async downloadFile(fileKey: string) {
-    return this.sendRequest({
-      method: "GET",
-      path: "/k/v1/file.json",
-      body: { fileKey },
+  public downloadFile(fileKey: string) {
+    return this.restApiClient.file.downloadFile({
+      fileKey,
     });
   }
 
   public async getAppCustomize(appId: string) {
-    return this.sendRequest({
-      method: "GET",
-      path: "/k/v1/app/customize.json",
-      body: { app: appId },
+    return this.restApiClient.app.getAppCustomize({
+      app: appId,
     });
-  }
-
-  public async sendRequest(params: RequestParams) {
-    const requestOptions = this.buildRequestOptions(params);
-    try {
-      return request(requestOptions).then((response) => {
-        if (response.statusCode !== 200) {
-          throw new Error(
-            `Failed to Request(StatusCode:${response.statusCode}`
-          );
-        }
-        const contentType = response.headers["content-type"];
-        if (contentType && contentType.startsWith("application/json")) {
-          return JSON.parse(response.body);
-        }
-        return response.body;
-      });
-    } catch (e) {
-      if (e.statusCode === 520) {
-        const responseBody = JSON.parse(e.response.body);
-        // We assume that CB_WA01 is an authentication error
-        if (responseBody.code === "CB_WA01") {
-          throw new AuthenticationError(responseBody.message);
-        }
-      }
-      throw new Error("Unexpected Error:" + e.toString());
-    }
-  }
-
-  private buildRequestOptions({
-    method,
-    path,
-    body,
-    contentType,
-  }: RequestParams): RequestOption {
-    const isFormData = contentType && contentType === "multipart/form-data";
-    const requestOptions: RequestOption = Object.assign(
-      {
-        method,
-        url: this.options.guestSpaceId
-          ? this.kintoneUrl +
-            `/k/guest/${this.options.guestSpaceId}` +
-            path.slice(2)
-          : this.kintoneUrl + path,
-        headers: {
-          "X-Cybozu-Authorization": this.auth,
-          "Content-Type": contentType || "application/json",
-        },
-        resolveWithFullResponse: true,
-      },
-      isFormData
-        ? { formData: body, body: null }
-        : { body: JSON.stringify(body) }
-    );
-    if (this.basicAuth) {
-      requestOptions.headers.Authorization = this.basicAuth;
-    }
-    if (this.options.proxy) {
-      requestOptions.proxy = this.options.proxy;
-      requestOptions.tunnel = true;
-    }
-    requestOptions.resolveWithFullResponse = true;
-    return requestOptions;
   }
 
   private getBase64EncodedCredentials(

--- a/packages/customize-uploader/src/KintoneApiClient.ts
+++ b/packages/customize-uploader/src/KintoneApiClient.ts
@@ -6,12 +6,13 @@ export interface Option {
   guestSpaceId: number;
 }
 
-export interface RequestParams {
-  method: "GET" | "POST" | "PUT" | "DELETE";
-  path: string;
-  body: object;
-  contentType?: string;
-}
+export type UpdateAppCustomizeParameter = {
+  app: string | number;
+  scope?: "ALL" | "ADMIN" | "NONE" | undefined;
+  desktop?: { [key: string]: unknown };
+  mobile?: { [key: string]: unknown };
+  revision?: string | number;
+};
 
 export default class KintoneApiClient {
   private restApiClient: KintoneRestAPIClient;
@@ -67,7 +68,7 @@ export default class KintoneApiClient {
     };
   }
 
-  public updateCustomizeSetting(params: any) {
+  public updateCustomizeSetting(params: UpdateAppCustomizeParameter) {
     return this.restApiClient.app.updateAppCustomize(params);
   }
 
@@ -102,7 +103,7 @@ export default class KintoneApiClient {
     });
   }
 
-  public async getAppCustomize(appId: string) {
+  public getAppCustomize(appId: string) {
     return this.restApiClient.app.getAppCustomize({
       app: appId,
     });

--- a/packages/customize-uploader/src/commands/__tests__/MockKintoneApiClient.ts
+++ b/packages/customize-uploader/src/commands/__tests__/MockKintoneApiClient.ts
@@ -1,10 +1,32 @@
 import KintoneApiClient, {
   Option as ApiClientOption,
-  RequestParams,
+  UpdateAppCustomizeParameter,
 } from "../../KintoneApiClient";
 
+type MethodParameter = "GET" | "POST" | "PUT" | "DELETE";
+
+const ApiPath = {
+  File: "/k/v1/file.json",
+  Customize: "/k/v1/app/customize.json",
+} as const;
+
+const ApiPreviewPath = {
+  Customize: "/k/v1/preview/app/customize.json",
+  Deploy: "/k/v1/preview/app/deploy.json",
+} as const;
+
+type ApiPathValues = typeof ApiPath[keyof typeof ApiPath];
+type ApiPreviewPathValues = typeof ApiPreviewPath[keyof typeof ApiPreviewPath];
+
+type PathParameter = ApiPathValues | ApiPreviewPathValues;
+
 export default class MockKintoneApiClient extends KintoneApiClient {
-  public logs: RequestParams[];
+  public logs: Array<{
+    method: MethodParameter;
+    path: PathParameter;
+    body?: Record<string, unknown>;
+    contentType?: string;
+  }>;
   public willBeReturnResponse: any;
   constructor(
     ...args: [string, string, string, string, string, ApiClientOption]
@@ -15,14 +37,14 @@ export default class MockKintoneApiClient extends KintoneApiClient {
     const appDeployResp = {
       apps: [{ status: "SUCCESS" }],
     };
-    this.willBeReturn("/k/v1/preview/app/deploy.json", "GET", appDeployResp)
-      .willBeReturn("/k/v1/preview/app/deploy.json", "POST", appDeployResp)
-      .willBeReturn("/k/v1/preview/app/customize.json", "PUT", {});
+    this.willBeReturn(ApiPreviewPath.Deploy, "GET", appDeployResp)
+      .willBeReturn(ApiPreviewPath.Deploy, "POST", appDeployResp)
+      .willBeReturn(ApiPreviewPath.Customize, "PUT", {});
   }
 
   public willBeReturn(
-    path: string,
-    method: string,
+    path: PathParameter,
+    method: MethodParameter,
     willBeReturn: string | object
   ) {
     let byPath: any = this.willBeReturnResponse[path];
@@ -33,11 +55,64 @@ export default class MockKintoneApiClient extends KintoneApiClient {
     this.willBeReturnResponse[path] = byPath;
     return this;
   }
+  public async getAppCustomize(appId: string) {
+    return this.getByPathResponse({
+      path: ApiPath.Customize,
+      method: "GET",
+      body: {
+        app: appId,
+      },
+    });
+  }
 
-  public async sendRequest(params: RequestParams) {
+  public async deploySetting(appId: string) {
+    return this.getByPathResponse({
+      path: ApiPreviewPath.Deploy,
+      method: "POST",
+      body: { app: appId },
+    });
+  }
+
+  public async downloadFile(fileKey: string) {
+    return this.getByPathResponse({
+      path: ApiPath.File,
+      method: "GET",
+      body: {
+        fileKey,
+      },
+    });
+  }
+
+  public async waitFinishingDeploy() {
+    return this.getByPathResponse({
+      path: ApiPreviewPath.Deploy,
+      method: "GET",
+    });
+  }
+
+  public async uploadFile(filePath: string) {
+    return this.getByPathResponse({
+      path: ApiPath.File,
+      method: "POST",
+    });
+  }
+
+  public async updateCustomizeSetting(params: UpdateAppCustomizeParameter) {
+    return this.getByPathResponse({
+      path: ApiPreviewPath.Customize,
+      method: "PUT",
+      body: params,
+    });
+  }
+
+  private getByPathResponse(params: {
+    path: PathParameter;
+    method: MethodParameter;
+    body?: Record<string, unknown>;
+  }) {
     this.logs.push(params);
     const method = params.method;
-    if (method === "POST" && params.path === "/k/v1/file.json") {
+    if (method === "POST" && params.path === ApiPath.File) {
       return { fileKey: `key--${params.path}` };
     }
     const byPath = this.willBeReturnResponse[params.path];

--- a/packages/customize-uploader/src/commands/__tests__/MockKintoneApiClient.ts
+++ b/packages/customize-uploader/src/commands/__tests__/MockKintoneApiClient.ts
@@ -69,7 +69,7 @@ export default class MockKintoneApiClient extends KintoneApiClient {
     return this.getByPathResponse({
       path: ApiPreviewPath.Deploy,
       method: "POST",
-      body: { app: appId },
+      body: { apps: [{ app: appId }] },
     });
   }
 
@@ -77,16 +77,16 @@ export default class MockKintoneApiClient extends KintoneApiClient {
     return this.getByPathResponse({
       path: ApiPath.File,
       method: "GET",
-      body: {
-        fileKey,
-      },
+      body: { fileKey },
     });
   }
 
-  public async waitFinishingDeploy() {
+  public async waitFinishingDeploy(appId: string, callback: () => void) {
+    callback();
     return this.getByPathResponse({
       path: ApiPreviewPath.Deploy,
       method: "GET",
+      body: { apps: [appId] },
     });
   }
 

--- a/packages/customize-uploader/src/commands/index.ts
+++ b/packages/customize-uploader/src/commands/index.ts
@@ -57,17 +57,15 @@ export async function upload(
             { files: manifest.desktop.css, type: "text/css" },
             { files: manifest.mobile.js, type: "text/javascript" },
             { files: manifest.mobile.css, type: "text/css" },
-          ].map(({ files, type }) =>
+          ].map(({ files }) =>
             Promise.all(
               files.map((file: string) =>
-                kintoneApiClient
-                  .prepareCustomizeFile(file, type)
-                  .then((result) => {
-                    if (result.type === "FILE") {
-                      console.log(`${file} ` + m("M_Uploaded"));
-                    }
-                    return result;
-                  })
+                kintoneApiClient.prepareCustomizeFile(file).then((result) => {
+                  if (result.type === "FILE") {
+                    console.log(`${file} ` + m("M_Uploaded"));
+                  }
+                  return result;
+                })
               )
             )
           )

--- a/packages/customize-uploader/src/commands/index.ts
+++ b/packages/customize-uploader/src/commands/index.ts
@@ -53,11 +53,11 @@ export async function upload(
       try {
         const [desktopJS, desktopCSS, mobileJS, mobileCSS] = await Promise.all(
           [
-            { files: manifest.desktop.js, type: "text/javascript" },
-            { files: manifest.desktop.css, type: "text/css" },
-            { files: manifest.mobile.js, type: "text/javascript" },
-            { files: manifest.mobile.css, type: "text/css" },
-          ].map(({ files }) =>
+            manifest.desktop.js,
+            manifest.desktop.css,
+            manifest.mobile.js,
+            manifest.mobile.css,
+          ].map((files) =>
             Promise.all(
               files.map((file: string) =>
                 kintoneApiClient.prepareCustomizeFile(file).then((result) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2219,20 +2219,10 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/bluebird@*":
-  version "3.5.32"
-  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.32.tgz#381e7b59e39f010d20bbf7e044e48f5caf1ab620"
-  integrity sha512-dIOxFfI0C+jz89g6lQ+TqhGgPQ0MxSnh/E4xuC0blhFtyW269+mPG5QeLgbdwst/LvdP8o1y0o/Gz5EHXLec/g==
-
 "@types/bytes@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@types/bytes/-/bytes-3.1.0.tgz#835a3e4aea3b4d7604aca216a78de372bff3ecc3"
   integrity sha512-5YG1AiIC8HPPXRvYAIa7ehK3YMAwd0DWiPCtpuL9sgKceWLyWsVtLRA+lT4NkoanDNF9slwQ66lPizWDpgRlWA==
-
-"@types/caseless@*":
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.2.tgz#f65d3d6389e01eeb458bd54dc8f52b95a9463bc8"
-  integrity sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==
 
 "@types/chokidar@^1.7.5":
   version "1.7.5"
@@ -2409,24 +2399,6 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.4.tgz#a59e851c1ba16c0513ea123830dd639a0a15cb6a"
   integrity sha512-+wYo+L6ZF6BMoEjtf8zB2esQsqdV6WsjRK/GP9WOgLPrq87PbNWgIxS76dS5uvl/QXtHGakZmwTznIfcPXcKlQ==
 
-"@types/request-promise@^4.1.46":
-  version "4.1.46"
-  resolved "https://registry.yarnpkg.com/@types/request-promise/-/request-promise-4.1.46.tgz#37df6efae984316dfbfbbe8fcda37f3ba52822f2"
-  integrity sha512-3Thpj2Va5m0ji3spaCk8YKrjkZyZc6RqUVOphA0n/Xet66AW/AiOAs5vfXhQIL5NmkaO7Jnun7Nl9NEjJ2zBaw==
-  dependencies:
-    "@types/bluebird" "*"
-    "@types/request" "*"
-
-"@types/request@*":
-  version "2.48.5"
-  resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.5.tgz#019b8536b402069f6d11bee1b2c03e7f232937a0"
-  integrity sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==
-  dependencies:
-    "@types/caseless" "*"
-    "@types/node" "*"
-    "@types/tough-cookie" "*"
-    form-data "^2.5.0"
-
 "@types/resolve@1.17.1":
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
@@ -2463,11 +2435,6 @@
   integrity sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==
   dependencies:
     "@types/node" "*"
-
-"@types/tough-cookie@*":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.0.tgz#fef1904e4668b6e5ecee60c52cc6a078ffa6697d"
-  integrity sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
 
 "@types/uglify-js@*":
   version "3.9.3"
@@ -3370,7 +3337,7 @@ bl@~0.8.1:
   dependencies:
     readable-stream "~1.0.26"
 
-bluebird@^3.5.0, bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5:
+bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -6065,15 +6032,6 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
-
-form-data@^2.5.0:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
-  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.6"
-    mime-types "^2.1.12"
 
 form-data@^3.0.0:
   version "3.0.0"
@@ -10868,16 +10826,6 @@ request-promise-native@^1.0.8:
   resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.9.tgz#e407120526a5efdc9a39b28a5679bf47b9d9dc28"
   integrity sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==
   dependencies:
-    request-promise-core "1.1.4"
-    stealthy-require "^1.1.1"
-    tough-cookie "^2.3.3"
-
-request-promise@^4.2.6:
-  version "4.2.6"
-  resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.6.tgz#7e7e5b9578630e6f598e3813c0f8eb342a27f0a2"
-  integrity sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==
-  dependencies:
-    bluebird "^3.5.0"
     request-promise-core "1.1.4"
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
[request-promise](https://github.com/request/request-promise) has already deprecated. 

## What

<!-- What is a solution you want to add? -->
It is replaced with `@kintone/rest-api-client`.

## How to test

<!-- How can we test this pull request? -->

```bash
$ cd examples/rest-api-client-demo
$ yarn deploy
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
