### PR TITLE
fix: should not ask base-url if use domain option of plugin-uploader

### DIFF
--- a/packages/plugin-uploader/src/params.ts
+++ b/packages/plugin-uploader/src/params.ts
@@ -33,7 +33,7 @@ export const inquireParams = ({
       message: m("Q_BaseUrl"),
       name: "baseUrl",
       default: baseUrl,
-      when: (v: inquirer.Answers) => !baseUrl && !v.domain,
+      when: (v: inquirer.Answers) => !baseUrl && !domain && !v.domain,
       validate: (v: string) => !!v,
     },
     {


### PR DESCRIPTION
## Why

In #534, `plugin-uploader` has supported base-url option.
Although a user specifies `--domain`, `plugin-uploader` asks about baseURL.


## What

Validate the value of optional domain, too.


## How to test

`yarn build` & Execute `bin/cli.js SAMPLE_PLUGIN.zip --domain example.cybozu.com`.

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
