### PR TITLE
fix: add Element type definition to avoid an error of @types/puppeteer

### DIFF
--- a/packages/create-plugin/tsconfig.json
+++ b/packages/create-plugin/tsconfig.json
@@ -5,7 +5,12 @@
     "target": "es2015",
     "lib": ["es2015"],
     "outDir": "dist",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "typeRoots": [
+      "node_modules/@types",
+      "../../node_modules/@types",
+      "types"
+    ], 
   },
   "indlude": ["src/**/*.ts"],
   "exclude": ["templates/**/*.ts"]

--- a/packages/create-plugin/types/global/index.d.ts
+++ b/packages/create-plugin/types/global/index.d.ts
@@ -1,0 +1,2 @@
+// see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24419
+declare interface Element {}

--- a/packages/rest-api-client/types/global/index.d.ts
+++ b/packages/rest-api-client/types/global/index.d.ts
@@ -30,3 +30,6 @@ declare class Blob {
 }
 
 declare const PACKAGE_VERSION: string;
+
+// see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24419
+declare interface Element {}

--- a/packages/webpack-plugin-kintone-plugin/tsconfig.json
+++ b/packages/webpack-plugin-kintone-plugin/tsconfig.json
@@ -6,7 +6,12 @@
     "strict": true,
     "target": "es5",
     "outDir": "dist",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "typeRoots": [
+      "node_modules/@types",
+      "../../node_modules/@types",
+      "types"
+    ], 
   },
   "indlude": ["src/**/*.ts"]
 }

--- a/packages/webpack-plugin-kintone-plugin/types/global/index.d.ts
+++ b/packages/webpack-plugin-kintone-plugin/types/global/index.d.ts
@@ -1,0 +1,2 @@
+// see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24419
+declare interface Element {}


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

To avoid an error of @types/puppeteer. https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24419
Errors occur in https://github.com/kintone/js-sdk/pull/401.

## What

<!-- What is a solution you want to add? -->
Element type definition is added.

## How to test

<!-- How can we test this pull request? -->
`yarn lint` & `yarn test`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `yarn lint` and `yarn test` on the root directory.
