### PR TITLE
feat: support environment variables for user authentication of dts-gen

### DIFF
--- a/packages/dts-gen/docs/how-to-use.md
+++ b/packages/dts-gen/docs/how-to-use.md
@@ -30,11 +30,12 @@ $ kintone-dts-gen --host http://***.cybozu.com \
 
 You can set the values through environment variables.
 
-host: KINTONE_DOMAIN  
-username: KINTONE_USERNAME  
-password: KINTONE_PASSWORD  
-basic-auth-username: KINTONE_BASIC_AUTH_USERNAME  
+```
+username: KINTONE_USERNAME
+password: KINTONE_PASSWORD
+basic-auth-username: KINTONE_BASIC_AUTH_USERNAME
 basic-auth-password: KINTONE_BASIC_AUTH_PASSWORD
+```
 
 kintone-dts-gen generates record field definition from kintone form settings.
 And from this command line option, record field type definition(`company.name.types.SampleFields`)

--- a/packages/dts-gen/docs/how-to-use.md
+++ b/packages/dts-gen/docs/how-to-use.md
@@ -28,6 +28,14 @@ $ kintone-dts-gen --host http://***.cybozu.com \
                  -o sample-fields.d.ts
 ```
 
+You can set the values through environment variables.
+
+host: KINTONE_DOMAIN  
+username: KINTONE_USERNAME  
+password: KINTONE_PASSWORD  
+basic-auth-username: KINTONE_BASIC_AUTH_USERNAME  
+basic-auth-password: KINTONE_BASIC_AUTH_PASSWORD
+
 kintone-dts-gen generates record field definition from kintone form settings.
 And from this command line option, record field type definition(`company.name.types.SampleFields`)
 is defined in `sample-fields.d.ts`.

--- a/packages/dts-gen/src/createCommanderProgram.test.ts
+++ b/packages/dts-gen/src/createCommanderProgram.test.ts
@@ -1,33 +1,64 @@
 import * as commander from "commander";
+import { before } from "lodash";
 import { createCommanderProgram } from "./createCommanderProgram";
 
 describe("createCommanderProgram", () => {
     let program: commander.Command;
-    beforeEach(() => {
-        program = createCommanderProgram();
+    describe("with environment variables", () => {
+        beforeEach(() => {
+            process.env.KINTONE_USERNAME = "admin";
+            process.env.KINTONE_PASSWORD = "password";
+            process.env.KINTONE_BASIC_AUTH_USERNAME =
+                "basic-auth-admin";
+            process.env.KINTONE_BASIC_AUTH_PASSWORD =
+                "basic-auth-password";
+            program = createCommanderProgram();
+        });
+        afterEach(() => {
+            delete process.env.KINTONE_USERNAME;
+            delete process.env.KINTONE_PASSWORD;
+            delete process.env.KINTONE_BASIC_AUTH_USERNAME;
+            delete process.env.KINTONE_BASIC_AUTH_PASSWORD;
+        });
+        test("default values", () => {
+            program.parse(["node", "index.js"]);
+            expect(program.username).toBe("admin");
+            expect(program.password).toBe("password");
+            expect(program.basicAuthUsername).toBe(
+                "basic-auth-admin"
+            );
+            expect(program.basicAuthPassword).toBe(
+                "basic-auth-password"
+            );
+            expect(program.output).toBe("fields.d.ts");
+        });
     });
+    describe("without environment variables", () => {
+        beforeEach(() => {
+            program = createCommanderProgram();
+        });
 
-    test("default values", () => {
-        program.parse(["node", "index.js"]);
+        test("default values", () => {
+            program.parse(["node", "index.js"]);
 
-        expect(program.demo).toBe(false);
-        expect(program.host).toBeUndefined();
-        expect(program.username).toBeUndefined();
-        expect(program.password).toBeUndefined();
-        expect(program.appId).toBeNull();
-        expect(program.guestSpaceId).toBeNull();
-        expect(program.preview).toBe(false);
-        expect(program.namespace).toBe("kintone.types");
-        expect(program.proxyHost).toBeNull();
-        expect(program.proxyPort).toBeNull();
-        expect(program.basicAuthUsername).toBeNull();
-        expect(program.basicAuthPassword).toBeNull();
-        expect(program.output).toBe("fields.d.ts");
-    });
+            expect(program.demo).toBe(false);
+            expect(program.host).toBeUndefined();
+            expect(program.username).toBeUndefined();
+            expect(program.password).toBeUndefined();
+            expect(program.appId).toBeNull();
+            expect(program.guestSpaceId).toBeNull();
+            expect(program.preview).toBe(false);
+            expect(program.namespace).toBe("kintone.types");
+            expect(program.proxyHost).toBeNull();
+            expect(program.proxyPort).toBeNull();
+            expect(program.basicAuthUsername).toBeNull();
+            expect(program.basicAuthPassword).toBeNull();
+            expect(program.output).toBe("fields.d.ts");
+        });
 
-    test("long flag values", () => {
-        // prettier-ignore
-        program.parse([
+        test("long flag values", () => {
+            // prettier-ignore
+            program.parse([
           "node", "index.js",
           "--demo",
           "--host", "HOST",
@@ -45,36 +76,39 @@ describe("createCommanderProgram", () => {
           "--output", "OUTPUT"
         ]);
 
-        expect(program.demo).toBe(true);
-        expect(program.host).toBe("HOST");
-        expect(program.username).toBe("USERNAME");
-        expect(program.password).toBe("PASSWORD");
-        expect(program.appId).toBe("APP_ID");
-        expect(program.guestSpaceId).toBe("GUEST_SPACE_ID");
-        expect(program.preview).toBe(true);
-        expect(program.namespace).toBe("NAMESPACE");
-        expect(program.proxyHost).toBe("PROXY_HOST");
-        expect(program.proxyPort).toBe("PROXY_PORT");
-        expect(program.basicAuthUsername).toBe(
-            "BASIC_AUTH_USERNAME"
-        );
-        expect(program.basicAuthPassword).toBe(
-            "BASIC_AUTH_PASSWORD"
-        );
-        expect(program.output).toBe("OUTPUT");
-    });
+            expect(program.demo).toBe(true);
+            expect(program.host).toBe("HOST");
+            expect(program.username).toBe("USERNAME");
+            expect(program.password).toBe("PASSWORD");
+            expect(program.appId).toBe("APP_ID");
+            expect(program.guestSpaceId).toBe(
+                "GUEST_SPACE_ID"
+            );
+            expect(program.preview).toBe(true);
+            expect(program.namespace).toBe("NAMESPACE");
+            expect(program.proxyHost).toBe("PROXY_HOST");
+            expect(program.proxyPort).toBe("PROXY_PORT");
+            expect(program.basicAuthUsername).toBe(
+                "BASIC_AUTH_USERNAME"
+            );
+            expect(program.basicAuthPassword).toBe(
+                "BASIC_AUTH_PASSWORD"
+            );
+            expect(program.output).toBe("OUTPUT");
+        });
 
-    test("short flag values", () => {
-        // prettier-ignore
-        program.parse([
+        test("short flag values", () => {
+            // prettier-ignore
+            program.parse([
           "node", "index.js",
           "-u", "USERNAME",
           "-p", "PASSWORD",
           "-o", "OUTPUT"
         ]);
 
-        expect(program.username).toBe("USERNAME");
-        expect(program.password).toBe("PASSWORD");
-        expect(program.output).toBe("OUTPUT");
+            expect(program.username).toBe("USERNAME");
+            expect(program.password).toBe("PASSWORD");
+            expect(program.output).toBe("OUTPUT");
+        });
     });
 });

--- a/packages/dts-gen/src/createCommanderProgram.test.ts
+++ b/packages/dts-gen/src/createCommanderProgram.test.ts
@@ -1,5 +1,4 @@
 import * as commander from "commander";
-import { before } from "lodash";
 import { createCommanderProgram } from "./createCommanderProgram";
 
 describe("createCommanderProgram", () => {
@@ -59,22 +58,22 @@ describe("createCommanderProgram", () => {
         test("long flag values", () => {
             // prettier-ignore
             program.parse([
-          "node", "index.js",
-          "--demo",
-          "--host", "HOST",
-          "--username", "USERNAME",
-          "--password", "PASSWORD",
-          "--app-id", "APP_ID",
-          "--guest-space-id", "GUEST_SPACE_ID",
-          "--preview",
-          "--type-name", "TYPE_NAME",
-          "--namespace", "NAMESPACE",
-          "--proxy-host", "PROXY_HOST",
-          "--proxy-port", "PROXY_PORT",
-          "--basic-auth-username", "BASIC_AUTH_USERNAME",
-          "--basic-auth-password", "BASIC_AUTH_PASSWORD",
-          "--output", "OUTPUT"
-        ]);
+                "node", "index.js",
+                "--demo",
+                "--host", "HOST",
+                "--username", "USERNAME",
+                "--password", "PASSWORD",
+                "--app-id", "APP_ID",
+                "--guest-space-id", "GUEST_SPACE_ID",
+                "--preview",
+                "--type-name", "TYPE_NAME",
+                "--namespace", "NAMESPACE",
+                "--proxy-host", "PROXY_HOST",
+                "--proxy-port", "PROXY_PORT",
+                "--basic-auth-username", "BASIC_AUTH_USERNAME",
+                "--basic-auth-password", "BASIC_AUTH_PASSWORD",
+                "--output", "OUTPUT"
+            ]);
 
             expect(program.demo).toBe(true);
             expect(program.host).toBe("HOST");
@@ -100,11 +99,11 @@ describe("createCommanderProgram", () => {
         test("short flag values", () => {
             // prettier-ignore
             program.parse([
-          "node", "index.js",
-          "-u", "USERNAME",
-          "-p", "PASSWORD",
-          "-o", "OUTPUT"
-        ]);
+                "node", "index.js",
+                "-u", "USERNAME",
+                "-p", "PASSWORD",
+                "-o", "OUTPUT"
+            ]);
 
             expect(program.username).toBe("USERNAME");
             expect(program.password).toBe("PASSWORD");

--- a/packages/dts-gen/src/createCommanderProgram.ts
+++ b/packages/dts-gen/src/createCommanderProgram.ts
@@ -11,8 +11,16 @@ export function createCommanderProgram() {
         )
 
         .option("--host [host]")
-        .option("-u, --username [username]")
-        .option("-p, --password [password]")
+        .option(
+            "-u, --username [username]",
+            "A username for the Kintone environment",
+            process.env.KINTONE_USERNAME
+        )
+        .option(
+            "-p, --password [password]",
+            "A password for the Kintone environment",
+            process.env.KINTONE_PASSWORD
+        )
         .option(
             "--app-id [appId]",
             "id of kintone app",
@@ -50,13 +58,13 @@ export function createCommanderProgram() {
         )
         .option(
             "--basic-auth-username [basicAuthUsername]",
-            "username for basic authentication",
-            null
+            "A username for basic authentication",
+            process.env.KINTONE_BASIC_AUTH_USERNAME
         )
         .option(
             "--basic-auth-password [basicAuthPassword]",
-            "password for basic authentication",
-            null
+            "A password for basic authentication",
+            process.env.KINTONE_BASIC_AUTH_PASSWORD
         )
         .option(
             "-o, --output [output]",

--- a/packages/dts-gen/src/createCommanderProgram.ts
+++ b/packages/dts-gen/src/createCommanderProgram.ts
@@ -14,12 +14,12 @@ export function createCommanderProgram() {
         .option(
             "-u, --username [username]",
             "A username for the Kintone environment",
-            process.env.KINTONE_USERNAME
+            process.env.KINTONE_USERNAME || null
         )
         .option(
             "-p, --password [password]",
             "A password for the Kintone environment",
-            process.env.KINTONE_PASSWORD
+            process.env.KINTONE_PASSWORD || null
         )
         .option(
             "--app-id [appId]",
@@ -59,12 +59,12 @@ export function createCommanderProgram() {
         .option(
             "--basic-auth-username [basicAuthUsername]",
             "A username for basic authentication",
-            process.env.KINTONE_BASIC_AUTH_USERNAME
+            process.env.KINTONE_BASIC_AUTH_USERNAME || null
         )
         .option(
             "--basic-auth-password [basicAuthPassword]",
             "A password for basic authentication",
-            process.env.KINTONE_BASIC_AUTH_PASSWORD
+            process.env.KINTONE_BASIC_AUTH_PASSWORD || null
         )
         .option(
             "-o, --output [output]",

--- a/packages/dts-gen/src/createCommanderProgram.ts
+++ b/packages/dts-gen/src/createCommanderProgram.ts
@@ -14,12 +14,12 @@ export function createCommanderProgram() {
         .option(
             "-u, --username [username]",
             "A username for the Kintone environment",
-            process.env.KINTONE_USERNAME || null
+            process.env.KINTONE_USERNAME
         )
         .option(
             "-p, --password [password]",
             "A password for the Kintone environment",
-            process.env.KINTONE_PASSWORD || null
+            process.env.KINTONE_PASSWORD
         )
         .option(
             "--app-id [appId]",

--- a/packages/dts-gen/src/index.ts
+++ b/packages/dts-gen/src/index.ts
@@ -8,28 +8,14 @@ import { createCommanderProgram } from "./createCommanderProgram";
 const program = createCommanderProgram();
 program.parse(process.argv);
 
-const {
-    // HTTP_PROXY,
-    // HTTPS_PROXY,
-    KINTONE_DOMAIN,
-    KINTONE_USERNAME,
-    KINTONE_PASSWORD,
-    KINTONE_BASIC_AUTH_USERNAME,
-    KINTONE_BASIC_AUTH_PASSWORD,
-} = process.env;
-
 const newClientInput = {
-    host: program.host || `https://${KINTONE_DOMAIN}`,
-    username: program.username || KINTONE_USERNAME,
-    password: program.password || KINTONE_PASSWORD,
+    host: program.host,
+    username: program.username,
+    password: program.password,
     proxyHost: program.proxyHost,
     proxyPort: program.proxyPort,
