### PR TITLE
fix(deps): revert js-base64 to v2

### DIFF
--- a/packages/rest-api-client/package.json
+++ b/packages/rest-api-client/package.json
@@ -64,7 +64,7 @@
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@types/core-js": "^2.5.4",
-    "@types/js-base64": "^3.0.0",
+    "@types/js-base64": "^2.3.2",
     "@types/qs": "^6.9.5",
     "rollup": "^2.28.1",
     "rollup-plugin-node-builtins": "^2.1.2",
@@ -76,7 +76,7 @@
     "axios": "^0.19.2",
     "core-js": "^3.6.5",
     "form-data": "^3.0.0",
-    "js-base64": "^3.4.5",
+    "js-base64": "^2.6.4",
     "qs": "^6.9.4"
   }
 }

--- a/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
@@ -3,7 +3,6 @@ import FormData from "form-data";
 import { injectPlatformDeps } from "../platform";
 import * as browserDeps from "../platform/browser";
 import os from "os";
-import * as Base64 from "js-base64";
 
 const packageJson = require("../../package.json");
 const nodeVersion = process.version;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2320,10 +2320,10 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
-"@types/js-base64@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/js-base64/-/js-base64-3.0.0.tgz#b7b4c130facefefd5c57ba82664c41e2995f91be"
-  integrity sha512-BnEyOcDE4H6bkg8m84xhdbkYoAoCg8sYERmAvE4Ff50U8jTfbmOinRdJpauBn1P9XsCCQgCLuSiyz3PM4WHYOA==
+"@types/js-base64@^2.3.2":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@types/js-base64/-/js-base64-2.3.2.tgz#266be882b28b52649b1d34db9515e54c8ef783f2"
+  integrity sha512-iGjZEnheu9n53fhlU+QLovdKHsdwPJ79iammNM0opTEp18zcJ/nNAIthuMilJoDPNUQHoqRAJdDNI5rxHY4nkA==
 
 "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4":
   version "7.0.5"
@@ -7900,10 +7900,10 @@ jest@^26.4.2:
     import-local "^3.0.2"
     jest-cli "^26.4.2"
 
-js-base64@^3.4.5:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.4.5.tgz#6d1921e65a172cfd924604e1416dfaff45752c3e"
-  integrity sha512-Ub/AANierdcT8nm4ndBn3KzpZQ3MdHX4a+bwoVdjgeHCZ0ZEcP+UB4nmR4Z5lR6SH3Y+qAPmgVR0RxKJNHNHEg==
+js-base64@^2.6.4:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
+  integrity sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
https://github.com/kintone/js-sdk/pull/319 upgrades js-base64 to v3. However,  js-base64 v3 doesn't support IE 11.
https://github.com/dankogai/js-base64/blob/96b271eb23441d3a48430b59b5d481db08674f5f/README.md#heads-up 

So this reverts js-base64 to v2.

## What

<!-- What is a solution you want to add? -->
revert #319 

## How to test

<!-- How can we test this pull request? -->

`yarn lint && yarn test`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
