### PR TITLE
refactor: move type definitions for auth

### DIFF
--- a/packages/rest-api-client/src/KintoneRequestConfigBuilder.ts
+++ b/packages/rest-api-client/src/KintoneRequestConfigBuilder.ts
@@ -9,7 +9,7 @@ import {
   Params,
   ProxyConfig,
 } from "./http/HttpClientInterface";
-import { BasicAuth, DiscriminatedAuth } from "./KintoneRestAPIClient";
+import { BasicAuth, DiscriminatedAuth } from "./types/auth";
 import { platformDeps } from "./platform/";
 
 type Data = Params | FormData;

--- a/packages/rest-api-client/src/KintoneRestAPIClient.ts
+++ b/packages/rest-api-client/src/KintoneRestAPIClient.ts
@@ -4,47 +4,14 @@ import { RecordClient } from "./client/RecordClient";
 import { FileClient } from "./client/FileClient";
 import { DefaultHttpClient } from "./http/";
 import { ProxyConfig } from "./http/HttpClientInterface";
+import { BasicAuth, DiscriminatedAuth } from "./types/auth";
 import { KintoneRequestConfigBuilder } from "./KintoneRequestConfigBuilder";
 import { KintoneResponseHandler } from "./KintoneResponseHandler";
 import { platformDeps } from "./platform/index";
 import { UnsupportedPlatformError } from "./platform/UnsupportedPlatformError";
 
-export type DiscriminatedAuth =
-  | ApiTokenAuth
-  | PasswordAuth
-  | SessionAuth
-  | OAuthTokenAuth;
-
-type Auth =
-  | Omit<ApiTokenAuth, "type">
-  | Omit<PasswordAuth, "type">
-  | Omit<SessionAuth, "type">
-  | Omit<OAuthTokenAuth, "type">;
-
-type ApiTokenAuth = {
-  type: "apiToken";
-  apiToken: string | string[];
-};
-
-type PasswordAuth = {
-  type: "password";
-  username: string;
-  password: string;
-};
-
-type SessionAuth = {
-  type: "session";
-};
-
-type OAuthTokenAuth = {
-  type: "oAuthToken";
-  oAuthToken: string;
-};
-
-export type BasicAuth = {
-  username: string;
-  password: string;
-};
+type OmitTypePropertyFromUnion<T> = T extends unknown ? Omit<T, "type"> : never;
+type Auth = OmitTypePropertyFromUnion<DiscriminatedAuth>;
 
 type Options = {
   baseUrl?: string;

--- a/packages/rest-api-client/src/platform/browser.ts
+++ b/packages/rest-api-client/src/platform/browser.ts
@@ -1,5 +1,5 @@
 import { UnsupportedPlatformError } from "./UnsupportedPlatformError";
-import { DiscriminatedAuth } from "../KintoneRestAPIClient";
+import { DiscriminatedAuth } from "../types/auth";
 
 export const readFileFromPath = (filePath: string) => {
   throw new UnsupportedPlatformError("Browser");

--- a/packages/rest-api-client/src/platform/index.ts
+++ b/packages/rest-api-client/src/platform/index.ts
@@ -1,4 +1,4 @@
-import { DiscriminatedAuth } from "./../KintoneRestAPIClient";
+import { DiscriminatedAuth } from "../types/auth";
 type PlatformDeps = {
   readFileFromPath: (
     filePath: string

--- a/packages/rest-api-client/src/types/auth.ts
+++ b/packages/rest-api-client/src/types/auth.ts
@@ -1,0 +1,30 @@
+type ApiTokenAuth = {
+  type: "apiToken";
+  apiToken: string | string[];
+};
+
+type PasswordAuth = {
+  type: "password";
+  username: string;
+  password: string;
+};
+
+type SessionAuth = {
+  type: "session";
+};
+
+type OAuthTokenAuth = {
+  type: "oAuthToken";
+  oAuthToken: string;
+};
+
+export type DiscriminatedAuth =
+  | ApiTokenAuth
+  | PasswordAuth
+  | SessionAuth
+  | OAuthTokenAuth;
+
+export type BasicAuth = {
+  username: string;
+  password: string;
+};


### PR DESCRIPTION
## Why

Type definitions for authentication object are located in KintoneRestAPIClient.ts.
However, since these definitions are independent from the definition of `KintoneRestAPIClient`,  they should be located in another file.
Actually, a circular reference occurs between KintoneRestAPIClient.ts and KintoneRequestConfigBuilder.ts because `KintoneRequestConfigBuilder` refers them.

## What

I create a new file to locate them & move them to there.

## How to test

`yarn test` & `yarn lint`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
