### PR TITLE
chore: manage `examples/*` by renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,14 @@
 {
   "extends": [
     "@cybozu"
+  ],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/__tests__/**",
+    "**/test/**",
+    "**/tests/**",
+    "**/__fixtures__/**"
   ]
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

Renovate does not manage dependencies in `examples/**` directory.
I'd like to that renovate updates packages in this directory similar to `packages/**`.

See #211

## What

This repository's configuration extends `@cybozu/renovate-config`.
`@cybozu/renovate-config` has a preset as `:ignoreModulesAndTests` (ref. https://github.com/cybozu/renovate-config/blob/master/package.json#L23).
This preset ignores `package.json` in `examples` directory (ref. https://docs.renovatebot.com/presets-default/#ignoremodulesandtests) .

So this PR is that overwrites `ignorePaths` as not to ignore `examples` directory.

## How to test
`renovate-config-validator`
Ref. https://docs.renovatebot.com/reconfigure-renovate/#reconfigure-via-pr

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
