### PR TITLE
Fix dts-gen tsc/lint

### DIFF
--- a/packages/dts-gen/package.json
+++ b/packages/dts-gen/package.json
@@ -9,7 +9,7 @@
     "tsc:check": "tsc --noEmit",
     "clean": "rm -rfv dist",
     "lint:fix": "eslint --fix src/**/*.ts",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint src/**/*.ts",
     "demo": "node dist/index.js --demo --type-name DemoFields -o demo-fields.d.ts",
     "generate": "node dist/index.js --host https://****.cybozu.com --username *** --password *** --app-id ***",
     "help": "node dist/index.js --help",
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.14",
     "@types/lodash": "^4.14.161",
+    "eslint": "^7.11.0",
     "jest": "^26.5.2",
     "standard-version": "^9.0.0",
     "ts-loader": "^8.0.3",

--- a/packages/dts-gen/package.json
+++ b/packages/dts-gen/package.json
@@ -36,9 +36,12 @@
     "prettier": "^2.1.2"
   },
   "devDependencies": {
+    "@types/jest": "^26.0.14",
     "@types/lodash": "^4.14.161",
+    "jest": "^26.5.2",
     "standard-version": "^9.0.0",
     "ts-loader": "^8.0.3",
+    "typescript": "^4.0.3",
     "webpack": "^4.44.1",
     "webpack-cli": "^3.3.12"
   },

--- a/packages/dts-gen/src/integration-tests/dts-gen-api-test.ts
+++ b/packages/dts-gen/src/integration-tests/dts-gen-api-test.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
 
+// eslint-disable-next-line max-statements
 function assertKintoneBuiltinFunctions() {
     // assert function exists in kintone top-level
     assertFunction(kintone.getRequestToken);

--- a/packages/dts-gen/src/kintone/clients/forms-client-impl.ts
+++ b/packages/dts-gen/src/kintone/clients/forms-client-impl.ts
@@ -46,9 +46,8 @@ function constructUrl(
         return `/k/guest/${guest}/v1/app/form/fields.json`;
     } else if (input.preview) {
         return "/k/v1/preview/app/form/fields.json";
-    } else {
-        return "/k/v1/app/form/fields.json";
     }
+    return "/k/v1/app/form/fields.json";
 }
 
 export const VisibleForTesting = {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
dts-genのnpm run build、npm run tscがエラーになる
<!-- Why do you want the feature and why does it make sense for the package? -->


## What
パッケージのインストール
ESLintエラーの対応
<!-- What is a solution you want to add? -->


## How to test
`yarn lint` and `yarn test` on the root directory.
<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
