### PR TITLE
chore: add skipLibCheck into some tsconfig.json

### DIFF
--- a/packages/create-plugin/tsconfig.json
+++ b/packages/create-plugin/tsconfig.json
@@ -5,7 +5,8 @@
     "target": "es2015",
     "lib": ["es2015"],
     "outDir": "dist",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "indlude": ["src/**/*.ts"],
   "exclude": ["templates/**/*.ts"]

--- a/packages/rest-api-client/tsconfig.json
+++ b/packages/rest-api-client/tsconfig.json
@@ -50,7 +50,7 @@
     ],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
 
@@ -63,6 +63,7 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    "skipLibCheck": true
   },
   "include": ["src/"]
 }

--- a/packages/webpack-plugin-kintone-plugin/tsconfig.json
+++ b/packages/webpack-plugin-kintone-plugin/tsconfig.json
@@ -6,7 +6,8 @@
     "strict": true,
     "target": "es5",
     "outDir": "dist",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "indlude": ["src/**/*.ts"]
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

# ⚠️ If #402 is merged, this should be closed.

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

To avoid an error of @types/puppeteer. https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24419
Errors occur in https://github.com/kintone/js-sdk/pull/401.

## What

<!-- What is a solution you want to add? -->
`skipLibCheck` compiler option is added into tsconfig.json.
https://www.typescriptlang.org/docs/handbook/compiler-options.html#compiler-options

## How to test

`yarn lint` & `yarn test`

<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `yarn lint` and `yarn test` on the root directory.
