### PR TITLE
Environment variables

### DIFF
--- a/packages/dts-gen/docs/how-to-use.md
+++ b/packages/dts-gen/docs/how-to-use.md
@@ -28,6 +28,14 @@ $ kintone-dts-gen --host http://***.cybozu.com \
                  -o sample-fields.d.ts
 ```
 
+You can set the values through environment variables.
+
+host: KINTONE_DOMAIN  
+username: KINTONE_USERNAME  
+password: KINTONE_PASSWORD  
+basic-auth-username: KINTONE_BASIC_AUTH_USERNAME  
+basic-auth-password: KINTONE_BASIC_AUTH_PASSWORD
+
 kintone-dts-gen generates record field definition from kintone form settings.
 And from this command line option, record field type definition(`company.name.types.SampleFields`)
 is defined in `sample-fields.d.ts`.

--- a/packages/dts-gen/src/index.ts
+++ b/packages/dts-gen/src/index.ts
@@ -8,14 +8,28 @@ import { createCommanderProgram } from "./createCommanderProgram";
 const program = createCommanderProgram();
 program.parse(process.argv);
 
+const {
+    // HTTP_PROXY,
+    // HTTPS_PROXY,
+    KINTONE_DOMAIN,
+    KINTONE_USERNAME,
+    KINTONE_PASSWORD,
+    KINTONE_BASIC_AUTH_USERNAME,
+    KINTONE_BASIC_AUTH_PASSWORD,
+} = process.env;
+
 const newClientInput = {
-    host: program.host,
-    username: program.username,
-    password: program.password,
+    host: program.host || `https://${KINTONE_DOMAIN}`,
+    username: program.username || KINTONE_USERNAME,
+    password: program.password || KINTONE_PASSWORD,
     proxyHost: program.proxyHost,
     proxyPort: program.proxyPort,
-    basicAuthUsername: program.basicAuthUsername,
-    basicAuthPassword: program.basicAuthPassword,
+    basicAuthUsername:
+        program.basicAuthUsername ||
+        KINTONE_BASIC_AUTH_USERNAME,
+    basicAuthPassword:
+        program.basicAuthPassword ||
+        KINTONE_BASIC_AUTH_PASSWORD,
 };
 
 const client = program.demo


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
plugin-uploader, customize-uploaderと同じ様に環境変数を利用したいです
その場合上記の2つとdts-genでは利用できるプロキシーオプションが異なります
上記の2つはHTTPS_PROXY、HTTP_PROXYが定義されています
dts-genはPROXY_HOST、PROXY_PORTが定義されています

もし取り込まれる可能性があるならpackage間の違いをどうすればよいか教えてほしいです
<!-- Why do you want the feature and why does it make sense for the package? -->


## What
環境変数を参照
<!-- What is a solution you want to add? -->


## How to test
`yarn lint` and `yarn test` on the root directory.
オプションが利用できること、環境変数が利用できること、両方指定した場合はオプションが優先されることを確認
<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
