### PR TITLE
fix: Modify `properties` type in AppClient

### DIFF
--- a/examples/rest-api-client-demo/src/app.ts
+++ b/examples/rest-api-client-demo/src/app.ts
@@ -30,7 +30,7 @@ export class App {
   public async addFormFields() {
     const properties = {
       fieldCode: {
-        type: "SINGLE_LINE_TEXT",
+        type: "SINGLE_LINE_TEXT" as const,
         code: "fieldCode",
         label: "Text Field",
       },
@@ -47,7 +47,7 @@ export class App {
   public async updateFormFields() {
     const properties = {
       fieldCode: {
-        type: "SINGLE_LINE_TEXT",
+        type: "SINGLE_LINE_TEXT" as const,
         label: "Text Field 2",
       },
     };

--- a/packages/rest-api-client/src/client/AppClient.ts
+++ b/packages/rest-api-client/src/client/AppClient.ts
@@ -44,13 +44,13 @@ type GroupLayoutForParameter = {
 type LayoutForParameter = Array<
   RowLayoutForParameter | SubtableLayoutForParameter | GroupLayoutForParameter
 >;
-type NestedPartial<T> = {
-  [K in keyof T]?: T[K] extends Array<infer R>
-    ? Array<NestedPartial<R>>
-    : NestedPartial<T[K]>;
-};
+type NestedPartial<T> = T extends object
+  ? {
+      [K in keyof T]?: NestedPartial<T[K]>;
+    }
+  : T;
 
-type PropertyForParameter = NestedPartial<Properties>;
+type PropertiesForParameter = NestedPartial<Properties>;
 
 export class AppClient {
   private client: HttpClient;
@@ -76,7 +76,7 @@ export class AppClient {
 
   public addFormFields(params: {
     app: AppID;
-    properties: PropertyForParameter;
+    properties: PropertiesForParameter;
     revision?: Revision;
   }): Promise<{ revision: string }> {
     const path = this.buildPathWithGuestSpaceId({
@@ -88,7 +88,7 @@ export class AppClient {
 
   public updateFormFields(params: {
     app: AppID;
-    properties: PropertyForParameter;
+    properties: PropertiesForParameter;
     revision?: Revision;
   }): Promise<{ revision: string }> {
     const path = this.buildPathWithGuestSpaceId({

--- a/packages/rest-api-client/src/client/AppClient.ts
+++ b/packages/rest-api-client/src/client/AppClient.ts
@@ -44,6 +44,13 @@ type GroupLayoutForParameter = {
 type LayoutForParameter = Array<
   RowLayoutForParameter | SubtableLayoutForParameter | GroupLayoutForParameter
 >;
+type NestedPartial<T> = {
+  [K in keyof T]?: T[K] extends Array<infer R>
+    ? Array<NestedPartial<R>>
+    : NestedPartial<T[K]>;
+};
+
+type PropertyForParameter = NestedPartial<Properties>;
 
 export class AppClient {
   private client: HttpClient;
@@ -69,7 +76,7 @@ export class AppClient {
 
   public addFormFields(params: {
     app: AppID;
-    properties: object;
+    properties: PropertyForParameter;
     revision?: Revision;
   }): Promise<{ revision: string }> {
     const path = this.buildPathWithGuestSpaceId({
@@ -81,7 +88,7 @@ export class AppClient {
 
   public updateFormFields(params: {
     app: AppID;
-    properties: object;
+    properties: PropertyForParameter;
     revision?: Revision;
   }): Promise<{ revision: string }> {
     const path = this.buildPathWithGuestSpaceId({

--- a/packages/rest-api-client/src/client/__tests__/AppClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/AppClient.test.ts
@@ -10,7 +10,7 @@ describe("AppClient", () => {
   const RECORD_ID = 3;
   const properties = {
     fieldCode: {
-      type: "SINGLE_LINE_TEXT",
+      type: "SINGLE_LINE_TEXT" as const,
       code: "fieldCode",
       label: "Text Field",
     },


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
AppClient needs properties type for parameter.
Because as it stands now, the parameter isn't being suggested properties.

## What
Add type definition for properties as the parameter.

As a trade-off for suggesting a property, you need to specify "as const" for the property "types"

example
```ts
const properties = {
  fieldCode: {
    type: "SINGLE_LINE_TEXT" as const,
    code: "fieldCode",
    label: "Text Field",
  },
};

appClient.updateFormFields({ app, properties, revision });
```

## How to test
Existing

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
