### PR TITLE
Supporting types generated dts gen

### DIFF
--- a/packages/rest-api-client/src/client/RecordClient.ts
+++ b/packages/rest-api-client/src/client/RecordClient.ts
@@ -50,16 +50,6 @@ export class RecordClient {
     return this.client.get(path, params);
   }
 
-  public getRecord2<T>(params: {
-    app: AppID;
-    id: RecordID;
-  }): Promise<{ record: Record<T> }> {
-    const path = this.buildPathWithGuestSpaceId({
-      endpointName: "record",
-    });
-    return this.client.get(path, params);
-  }
-
   public addRecord(params: {
     app: AppID;
     record?: RecordForParameter;

--- a/packages/rest-api-client/src/client/RecordClient.ts
+++ b/packages/rest-api-client/src/client/RecordClient.ts
@@ -265,7 +265,9 @@ export class RecordClient {
     const { condition, ...rest } = params;
     const conditionQuery = condition ? `${condition} and ` : "";
     const query = `${conditionQuery}$id > ${id} order by $id asc limit ${GET_RECORDS_LIMIT}`;
-    const result = await this.getRecords<T & { $id: unknown }>({
+    const result = await this.getRecords<
+      T & { $id: { type: string; value: string } }
+    >({
       ...rest,
       query,
     });

--- a/packages/rest-api-client/src/client/types/record/index.ts
+++ b/packages/rest-api-client/src/client/types/record/index.ts
@@ -1,8 +1,12 @@
 import { Field } from "../../../KintoneFields/types/field";
 
-export type Record = {
-  [fieldCode: string]: Field;
-};
+export type Record<T = void> = T extends object
+  ? {
+      [fieldCode in Extract<keyof T, string>]: Field;
+    }
+  : {
+      [fieldCode: string]: Field;
+    };
 
 export type UpdateKey = {
   field: string;

--- a/packages/rest-api-client/src/client/types/record/index.ts
+++ b/packages/rest-api-client/src/client/types/record/index.ts
@@ -1,8 +1,8 @@
 import { Field } from "../../../KintoneFields/types/field";
 
-export type Record<T = void> = T extends object
+export type Record<T = void> = T extends { [fieldCode: string]: any }
   ? {
-      [fieldCode in Extract<keyof T, string>]: Field;
+      [fieldCode in keyof T]: T[fieldCode];
     }
   : {
       [fieldCode: string]: Field;


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

Index signature type error occurs when I using types generated by kintone-dts-gen as generics. 
![image](https://user-images.githubusercontent.com/1659899/94525094-7eaf2e00-026e-11eb-9e24-19c4a60f84d2.png)

I want to use types generated by kintone-dts-gen without casting.

## What

I've extended `Record` type to support kintone-dts-gen types as well.
Could you please check if this implementation is okay?

## How to test

Now I editing.


## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `yarn lint` and `yarn test` on the root directory.
