### PR TITLE
refactor: move the type definition for Layout

### DIFF
--- a/packages/rest-api-client/src/KintoneFields/types/layout.ts
+++ b/packages/rest-api-client/src/KintoneFields/types/layout.ts
@@ -18,12 +18,6 @@ export type Group<T extends Array<Row<Field.OneOf[]>>> = {
   layout: T;
 };
 
-export type Layout = Array<
-  | Row<Field.OneOf[]>
-  | Subtable<Field.InSubtable[]>
-  | Group<Array<Row<Field.OneOf[]>>>
->;
-
 export type OneOf =
   | Row<Field.OneOf[]>
   | Subtable<Field.InSubtable[]>

--- a/packages/rest-api-client/src/client/types/app/form.ts
+++ b/packages/rest-api-client/src/client/types/app/form.ts
@@ -1,7 +1,17 @@
 import { OneOf as FieldProperty } from "../../../KintoneFields/types/property";
+import {
+  Row,
+  Subtable,
+  Group,
+  Field,
+} from "../../../KintoneFields/types/layout";
 
 export type Properties = {
   [fieldCode: string]: FieldProperty;
 };
 
-export { Layout } from "../../../KintoneFields/types/layout";
+export type Layout = Array<
+  | Row<Field.OneOf[]>
+  | Subtable<Field.InSubtable[]>
+  | Group<Array<Row<Field.OneOf[]>>>
+>;


### PR DESCRIPTION
## Why

Although the `Layout` type definition is located in KintoneFields/types/layout.ts and exported from the file, this type is not exported externally(just be used in the definition of `KintoneRestAPIClient`).
It is inappropriate to locate type definitions like this in there.

## What

I move this definition to client/types/app/form.ts.

## How to test

`yarn lint` & `yarn test`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
