### PR TITLE
feat: support environment variable for base URL of customize uploader

### DIFF
--- a/packages/customize-uploader/README.md
+++ b/packages/customize-uploader/README.md
@@ -60,7 +60,8 @@ If you want to upload the customize files automatically when a file is updated, 
   Usage
     $ kintone-customize-uploader <manifestFile>
   Options
-    --domain Domain of your kintone
+    --base-url Base-url of your kintone
+    --domain Domain of your kintone (If you set --base-url, this value is not necessary.)
     --username Login username
     --password User's password
     --basic-auth-username Basic Authentication username
@@ -79,6 +80,7 @@ If you want to upload the customize files automatically when a file is updated, 
     import download js/css files and update customize-manifest.json
 
     You can set the values through environment variables
+    base-url: KINTONE_BASE_URL
     domain: KINTONE_DOMAIN
     username: KINTONE_USERNAME
     password: KINTONE_PASSWORD

--- a/packages/customize-uploader/README.md
+++ b/packages/customize-uploader/README.md
@@ -81,7 +81,7 @@ If you want to upload the customize files automatically when a file is updated, 
 
     You can set the values through environment variables
     base-url: KINTONE_BASE_URL
-    domain: KINTONE_DOMAIN
+    domain: KINTONE_DOMAIN (If you set `base-url`, this value is not necessary.)
     username: KINTONE_USERNAME
     password: KINTONE_PASSWORD
     basic-auth-username: KINTONE_BASIC_AUTH_USERNAME

--- a/packages/customize-uploader/bin/cli.js
+++ b/packages/customize-uploader/bin/cli.js
@@ -44,7 +44,7 @@ const cli = meow(
 
     You can set the values through environment variables
     base-url: KINTONE_BASE_URL
-    domain: KINTONE_DOMAIN
+    domain: KINTONE_DOMAIN (If you set base-url, this value is not necessary.)
     username: KINTONE_USERNAME
     password: KINTONE_PASSWORD
     basic-auth-username: KINTONE_BASIC_AUTH_USERNAME

--- a/packages/customize-uploader/bin/cli.js
+++ b/packages/customize-uploader/bin/cli.js
@@ -11,6 +11,7 @@ const {
   HTTP_PROXY,
   HTTPS_PROXY,
   KINTONE_DOMAIN,
+  KINTONE_BASE_URL,
   KINTONE_USERNAME,
   KINTONE_PASSWORD,
   KINTONE_BASIC_AUTH_USERNAME,
@@ -22,14 +23,15 @@ const cli = meow(
   Usage
     $ kintone-customize-uploader <manifestFile>
   Options
-    --domain Domain of your kintone
+    --base-url Base-url of your kintone
+    --domain Domain of your kintone (If you set --base-url, this value is not necessary.)
     --username Login username
     --password User's password
     --basic-auth-username Basic Authentication username
     --basic-auth-password Basic Authentication password
     --proxy Proxy server
     --watch Watch the changes of customize files and re-run
-    --dest-dir -d option for subcommands 
+    --dest-dir -d option for subcommands
                   this option stands for output directory
                   default value is dest/
     --lang Using language (en or ja)
@@ -37,10 +39,11 @@ const cli = meow(
 
   SubCommands
     init   generate customize-manifest.json
-    
+
     import download js/css files and update customize-manifest.json
-    
+
     You can set the values through environment variables
+    base-url: KINTONE_BASE_URL
     domain: KINTONE_DOMAIN
     username: KINTONE_USERNAME
     password: KINTONE_PASSWORD
@@ -53,6 +56,10 @@ const cli = meow(
       domain: {
         type: "string",
         default: KINTONE_DOMAIN || "",
+      },
+      baseUrl: {
+        type: "string",
+        default: KINTONE_BASE_URL || "",
       },
       username: {
         type: "string",
@@ -110,6 +117,7 @@ const {
   basicAuthUsername,
   basicAuthPassword,
   domain,
+  baseUrl,
   proxy,
   watch,
   lang,
@@ -139,11 +147,11 @@ if (isInitCommand) {
     })
     .catch((error) => console.log(error.message));
 } else {
-  inquireParams({ username, password, domain, lang })
+  inquireParams({ username, password, baseUrl, domain, lang })
     .then((params) => {
       if (isImportCommand) {
         runImport(
-          params.domain,
+          params.baseUrl || params.domain,
           params.username,
           params.password,
           basicAuthUsername,
@@ -153,7 +161,7 @@ if (isInitCommand) {
         );
       } else {
         run(
-          params.domain,
+          params.baseUrl || params.domain,
           params.username,
           params.password,
           basicAuthUsername,

--- a/packages/customize-uploader/src/messages.ts
+++ b/packages/customize-uploader/src/messages.ts
@@ -5,6 +5,7 @@ const messages = {
     en: "Please specify manifest file",
     ja: "マニフェストファイルを指定してください",
   },
+  // TODO: remove Q_Domain when `domain` option is deprecated.
   Q_Domain: {
     en: "Input your kintone's domain (example.cybozu.com):",
     ja: "kintoneのドメインを入力してください (example.cybozu.com):",

--- a/packages/customize-uploader/src/messages.ts
+++ b/packages/customize-uploader/src/messages.ts
@@ -9,6 +9,10 @@ const messages = {
     en: "Input your kintone's domain (example.cybozu.com):",
     ja: "kintoneのドメインを入力してください (example.cybozu.com):",
   },
+  Q_BaseUrl: {
+    en: "Input your kintone's base URL (https://example.cybozu.com):",
+    ja: "kintoneのベースURLを入力してください (https://example.cybozu.com):",
+  },
   Q_UserName: {
     en: "Input your username:",
     ja: "ログイン名を入力してください:",

--- a/packages/customize-uploader/src/params/index.ts
+++ b/packages/customize-uploader/src/params/index.ts
@@ -5,19 +5,35 @@ import { getBoundMessage } from "../messages";
 interface Params {
   username?: string;
   password?: string;
+  baseUrl?: string;
   domain?: string;
   lang: Lang;
 }
 
-export const inquireParams = ({ username, password, domain, lang }: Params) => {
+export const inquireParams = ({
+  username,
+  password,
+  domain,
+  baseUrl,
+  lang,
+}: Params) => {
   const m = getBoundMessage(lang);
   const questions = [
+    // TODO: remove domain when domain is deprecated
     {
       type: "input",
       message: m("Q_Domain"),
       name: "domain",
       default: domain,
-      when: () => !domain,
+      when: () => !baseUrl && !domain,
+      validate: (v: string) => !!v,
+    },
+    {
+      type: "input",
+      message: m("Q_BaseUrl"),
+      name: "baseUrl",
+      default: baseUrl,
+      when: (v: inquirer.Answers) => !baseUrl && !domain && !v.domain,
       validate: (v: string) => !!v,
     },
     {
@@ -40,7 +56,9 @@ export const inquireParams = ({ username, password, domain, lang }: Params) => {
 
   return inquirer
     .prompt(questions)
-    .then((answers) => Object.assign({ username, password, domain }, answers));
+    .then((answers) =>
+      Object.assign({ username, password, domain, baseUrl }, answers)
+    );
 };
 
 export * from "./init";


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

This is a part of #530 

## What

I've added an environment variable and a CLI flag support in customize-uploader.

- `KINTONE_BASE_URL`

## How to test

- set `KINTONE_BASE_URL` to the environment variables and run `bin/cli.js sample/customize-manifest.json`
- execute the following commands with `--base-url` option.
  - `bin/cli.js sample/customize-manifest.json`
  - `bin/cli.js import sample/customize-manifest.json`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
