### PR TITLE
docs: update links for the documentations of dts-gen

### DIFF
--- a/packages/dts-gen/README.md
+++ b/packages/dts-gen/README.md
@@ -12,9 +12,9 @@ npm install -D @kintone/dts-gen
 ```
 
 ## Documentation
-- [How To Use](https://kintone.github.io/dts-gen/docs/#/README)
-- [Field Type Definition Guide](https://kintone.github.io/dts-gen/docs/#/field-type-definition-guide)
-- [Maintenance Guide](https://kintone.github.io/dts-gen/docs/#/maintenance-guide)
+- [How To Use](https://github.com/kintone/js-sdk/blob/master/packages/dts-gen/docs/how-to-use.md)
+- [Field Type Definition Guide](https://github.com/kintone/js-sdk/blob/master/packages/dts-gen/docs/field-type-definition-guide.md)
+- [Maintenance Guide](https://github.com/kintone/js-sdk/blob/master/packages/dts-gen/docs/maintenance-guide.md)
 
 ## License
 

--- a/packages/dts-gen/docs/maintenance-guide.md
+++ b/packages/dts-gen/docs/maintenance-guide.md
@@ -5,8 +5,8 @@
 This package is managed with `yarn`, so you have to install `yarn` to build `dts-gen`.
 
 ```
-% yarn
-% yarn build
+$ yarn
+$ yarn build
 ```
 
 You can see the build files in `dist` directory.

--- a/packages/dts-gen/docs/maintenance-guide.md
+++ b/packages/dts-gen/docs/maintenance-guide.md
@@ -1,9 +1,15 @@
 # Maintenance Guide
 
 ## How to build
-Just run `npm run build`.
 
-You can artifact in `dist` directory.
+This package is managed with `yarn`, so you have to install `yarn` to build `dts-gen`.
+
+```
+% yarn
+% yarn build
+```
+
+You can see the build files in `dist` directory.
 
 After build process finished, build artifact are below:
 
@@ -65,13 +71,3 @@ You can run the test code as a kintone customize js customize code.
 `-u, --p, --host`:
 
 username, password, host of kintone.
-
-## How to run unit tests
-
-Just run `npm run test`.
-
-## Write document
-
-This document was written by `docsify`.
-
-See Reference: [Quick Start](https://docsify.js.org/#/quickstart)


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

We no longer host the documentations for `dts-gen` on GitHub Pages.

## What

<!-- What is a solution you want to add? -->

I've updated the links of documentations for `dts-gen` from hosted pages to markdown files.

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `yarn lint` and `yarn test` on the root directory.
