### PR TITLE
feat: support Node.js native ESM for rest-api-client

### DIFF
--- a/packages/rest-api-client/index.mjs
+++ b/packages/rest-api-client/index.mjs
@@ -1,0 +1,5 @@
+import module from "module";
+// eslint-disable-next-line node/no-unsupported-features/node-builtins
+const require = module.createRequire(import.meta.url);
+
+export const { KintoneRestAPIClient } = require(".");

--- a/packages/rest-api-client/package.json
+++ b/packages/rest-api-client/package.json
@@ -43,7 +43,8 @@
   "files": [
     "esm",
     "lib",
-    "umd"
+    "umd",
+    "index.mjs"
   ],
   "keywords": [
     "kintone",
@@ -78,5 +79,10 @@
     "form-data": "^3.0.0",
     "js-base64": "^3.4.5",
     "qs": "^6.9.4"
+  },
+  "exports": {
+    "import": "./index.mjs",
+    "require": "./lib/index.js",
+    "default": "./lib/index.js"
   }
 }

--- a/packages/rest-api-client/package.json
+++ b/packages/rest-api-client/package.json
@@ -81,8 +81,11 @@
     "qs": "^6.9.4"
   },
   "exports": {
-    "import": "./index.mjs",
-    "require": "./lib/index.js",
-    "default": "./lib/index.js"
+    "node": {
+      "import": "./index.mjs",
+      "require": "./lib/index.js",
+      "default": "./lib/index.js"
+    },
+    "browser": "./lib/index.browser.js"
   }
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
The alternative to #387

## What

<!-- What is a solution you want to add? -->
Simple ESM file `index.mjs` is added. And `"exports"` field is added into package.json to support Dual Package (ESM/CJS)

## How to test

<!-- How can we test this pull request? -->

Create the ESM file and run it, please.

```js
import { KintoneRestAPIClient } from "@kintone/rest-api-client";

console.log(KintoneRestAPIClient.version);
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
