### PR TITLE
fix: `npm start` with the modern template

### DIFF
--- a/packages/create-plugin/templates/modern/package.json.tmpl
+++ b/packages/create-plugin/templates/modern/package.json.tmpl
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     <% if (enablePluginUploader) { %>
+    "prestart": "npm run build",
     "start": "node scripts/npm-start.js",
     "upload": "kintone-plugin-uploader dist/plugin.zip --watch --waiting-dialog-ms 3000",
     <% } else { %>


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

We've released a new template called `modern` in the `create-plugin` package. 
But the `npm start` isn't succeed at the first time. The reason is that running `uploader` at the first time doesn't have target files created by `webpack` because the script run `webpack` and `uploader` parallel.

## What

<!-- What is a solution you want to add? -->
I've added `prebuild` script to run `webpack` before `npm start`.

## How to test

<!-- How can we test this pull request? -->
```
% yarn build
% yarn create-plugin --template modern ~/target/dir
% cd ~/target/dir
% npm start
:
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
