### PR TITLE
feat: support HTTP(S)_PROXY and --proxys option  in dts-gen

### DIFF
--- a/packages/dts-gen/docs/how-to-use.md
+++ b/packages/dts-gen/docs/how-to-use.md
@@ -68,6 +68,23 @@ is defined in `sample-fields.d.ts`.
 
 **If you change form settings in kintone, Please re-generate type definition files**
 
+### Proxy support
+
+You can use a proxy server with `--proxy` option.
+
+```bash
+$ kintone-dts-gen --base-url https://***.cybozu.com \
+                 -u username \
+                 -p password \
+                 --proxy http://localhost:8000 \
+                 --app-id 12 \
+                 --type-name SampleFields \
+                 --namespace company.name.types \
+                 -o sample-fields.d.ts
+```
+
+In addition, you can use `HTTP_PROXY` and `HTTPS_PROXY` environment variables instead of the command line option.
+
 ### demo mode
 If you won't have a kintone, you can try with demo mode.
 you can generate demo type definition like below:

--- a/packages/dts-gen/src/cli-parser.ts
+++ b/packages/dts-gen/src/cli-parser.ts
@@ -6,6 +6,7 @@ interface ParsedArgs {
     password: string | null;
     oAuthToken: string | null;
     apiToken: string | null;
+    proxy: string | null;
     proxyHost: string | null;
     proxyPort: string | null;
     basicAuthPassword: string | null;
@@ -93,6 +94,9 @@ export function parse(argv: string[]): ParsedArgs {
             "proxy port",
             null
         )
+        // Axios handles HTTP_PROXY and HTTPS_PROXY natively,
+        // so we don't use the environment variables as the default value
+        .option("--proxy [proxy]", "proxy server", null)
         .option(
             "--basic-auth-username [basicAuthUsername]",
             "A username for basic authentication",
@@ -116,6 +120,7 @@ export function parse(argv: string[]): ParsedArgs {
         password,
         apiToken,
         oauthToken,
+        proxy,
         proxyHost,
         proxyPort,
         basicAuthPassword,
@@ -142,6 +147,7 @@ export function parse(argv: string[]): ParsedArgs {
         password,
         apiToken,
         oAuthToken: oauthToken,
+        proxy,
         proxyHost,
         proxyPort,
         basicAuthPassword,

--- a/packages/dts-gen/src/integration-tests/setup-test-app.ts
+++ b/packages/dts-gen/src/integration-tests/setup-test-app.ts
@@ -12,6 +12,7 @@ program
     .option("-p, --password <password>")
     .option("--proxy-host [proxyHost]", "proxy host", null)
     .option("--proxy-port [proxyPort]", "proxy port", null)
+    .option("--proxy [proxy]", "proxy server", null)
     .option(
         "--basic-auth-username [basicAuthUsername]",
         "username for basic authentication",
@@ -41,6 +42,7 @@ async function handleSetupApp(command) {
         oAuthToken: command.oAuthToken,
         proxyHost: command.proxyHost,
         proxyPort: command.proxyPort,
+        proxy: command.proxy,
         basicAuthUsername: command.basicAuthUsername,
         basicAuthPassword: command.basicAuthPassword,
     };

--- a/packages/dts-gen/src/kintone/clients/axios-utils.test.ts
+++ b/packages/dts-gen/src/kintone/clients/axios-utils.test.ts
@@ -38,7 +38,7 @@ describe("FormsClientImpl#constructor", () => {
         const expectedCalledWith = {
             headers,
             baseURL: baseUrl,
-            proxy: false,
+            proxy: undefined,
         } as AxiosRequestConfig;
         assertConstructorWithArgs(
             input,
@@ -93,7 +93,7 @@ describe("FormsClientImpl#constructor", () => {
         const expectedCalledWith = {
             headers,
             baseURL: baseUrl,
-            proxy: false,
+            proxy: undefined,
         } as AxiosRequestConfig;
         assertConstructorWithArgs(
             input,

--- a/packages/dts-gen/src/kintone/clients/axios-utils.test.ts
+++ b/packages/dts-gen/src/kintone/clients/axios-utils.test.ts
@@ -26,6 +26,7 @@ describe("FormsClientImpl#constructor", () => {
             baseUrl,
             username: "username",
             password: "password",
+            proxy: null,
             proxyHost: null,
             proxyPort: null,
             basicAuthPassword: null,
@@ -46,11 +47,12 @@ describe("FormsClientImpl#constructor", () => {
         );
     });
 
-    test("with proxy", () => {
+    test("with proxyHost and proxyPort option", () => {
         const input = {
             baseUrl,
             username: "username",
             password: "password",
+            proxy: null,
             proxyHost: "proxyHost",
             proxyPort: "1234",
             basicAuthPassword: null,
@@ -74,11 +76,45 @@ describe("FormsClientImpl#constructor", () => {
         );
     });
 
+    test("with proxy option", () => {
+        const input = {
+            baseUrl,
+            username: "username",
+            password: "password",
+            proxy: "http://admin:password@localhost:1234",
+            proxyHost: null,
+            proxyPort: null,
+            basicAuthPassword: null,
+            basicAuthUsername: null,
+        };
+
+        const headers = {
+            "X-Cybozu-Authorization": authToken,
+        };
+        const expectedCalledWith = {
+            headers,
+            baseURL: baseUrl,
+            proxy: {
+                host: "localhost",
+                port: 1234,
+                auth: {
+                    username: "admin",
+                    password: "password",
+                },
+            },
+        };
+        assertConstructorWithArgs(
+            input,
+            expectedCalledWith
+        );
+    });
+
     test("with basic auth", () => {
         const input = {
             baseUrl,
             username: "username",
             password: "password",
+            proxy: null,
             proxyHost: null,
             proxyPort: null,
             basicAuthPassword: "basicUsername",

--- a/packages/dts-gen/src/kintone/clients/axios-utils.ts
+++ b/packages/dts-gen/src/kintone/clients/axios-utils.ts
@@ -20,7 +20,7 @@ export interface NewInstanceInput {
 function newAxiosInstance(
     input: NewInstanceInput
 ): AxiosInstance {
-    let proxy: AxiosProxyConfig | false = false;
+    let proxy: AxiosProxyConfig | undefined;
     if (
         input.proxyHost !== null &&
         input.proxyPort !== null

--- a/packages/dts-gen/src/kintone/clients/axios-utils.ts
+++ b/packages/dts-gen/src/kintone/clients/axios-utils.ts
@@ -9,8 +9,9 @@ export interface NewInstanceInput {
     baseUrl: string;
     username: string | null;
     password: string | null;
-    oAuthToken: string;
-    apiToken: string;
+    oAuthToken: string | null;
+    apiToken: string | null;
+    proxy: string | null;
     proxyHost: string | null;
     proxyPort: string | null;
     basicAuthPassword: string | null;
@@ -21,7 +22,18 @@ function newAxiosInstance(
     input: NewInstanceInput
 ): AxiosInstance {
     let proxy: AxiosProxyConfig | undefined;
-    if (
+    // parse the proxy URL like http://admin:pass@localhost:8000
+    if (input.proxy) {
+        const proxyUrl = new URL(input.proxy);
+        proxy = {
+            host: proxyUrl.hostname,
+            port: parseInt(proxyUrl.port, 10),
+            auth: {
+                username: proxyUrl.username,
+                password: proxyUrl.password,
+            },
+        };
+    } else if (
         input.proxyHost !== null &&
         input.proxyPort !== null
     ) {

--- a/packages/dts-gen/src/kintone/clients/forms-client-impl.test.ts
+++ b/packages/dts-gen/src/kintone/clients/forms-client-impl.test.ts
@@ -74,6 +74,7 @@ describe("FormsClientImpl#fetchFormProperties", () => {
             oAuthToken: null,
             proxyHost: null,
             proxyPort: null,
+            proxy: null,
             basicAuthPassword: null,
             basicAuthUsername: null,
         };


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

This is a part of #530.

<!-- Why do you want the feature and why does it make sense for the package? -->


## What

I've added `HTTPS_PROXY` and `HTTP_PROXY` support in `dts-gen`.
In addition, I've added the `--proxy` option.
`proxyHost` and `proxyPort` are inconsistent with other packages like `customize-uploader` and `plugin-uploader`.
I'll deprecate these command line options in the future.

<!-- What is a solution you want to add? -->


## How to test

<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
