### PR TITLE
fix: KintoneRestAPIClient.version differs between UMD files and npm

### DIFF
--- a/packages/rest-api-client/package.json
+++ b/packages/rest-api-client/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "npm-run-all -l -s clean -p build:*",
     "lint": "run-p -l lint:*",
+    "prepublish": "npm run build",
     "prerelease": "npm-run-all -p lint test -s build",
     "test": "jest",
     "test:ci": "jest --runInBand",

--- a/packages/rest-api-client/package.json
+++ b/packages/rest-api-client/package.json
@@ -17,7 +17,7 @@
     "build": "npm-run-all -l -s clean -p build:*",
     "lint": "run-p -l lint:*",
     "prepublish": "npm run build",
-    "prerelease": "npm-run-all -p lint test -s build",
+    "prerelease": "npm-run-all -p lint test -s",
     "test": "jest",
     "test:ci": "jest --runInBand",
     "build:umd_dev": "webpack --mode development",

--- a/packages/rest-api-client/package.json
+++ b/packages/rest-api-client/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "npm-run-all -l -s clean -p build:*",
     "lint": "run-p -l lint:*",
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run build",
     "prerelease": "npm-run-all -p lint test -s",
     "test": "jest",
     "test:ci": "jest --runInBand",


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
Using rest-api-client with UMD build file, KintoneRestAPIClient.version shows old version.

For example, When we use @kintone/rest-api-client@1.5.0, UMD file shows `1.4.2` running `KintoneRestAPIClient.version`.
see https://unpkg.com/@kintone/rest-api-client@1.5.0/umd/KintoneRestAPIClient.js

## What

<!-- What is a solution you want to add? -->
The reason why we make such a mistake is below.
KintoneRestAPIClient.version refers to packageJson.version. Actually, we inject the version into UMD file with webpack. https://github.com/kintone/js-sdk/blob/master/packages/rest-api-client/webpack.config.js#L33
We update version in package.json and publish the package after building UMD file with webpack.

The solution is just adding 'prepublish' command into rest-api-client/package.json.
We need to build UMD file after updating version in package.json.
Lerna has a lifecycle in 'publish' command. 
https://github.com/lerna/lerna/tree/master/commands/publish#lifecycle-scripts
We can use lifecycle-scripts for each package.

## How to test

<!-- How can we test this pull request? -->
Run 'yarn release'

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
