### PR TITLE
feat: support OAuth token of customize uploader

### DIFF
--- a/packages/customize-uploader/README.md
+++ b/packages/customize-uploader/README.md
@@ -64,6 +64,7 @@ If you want to upload the customize files automatically when a file is updated, 
     --domain Domain of your kintone (If you set --base-url, this value is not necessary.)
     --username Login username
     --password User's password
+    --oauth-token OAuth access token (If you set a set of --username and --password, this value is not necessary.)
     --basic-auth-username Basic Authentication username
     --basic-auth-password Basic Authentication password
     --proxy Proxy server
@@ -84,6 +85,7 @@ If you want to upload the customize files automatically when a file is updated, 
     domain: KINTONE_DOMAIN (If you set `base-url`, this value is not necessary.)
     username: KINTONE_USERNAME
     password: KINTONE_PASSWORD
+    oauth-token: KINTONE_OAUTH_TOKEN (If you set a set of username and password, this value is not necessary.)
     basic-auth-username: KINTONE_BASIC_AUTH_USERNAME
     basic-auth-password: KINTONE_BASIC_AUTH_PASSWORD
     proxy: HTTPS_PROXY or HTTP_PROXY

--- a/packages/customize-uploader/README.md
+++ b/packages/customize-uploader/README.md
@@ -99,7 +99,7 @@ If you omit the options, you can input the options interactively.
 ? Input your password: [hidden]
 ```
 
-If you use OAuthToken, you need to grant scopes corresponding to the command.
+If you use OAuth access token, you need to grant scopes corresponding to the command.
 
 - To upload a customize setting:
   `k:app_settings:write` and `k:file:write`

--- a/packages/customize-uploader/README.md
+++ b/packages/customize-uploader/README.md
@@ -102,7 +102,7 @@ If you omit the options, you can input the options interactively.
 If you use OAuth access token, you need to grant scopes corresponding to the command.
 
 - To upload a customize setting:
-  `k:app_settings:write` and `k:file:write`
+  `k:app_settings:read`, `k:app_settings:write` and `k:file:write`
 - To import a customize setting by using `import` of subcommand:
   `k:app_settings:read` and `k:file:read`
 

--- a/packages/customize-uploader/README.md
+++ b/packages/customize-uploader/README.md
@@ -99,6 +99,15 @@ If you omit the options, you can input the options interactively.
 ? Input your password: [hidden]
 ```
 