-    basicAuthUsername:
-        program.basicAuthUsername ||
-        KINTONE_BASIC_AUTH_USERNAME,
-    basicAuthPassword:
-        program.basicAuthPassword ||
-        KINTONE_BASIC_AUTH_PASSWORD,
+    basicAuthUsername: program.basicAuthUsername,
+    basicAuthPassword: program.basicAuthPassword,
 };
 
 const client = program.demo

--- a/packages/dts-gen/src/index.ts
+++ b/packages/dts-gen/src/index.ts
@@ -8,14 +8,28 @@ import { createCommanderProgram } from "./createCommanderProgram";
 const program = createCommanderProgram();
 program.parse(process.argv);
 
+const {
+    // HTTP_PROXY,
+    // HTTPS_PROXY,
+    KINTONE_DOMAIN,
+    KINTONE_USERNAME,
+    KINTONE_PASSWORD,
+    KINTONE_BASIC_AUTH_USERNAME,
+    KINTONE_BASIC_AUTH_PASSWORD,
+} = process.env;
+
 const newClientInput = {
-    host: program.host,
-    username: program.username,
-    password: program.password,
+    host: program.host || `https://${KINTONE_DOMAIN}`,
+    username: program.username || KINTONE_USERNAME,
+    password: program.password || KINTONE_PASSWORD,
     proxyHost: program.proxyHost,
     proxyPort: program.proxyPort,
-    basicAuthUsername: program.basicAuthUsername,
-    basicAuthPassword: program.basicAuthPassword,
+    basicAuthUsername:
+        program.basicAuthUsername ||
+        KINTONE_BASIC_AUTH_USERNAME,
+    basicAuthPassword:
+        program.basicAuthPassword ||
+        KINTONE_BASIC_AUTH_PASSWORD,
 };
 
 const client = program.demo


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

This is a part of #530 

<!-- Why do you want the feature and why does it make sense for the package? -->


## What

<!-- What is a solution you want to add? -->

This PR is based on #458 (Thank you @potaracom 👏 ).
I've added the following environment variables support in `dts-gen`

- `KINTONE_USERNAME`
- `KINTONE_PASSWORD`
- `KINTONE_BASIC_AUTH_USERNAME`
- `KINTONE_BASIC_AUTH_PASSWORD`

I'll add other environment variables support in other PRs.

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `yarn lint` and `yarn test` on the root directory.
