### PR TITLE
chore: run the build script for packages depend on rest-api-client

### DIFF
--- a/packages/rest-api-client/package.json
+++ b/packages/rest-api-client/package.json
@@ -17,7 +17,7 @@
     "build": "npm-run-all -l -s clean -p build:*",
     "lint": "run-p -l lint:*",
     "prepublishOnly": "npm run build",
-    "prerelease": "npm-run-all -p lint test -s",
+    "prerelease": "npm-run-all -p lint test -s build",
     "test": "jest",
     "test:ci": "jest --runInBand",
     "build:umd_dev": "rollup -c --environment BUILD:development",


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
We run the `build` script at `prepublishOnly`, but we also have to run the script at `prelease` for pacakges depend on `rest-api-client` in js-sdk.
Otherwise, we cannot guarantee using the latest build of `rest-api-client` with these packages.

## What

I've added the `build` script at prerelease stage.
<!-- What is a solution you want to add? -->

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `yarn lint` and `yarn test` on the root directory.
