### PR TITLE
feat: support Node.js native ESM for rest-api-client

### DIFF
--- a/packages/rest-api-client/package.json
+++ b/packages/rest-api-client/package.json
@@ -22,6 +22,7 @@
     "test:ci": "jest --runInBand",
     "build:umd_dev": "rollup -c --environment BUILD:development",
     "build:umd_prod": "rollup -c --environment BUILD:production",
+    "build:mjs": "rollup --config rollup.config.esm.js",
     "build:compile": "run-p compile",
     "clean": "rimraf lib esm umd",
     "compile": "run-p -l compile:*",
@@ -78,5 +79,11 @@
     "form-data": "^3.0.0",
     "js-base64": "^2.6.4",
     "qs": "^6.9.4"
+  },
+  "exports": {
+    ".": {
+      "import": "./esm/index.mjs",
+      "require": "./lib/index.js"
+    }
   }
 }

--- a/packages/rest-api-client/rollup.config.esm.js
+++ b/packages/rest-api-client/rollup.config.esm.js
@@ -8,7 +8,7 @@ import builtinModules from "builtin-modules";
 const extensions = [".ts", ".js"];
 
 export default {
-  input: "./src/index.esm.mjs",
+  input: "./src/index.esm.ts",
   output: {
     file: "./esm/index.mjs",
     format: "esm",

--- a/packages/rest-api-client/rollup.config.esm.js
+++ b/packages/rest-api-client/rollup.config.esm.js
@@ -1,0 +1,41 @@
+import resolve from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
+import json from "@rollup/plugin-json";
+import pkgJson from "./package.json";
+import babel from "@rollup/plugin-babel";
+import builtinModules from "builtin-modules";
+
+const extensions = [".ts", ".js"];
+
+export default {
+  input: "./src/index.esm.mjs",
+  output: {
+    file: "./esm/index.mjs",
+    format: "esm",
+  },
+  plugins: [
+    babel({
+      babelHelpers: "bundled",
+      presets: [
+        [
+          "@babel/preset-env",
+          {
+            targets: {
+              // The reason why we use `browsers` property is https://github.com/babel/babel/issues/10182#issuecomment-509561834
+              browsers: [`node ${pkgJson.engines.node}`],
+            },
+          },
+        ],
+        "@babel/preset-typescript",
+      ],
+      extensions,
+      include: ["src/**/*"],
+    }),
+    resolve({
+      preferBuiltins: false,
+    }),
+    commonjs({ extensions }),
+    json(),
+  ],
+  external: builtinModules,
+};

--- a/packages/rest-api-client/src/__tests__/setup.ts
+++ b/packages/rest-api-client/src/__tests__/setup.ts
@@ -1,6 +1,8 @@
 import { injectPlatformDeps } from "../platform/";
 import * as nodeDeps from "../platform/node";
+import { injectPackageJson } from "../platform/packageJson";
 
 beforeEach(() => {
+  injectPackageJson(require("../../package.json"));
   injectPlatformDeps(nodeDeps);
 });

--- a/packages/rest-api-client/src/index.esm.mjs
+++ b/packages/rest-api-client/src/index.esm.mjs
@@ -1,0 +1,11 @@
+import { injectPlatformDeps } from "./platform";
+import * as nodeDeps from "./platform/node";
+import { injectPackageJson } from "./platform/packageJson";
+import module from "module";
+// eslint-disable-next-line node/no-unsupported-features/node-builtins
+const _require = module.createRequire(import.meta.url);
+
+injectPackageJson(_require("../package.json"));
+injectPlatformDeps(nodeDeps);
+
+export { KintoneRestAPIClient } from "./KintoneRestAPIClient";

--- a/packages/rest-api-client/src/index.esm.ts
+++ b/packages/rest-api-client/src/index.esm.ts
@@ -2,6 +2,7 @@ import { injectPlatformDeps } from "./platform";
 import * as nodeDeps from "./platform/node";
 import { injectPackageJson } from "./platform/packageJson";
 import module from "module";
+// @ts-expect-error to avoid `The 'import.meta' meta-property is only allowed when the '--module' option is 'esnext' or 'system'.`
 // eslint-disable-next-line node/no-unsupported-features/node-builtins
 const _require = module.createRequire(import.meta.url);
 

--- a/packages/rest-api-client/src/index.ts
+++ b/packages/rest-api-client/src/index.ts
@@ -1,6 +1,8 @@
 import { injectPlatformDeps } from "./platform/";
 import * as nodeDeps from "./platform/node";
+import { injectPackageJson } from "./platform/packageJson";
 
+injectPackageJson(require("../package.json"));
 injectPlatformDeps(nodeDeps);
 
 export { KintoneRestAPIClient } from "./KintoneRestAPIClient";

--- a/packages/rest-api-client/src/platform/node.ts
+++ b/packages/rest-api-client/src/platform/node.ts
@@ -4,7 +4,7 @@ import { basename } from "path";
 import { UnsupportedPlatformError } from "./UnsupportedPlatformError";
 import https from "https";
 import os from "os";
-const packageJson = require("../../package.json");
+import { packageJson } from "./packageJson";
 
 const readFile = promisify(fs.readFile);
 
@@ -69,5 +69,5 @@ export const buildBaseUrl = (baseUrl: string | undefined) => {
 };
 
 export const getVersion = () => {
-  return packageJson.version;
+  return packageJson.version as string;
 };

--- a/packages/rest-api-client/src/platform/packageJson.ts
+++ b/packages/rest-api-client/src/platform/packageJson.ts
@@ -1,0 +1,6 @@
+export let packageJson: Record<string, unknown>;
+
+export const injectPackageJson = (param: typeof packageJson) => {
+  packageJson = param;
+  return packageJson;
+};


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
Node.js has already supported ES Modules.
see https://nodejs.org/api/esm.html

However, Node.js ESM is still experimental.

We can import `@kintone/rest-api-client` in a ESM file now.
But we cannot use named import because the package provides only CJS file. So, we have to write code like the below.

```js
import mod from "@kintone/rest-api-client";
const { KintoneRestAPIClient } = mod;
```

I think it is more useful to use named import like below.

```js
import { KintoneRestAPIClient } from "@kintone/rest-api-client";
```

## What

<!-- What is a solution you want to add? -->
- [Conditional Exports](https://nodejs.org/api/esm.html#esm_conditional_exports) is used to provide ESM file. I add "exports" field into package.json.
- Bundle files to resolve import path. All import paths in TypeScript source files don't have extensions. ESM needs file extensions in import paths.
- `require` cannot be used in ESM file. I added packageJson.ts to be available to inject package.json object from outside. So we can inject package.json object from ESM/CJS entry files.

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
