### PR TITLE
feat: support environment variable for base URL of plugin-uploader

### DIFF
--- a/packages/plugin-uploader/README.md
+++ b/packages/plugin-uploader/README.md
@@ -47,6 +47,7 @@ You can create a project based on `@kintone/plugin-packer` using [@kintone/creat
     $ kintone-plugin-uploader <pluginPath>
   Options
     --domain Domain of your kintone
+    --base-url Base-url of your kintone (If you set domain, its value is not necessary.)
     --username Login username
     --password User's password
     --proxy Proxy server
@@ -57,6 +58,7 @@ You can create a project based on `@kintone/plugin-packer` using [@kintone/creat
 
     You can set the values through environment variables
     domain: KINTONE_DOMAIN
+    base-url: KINTONE_BASE_URL (If you set domain, its value is not necessary.)
     username: KINTONE_USERNAME
     password: KINTONE_PASSWORD
     basic-auth-username: KINTONE_BASIC_AUTH_USERNAME

--- a/packages/plugin-uploader/README.md
+++ b/packages/plugin-uploader/README.md
@@ -46,8 +46,8 @@ You can create a project based on `@kintone/plugin-packer` using [@kintone/creat
   Usage
     $ kintone-plugin-uploader <pluginPath>
   Options
-    --domain Domain of your kintone
-    --base-url Base-url of your kintone (If you set domain, its value is not necessary.)
+    --base-url Base-url of your kintone
+    --domain Domain of your kintone (If you set `--base-url`, this value is not necessary.)
     --username Login username
     --password User's password
     --proxy Proxy server
@@ -57,8 +57,8 @@ You can create a project based on `@kintone/plugin-packer` using [@kintone/creat
     --lang Using language (en or ja)
 
     You can set the values through environment variables
-    domain: KINTONE_DOMAIN
-    base-url: KINTONE_BASE_URL (If you set domain, its value is not necessary.)
+    base-url: KINTONE_BASE_URL
+    domain: KINTONE_DOMAIN (If you set `base-url`, this value is not necessary.)
     username: KINTONE_USERNAME
     password: KINTONE_PASSWORD
     basic-auth-username: KINTONE_BASIC_AUTH_USERNAME

--- a/packages/plugin-uploader/bin/cli.js
+++ b/packages/plugin-uploader/bin/cli.js
@@ -130,7 +130,7 @@ wait(waitingDialogMs)
   .then(() => inquireParams({ username, password, domain, baseUrl, lang }))
   .then((answers) => {
     run(
-      baseUrl || answers.domain,
+      answers.baseUrl || answers.domain,
       answers.username,
       answers.password,
       pluginPath,

--- a/packages/plugin-uploader/bin/cli.js
+++ b/packages/plugin-uploader/bin/cli.js
@@ -13,6 +13,7 @@ const {
   HTTP_PROXY,
   HTTPS_PROXY,
   KINTONE_DOMAIN,
+  KINTONE_BASE_URL,
   KINTONE_USERNAME,
   KINTONE_PASSWORD,
   KINTONE_BASIC_AUTH_USERNAME,
@@ -25,6 +26,7 @@ const cli = meow(
     $ kintone-plugin-uploader <pluginPath>
   Options
     --domain Domain of your kintone
+    --base-url Base-url of your kintone (If you set domain, its value is not necessary.)
     --username Login username
     --password User's password
     --proxy Proxy server
@@ -36,6 +38,7 @@ const cli = meow(
 
     You can set the values through environment variables
     domain: KINTONE_DOMAIN
+    base-url: KINTONE_BASE_URL (If you set domain, its value is not necessary.)
     username: KINTONE_USERNAME
     password: KINTONE_PASSWORD
     basic-auth-username: KINTONE_BASIC_AUTH_USERNAME
@@ -47,6 +50,10 @@ const cli = meow(
       domain: {
         type: "string",
         default: KINTONE_DOMAIN || "",
+      },
+      baseUrl: {
+        type: "string",
+        default: KINTONE_BASE_URL || "",
       },
       username: {
         type: "string",
@@ -89,6 +96,7 @@ const {
   username,
   password,
   domain,
+  baseUrl,
   proxy,
   basicAuthUsername,
   basicAuthPassword,
@@ -119,7 +127,13 @@ if (!pluginPath) {
 const wait = (ms) => new Promise((r) => setTimeout(r, ms));
 
 wait(waitingDialogMs)
-  .then(() => inquireParams({ username, password, domain, lang }))
-  .then((answers) =>
-    run(answers.domain, answers.username, answers.password, pluginPath, options)
-  );
+  .then(() => inquireParams({ username, password, domain, baseUrl, lang }))
+  .then((answers) => {
+    run(
+      baseUrl || answers.domain,
+      answers.username,
+      answers.password,
+      pluginPath,
+      options
+    );
+  });

--- a/packages/plugin-uploader/src/index.ts
+++ b/packages/plugin-uploader/src/index.ts
@@ -29,8 +29,10 @@ async function readyForUpload(
   const m = getBoundMessage(lang);
 
   const page = await browser.newPage();
-  const kintoneUrl = `https://${domain}/`;
-  const loginUrl = `${kintoneUrl}login?saml=off`;
+  const kintoneUrl = domain.match(/^https:\/\//)
+    ? `${domain}`
+    : `https://${domain}`;
+  const loginUrl = `${kintoneUrl}/login?saml=off`;
 
   if (basicAuth) {
     await page.authenticate(basicAuth);
@@ -56,7 +58,7 @@ async function readyForUpload(
     throw chalk.red(m("Error_failedLogin"));
   }
 
-  const pluginUrl = `${kintoneUrl}k/admin/system/plugin/`;
+  const pluginUrl = `${kintoneUrl}/k/admin/system/plugin/`;
   console.log(`Navigate to ${pluginUrl}`);
   await page.goto(pluginUrl);
 

--- a/packages/plugin-uploader/src/messages.ts
+++ b/packages/plugin-uploader/src/messages.ts
@@ -4,9 +4,14 @@ type LangMap = { [lang in Lang]: string };
 type MessageMap = { [key in keyof typeof messages]: LangMap };
 
 const messages = {
+  // TODO: remove Q_Domain when `domain` option is deprecated.
   Q_Domain: {
     en: "Input your Kintone subdomain (example.cybozu.com):",
     ja: "kintoneのドメインを入力してください (example.cybozu.com):",
+  },
+  Q_BaseUrl: {
+    en: "Input your kintone's base URL (https://example.cybozu.com):",
+    ja: "kintoneのベースURLを入力してください (https://example.cybozu.com):",
   },
   Q_UserName: {
     en: "Input your username:",

--- a/packages/plugin-uploader/src/params.ts
+++ b/packages/plugin-uploader/src/params.ts
@@ -33,7 +33,7 @@ export const inquireParams = ({
       message: m("Q_BaseUrl"),
       name: "baseUrl",
       default: baseUrl,
-      when: (v) => !baseUrl && !v.domain,
+      when: (v: inquirer.Answers) => !baseUrl && !v.domain,
       validate: (v: string) => !!v,
     },
     {

--- a/packages/plugin-uploader/src/params.ts
+++ b/packages/plugin-uploader/src/params.ts
@@ -6,10 +6,17 @@ interface Params {
   username?: string;
   password?: string;
   domain?: string;
+  baseUrl?: string;
   lang: Lang;
 }
 
-export const inquireParams = ({ username, password, domain, lang }: Params) => {
+export const inquireParams = ({
+  username,
+  password,
+  domain,
+  baseUrl,
+  lang,
+}: Params) => {
   const m = getBoundMessage(lang);
   const questions: inquirer.Question[] = [
     {
@@ -17,7 +24,7 @@ export const inquireParams = ({ username, password, domain, lang }: Params) => {
       message: m("Q_Domain"),
       name: "domain",
       default: domain,
-      when: () => !domain,
+      when: () => !baseUrl && !domain,
       validate: (v: string) => !!v,
     },
     {

--- a/packages/plugin-uploader/src/params.ts
+++ b/packages/plugin-uploader/src/params.ts
@@ -19,12 +19,21 @@ export const inquireParams = ({
 }: Params) => {
   const m = getBoundMessage(lang);
   const questions: inquirer.Question[] = [
+    // TODO: remove an object of domain when `domain` option is deprecated
     {
       type: "input",
       message: m("Q_Domain"),
       name: "domain",
       default: domain,
       when: () => !baseUrl && !domain,
+      validate: (v: string) => !!v,
+    },
+    {
+      type: "input",
+      message: m("Q_BaseUrl"),
+      name: "baseUrl",
+      default: baseUrl,
+      when: (v) => !baseUrl && !v.domain,
       validate: (v: string) => !!v,
     },
     {
@@ -47,5 +56,7 @@ export const inquireParams = ({
 
   return inquirer
     .prompt(questions)
-    .then((answers) => Object.assign({ username, password, domain }, answers));
+    .then((answers) =>
+      Object.assign({ username, password, domain, baseUrl }, answers)
+    );
 };


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

This is a part of #530

## What

I've added an environment variable and a CLI flag support in plugin-uploader.

- `KINTONE_BASE_URL`

## How to test

- set `KINTONE_BASE_URL`to environment valiable and execute `bin/cli.js SAMPLE_PLUGIN.zip`
- execute `bin/cli.js SAMPLE_PLUGIN.zip` with `--base-url` option


## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