+If you use OAuthToken, you need to grant scopes corresponding to the command.
+
+- To upload a customize setting:
+  `k:app_settings:write` and `k:file:write`
+- To import a customize setting by using `import` of subcommand:
+  `k:app_settings:read` and `k:file:read`
+
+For the details; Please see [How to add OAuth clients](https://developer.kintone.io/hc/en-us/articles/360001562353)
+
 ## Example
 This is an example of `customize-manifest.json` .
 ```json

--- a/packages/customize-uploader/bin/cli.js
+++ b/packages/customize-uploader/bin/cli.js
@@ -155,7 +155,14 @@ if (isInitCommand) {
     })
     .catch((error) => console.log(error.message));
 } else {
-  inquireParams({ username, password, oauthToken, baseUrl, domain, lang })
+  inquireParams({
+    username,
+    password,
+    oAuthToken: oauthToken,
+    baseUrl,
+    domain,
+    lang,
+  })
     .then((params) => {
       if (isImportCommand) {
         runImport(

--- a/packages/customize-uploader/bin/cli.js
+++ b/packages/customize-uploader/bin/cli.js
@@ -14,6 +14,7 @@ const {
   KINTONE_BASE_URL,
   KINTONE_USERNAME,
   KINTONE_PASSWORD,
+  KINTONE_OAUTH_TOKEN,
   KINTONE_BASIC_AUTH_USERNAME,
   KINTONE_BASIC_AUTH_PASSWORD,
 } = process.env;
@@ -27,6 +28,7 @@ const cli = meow(
     --domain Domain of your kintone (If you set --base-url, this value is not necessary.)
     --username Login username
     --password User's password
+    --oauth-token OAuth access token (If you set a set of --username and --password, this value is not necessary.)
     --basic-auth-username Basic Authentication username
     --basic-auth-password Basic Authentication password
     --proxy Proxy server
@@ -47,6 +49,7 @@ const cli = meow(
     domain: KINTONE_DOMAIN (If you set base-url, this value is not necessary.)
     username: KINTONE_USERNAME
     password: KINTONE_PASSWORD
+    oauth-token: KINTONE_OAUTH_TOKEN (If you set a set of username and password, this value is not necessary.)
     basic-auth-username: KINTONE_BASIC_AUTH_USERNAME
     basic-auth-password: KINTONE_BASIC_AUTH_PASSWORD
     proxy: HTTPS_PROXY or HTTP_PROXY
@@ -68,6 +71,10 @@ const cli = meow(
       password: {
         type: "string",
         default: KINTONE_PASSWORD || "",
+      },
+      oauthToken: {
+        type: "string",
+        default: KINTONE_OAUTH_TOKEN || "",
       },
       basicAuthUsername: {
         type: "string",
@@ -116,6 +123,7 @@ const {
   password,
   basicAuthUsername,
   basicAuthPassword,
+  oauthToken,
   domain,
   baseUrl,
   proxy,
@@ -147,13 +155,14 @@ if (isInitCommand) {
     })
     .catch((error) => console.log(error.message));
 } else {
-  inquireParams({ username, password, baseUrl, domain, lang })
+  inquireParams({ username, password, oauthToken, baseUrl, domain, lang })
     .then((params) => {
       if (isImportCommand) {
         runImport(
           params.baseUrl || params.domain,
           params.username,
           params.password,
+          oauthToken,
           basicAuthUsername,
           basicAuthPassword,
           manifestFile,
@@ -164,6 +173,7 @@ if (isInitCommand) {
           params.baseUrl || params.domain,
           params.username,
           params.password,
+          oauthToken,
           basicAuthUsername,
           basicAuthPassword,
           manifestFile,

--- a/packages/customize-uploader/src/KintoneApiClient.ts
+++ b/packages/customize-uploader/src/KintoneApiClient.ts
@@ -19,7 +19,7 @@ export default class KintoneApiClient {
   public constructor(
     username: string | null,
     password: string | null,
-    oauthToken: string | null,
+    oAuthToken: string | null,
     basicAuthUsername: string | null,
     basicAuthPassword: string | null,
     domain: string,
@@ -34,9 +34,9 @@ export default class KintoneApiClient {
         password,
       };
     }
-    if (oauthToken) {
+    if (oAuthToken) {
       auth = {
-        oAuthToken: oauthToken,
+        oAuthToken,
       };
     }
     let basicAuth;

--- a/packages/customize-uploader/src/KintoneApiClient.ts
+++ b/packages/customize-uploader/src/KintoneApiClient.ts
@@ -17,8 +17,9 @@ export type UpdateAppCustomizeParameter = {
 export default class KintoneApiClient {
   private restApiClient: KintoneRestAPIClient;
   public constructor(
-    username: string,
-    password: string,
+    username: string | null,
+    password: string | null,
+    oauthToken: string | null,
     basicAuthUsername: string | null,
     basicAuthPassword: string | null,
     domain: string,
@@ -26,6 +27,18 @@ export default class KintoneApiClient {
   ) {
     const kintoneUrl =
       domain.indexOf("https://") > -1 ? domain : `https://${domain}`;
+    let auth;
+    if (username && password) {
+      auth = {
+        username,
+        password,
+      };
+    }
+    if (oauthToken) {
+      auth = {
+        oAuthToken: oauthToken,
+      };
+    }
     let basicAuth;
     if (basicAuthUsername && basicAuthPassword) {
       basicAuth = {
@@ -35,7 +48,7 @@ export default class KintoneApiClient {
     }
     this.restApiClient = new KintoneRestAPIClient({
       baseUrl: kintoneUrl,
-      auth: { username, password },
+      auth,
       basicAuth,
       featureFlags: {
         enableAbortSearchError: false,

--- a/packages/customize-uploader/src/commands/__tests__/MockKintoneApiClient.ts
+++ b/packages/customize-uploader/src/commands/__tests__/MockKintoneApiClient.ts
@@ -29,7 +29,7 @@ export default class MockKintoneApiClient extends KintoneApiClient {
   }>;
   public willBeReturnResponse: any;
   constructor(
-    ...args: [string, string, string, string, string, ApiClientOption]
+    ...args: [string, string, string, string, string, string, ApiClientOption]
   ) {
     super(...args);
     this.logs = [];

--- a/packages/customize-uploader/src/commands/__tests__/import.test.ts
+++ b/packages/customize-uploader/src/commands/__tests__/import.test.ts
@@ -32,6 +32,7 @@ describe("import", () => {
       kintoneApiClient = new MockKintoneApiClient(
         "kintone",
         "hogehoge",
+        "oauthToken",
         "basicAuthUser",
         "basicAuthPass",
         "example.com",

--- a/packages/customize-uploader/src/commands/__tests__/import.test.ts
+++ b/packages/customize-uploader/src/commands/__tests__/import.test.ts
@@ -32,7 +32,7 @@ describe("import", () => {
       kintoneApiClient = new MockKintoneApiClient(
         "kintone",
         "hogehoge",
-        "oauthToken",
+        "oAuthToken",
         "basicAuthUser",
         "basicAuthPass",
         "example.com",

--- a/packages/customize-uploader/src/commands/__tests__/index.test.ts
+++ b/packages/customize-uploader/src/commands/__tests__/index.test.ts
@@ -12,6 +12,7 @@ describe("index", () => {
       kintoneApiClient = new MockKintoneApiClient(
         "kintone",
         "hogehoge",
+        "oauthToken",
         "basicAuthUser",
         "basicAuthPass",
         "example.com",

--- a/packages/customize-uploader/src/commands/__tests__/index.test.ts
+++ b/packages/customize-uploader/src/commands/__tests__/index.test.ts
@@ -12,7 +12,7 @@ describe("index", () => {
       kintoneApiClient = new MockKintoneApiClient(
         "kintone",
         "hogehoge",
-        "oauthToken",
+        "oAuthToken",
         "basicAuthUser",
         "basicAuthPass",
         "example.com",

--- a/packages/customize-uploader/src/commands/import.ts
+++ b/packages/customize-uploader/src/commands/import.ts
@@ -184,8 +184,9 @@ function downloadAndWriteFile(
 
 export const runImport = async (
   domain: string,
-  username: string,
-  password: string,
+  username: string | null,
+  password: string | null,
+  oauthToken: string | null,
   basicAuthUsername: string | null,
   basicAuthPassword: string | null,
   manifestFile: string,
@@ -202,6 +203,7 @@ export const runImport = async (
   const kintoneApiClient = new KintoneApiClient(
     username,
     password,
+    oauthToken,
     basicAuthUsername,
     basicAuthPassword,
     domain,

--- a/packages/customize-uploader/src/commands/import.ts
+++ b/packages/customize-uploader/src/commands/import.ts
@@ -186,7 +186,7 @@ export const runImport = async (
   domain: string,
   username: string | null,
   password: string | null,
-  oauthToken: string | null,
+  oAuthToken: string | null,
   basicAuthUsername: string | null,
   basicAuthPassword: string | null,
   manifestFile: string,
@@ -203,7 +203,7 @@ export const runImport = async (
   const kintoneApiClient = new KintoneApiClient(
     username,
     password,
-    oauthToken,
+    oAuthToken,
     basicAuthUsername,
     basicAuthPassword,
     domain,

--- a/packages/customize-uploader/src/commands/index.ts
+++ b/packages/customize-uploader/src/commands/index.ts
@@ -130,8 +130,9 @@ export async function upload(
 
 export const run = async (
   domain: string,
-  username: string,
-  password: string,
+  username: string | null,
+  password: string | null,
+  oauthToken: string | null,
   basicAuthUsername: string | null,
   basicAuthPassword: string | null,
   manifestFile: string,
@@ -158,6 +159,7 @@ export const run = async (
   const kintoneApiClient = new KintoneApiClient(
     username,
     password,
+    oauthToken,
     basicAuthUsername,
     basicAuthPassword,
     domain,

--- a/packages/customize-uploader/src/commands/index.ts
+++ b/packages/customize-uploader/src/commands/index.ts
@@ -132,7 +132,7 @@ export const run = async (
   domain: string,
   username: string | null,
   password: string | null,
-  oauthToken: string | null,
+  oAuthToken: string | null,
   basicAuthUsername: string | null,
   basicAuthPassword: string | null,
   manifestFile: string,
@@ -159,7 +159,7 @@ export const run = async (
   const kintoneApiClient = new KintoneApiClient(
     username,
     password,
-    oauthToken,
+    oAuthToken,
     basicAuthUsername,
     basicAuthPassword,
     domain,

--- a/packages/customize-uploader/src/params/index.ts
+++ b/packages/customize-uploader/src/params/index.ts
@@ -5,7 +5,7 @@ import { getBoundMessage } from "../messages";
 interface Params {
   username?: string;
   password?: string;
-  oauthToken?: string;
+  oAuthToken?: string;
   baseUrl?: string;
   domain?: string;
   lang: Lang;
@@ -17,7 +17,7 @@ export const inquireParams = ({
   domain,
   baseUrl,
   lang,
-  oauthToken,
+  oAuthToken,
 }: Params) => {
   const m = getBoundMessage(lang);
   const questions = [
@@ -43,7 +43,7 @@ export const inquireParams = ({
       name: "username",
       message: m("Q_UserName"),
       default: username,
-      when: () => !oauthToken && !username,
+      when: () => !oAuthToken && !username,
       validate: (v: string) => !!v,
     },
     {
@@ -51,7 +51,7 @@ export const inquireParams = ({
       name: "password",
       message: m("Q_Password"),
       default: password,
-      when: () => !oauthToken && !password,
+      when: () => !oAuthToken && !password,
       validate: (v: string) => !!v,
     },
   ];

--- a/packages/customize-uploader/src/params/index.ts
+++ b/packages/customize-uploader/src/params/index.ts
@@ -5,6 +5,7 @@ import { getBoundMessage } from "../messages";
 interface Params {
   username?: string;
   password?: string;
+  oauthToken?: string;
   baseUrl?: string;
   domain?: string;
   lang: Lang;
@@ -16,6 +17,7 @@ export const inquireParams = ({
   domain,
   baseUrl,
   lang,
+  oauthToken,
 }: Params) => {
   const m = getBoundMessage(lang);
   const questions = [
@@ -41,7 +43,7 @@ export const inquireParams = ({
       name: "username",
       message: m("Q_UserName"),
       default: username,
-      when: () => !username,
+      when: () => !oauthToken && !username,
       validate: (v: string) => !!v,
     },
     {
@@ -49,7 +51,7 @@ export const inquireParams = ({
       name: "password",
       message: m("Q_Password"),
       default: password,
-      when: () => !password,
+      when: () => !oauthToken && !password,
       validate: (v: string) => !!v,
     },
   ];


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

This is a part of #530

## What

- add `--oauth-token` option and support the `KINTONE_OAUTH_TOKEN` environment value.
- support authorization using an OAuth access token.


## How to test

1. specify the following scopes and generate OAuth access tokens:
    - for upload
      - k:file:write
      - k:app_settings:read
      - k:app_settings:write
    - for import
      - k:file:read
      - k:app_settings:read
1. build and run it.
    ```shell
    $ yarn
    $ cd packages/customize-uploader
    $ yarn build
    $ node bin/cli.js sample/customize-manifest.json --oauth-token YOUR_OAUTH_ACCESS_TOKEN_FOR_UPLOAD
    $ node bin/cli.js import sample/customize-manifest.json --oauth-token YOUR_OAUTH_ACCESS_TOKEN_FOR_IMPORT
    ```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
