### PR TITLE
fix: change the timing to show the warning for large offset

### DIFF
--- a/packages/rest-api-client/src/client/RecordClient.ts
+++ b/packages/rest-api-client/src/client/RecordClient.ts
@@ -124,9 +124,14 @@ export class RecordClient {
       records: T[];
       totalCount: string | null;
     }>(path, params);
-    if (params.query) {
+    this.warnMaximumOffsetValueIfNeeded(params.query);
+    return response;
+  }
+
+  private warnMaximumOffsetValueIfNeeded(query?: string) {
+    if (query) {
       const regexp = /offset\s+(\d+)/i;
-      const result = params.query.match(regexp);
+      const result = query.match(regexp);
       if (
         !this.didWarnMaximumOffsetValue &&
         result &&
@@ -138,7 +143,6 @@ export class RecordClient {
         );
       }
     }
-    return response;
   }
 
   public async addRecords(params: {

--- a/packages/rest-api-client/src/client/RecordClient.ts
+++ b/packages/rest-api-client/src/client/RecordClient.ts
@@ -111,7 +111,7 @@ export class RecordClient {
   }
 
   // TODO: `records` type in return type should be filtered by `fields`.
-  public getRecords<T extends Record>(params: {
+  public async getRecords<T extends Record>(params: {
     app: AppID;
     fields?: string[];
     query?: string;
@@ -120,6 +120,10 @@ export class RecordClient {
     const path = this.buildPathWithGuestSpaceId({
       endpointName: "records",
     });
+    const response = await this.client.get<{
+      records: T[];
+      totalCount: string | null;
+    }>(path, params);
     if (params.query) {
       const regexp = /offset\s+(\d+)/i;
       const result = params.query.match(regexp);
@@ -134,7 +138,7 @@ export class RecordClient {
         );
       }
     }
-    return this.client.get(path, params);
+    return response;
   }
 
   public async addRecords(params: {

--- a/packages/rest-api-client/src/client/__tests__/RecordClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/RecordClient.test.ts
@@ -255,6 +255,7 @@ describe("RecordClient", () => {
           expect(consoleWarnMock.mock.calls.length).toBe(1);
         });
         it("doesn't output any message to the console when the request fails", async () => {
+          expect.assertions(1);
           mockClient.mockResponse(new Error("failed"));
           try {
             await recordClient.getRecords(params);

--- a/packages/rest-api-client/src/client/__tests__/RecordClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/RecordClient.test.ts
@@ -238,8 +238,6 @@ describe("RecordClient", () => {
           totalCount: true,
         };
         it("doesn't output any message to the console", async () => {
-          const getMockFn = jest.fn();
-          mockClient.get = getMockFn;
           await recordClient.getRecords(params);
           expect(consoleWarnMock.mock.calls.length).toBe(0);
         });
@@ -252,15 +250,12 @@ describe("RecordClient", () => {
           totalCount: true,
         };
         it("outputs a message to the console only once when the request succeeds", async () => {
-          const getMockFn = jest.fn().mockResolvedValue({});
-          mockClient.get = getMockFn;
           await recordClient.getRecords(params);
           await recordClient.getRecords(params);
           expect(consoleWarnMock.mock.calls.length).toBe(1);
         });
         it("doesn't output any message to the console when the request fails", async () => {
-          const getMockFn = jest.fn().mockRejectedValue({});
-          mockClient.get = getMockFn;
+          mockClient.mockResponse(new Error("failed"));
           try {
             await recordClient.getRecords(params);
           } catch {


### PR DESCRIPTION
## Why

Fixes https://github.com/kintone/js-sdk-ja/issues/3

## What
I shift the timing to show the warning about maximum offset value after the request to get records has done.
Because the request sent to an environment which has already been applied the maximum offset value limitation will be fail, in the case, the warning are not be shown.

## How to test

`yarn test & yarn lint`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
