### PR TITLE
fix: add package.json into pkg.exports of rest-api-client

### DIFF
--- a/packages/rest-api-client/package.json
+++ b/packages/rest-api-client/package.json
@@ -82,11 +82,14 @@
     "qs": "^6.9.4"
   },
   "exports": {
-    "node": {
-      "import": "./index.mjs",
-      "require": "./lib/index.js",
-      "default": "./lib/index.js"
+    ".": {
+      "node": {
+        "import": "./index.mjs",
+        "require": "./lib/index.js",
+        "default": "./lib/index.js"
+      },
+      "browser": "./lib/index.browser.js"
     },
-    "browser": "./lib/index.browser.js"
+    "./package.json": "./package.json"
   }
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
package.json of @kintone/rest-api-client cannot be imported like the following code due to #214.
It may break the build system of React Native or so on.
ref: https://github.com/nodejs/node/issues/33460

```javascript
const pkg = require("@kintone/rest-api-client/package.json");
// Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports" 
```

## What

<!-- What is a solution you want to add? -->
package.json is added into the "exports" field in package.json of rest-api-client.

## How to test

<!-- How can we test this pull request? -->
To check added code.
1. checkout this pull request
2. Run `npm link` in js-sdk/packages/rest-api-client directory
3. Run `npm link @kintone/rest-api-client` in the directory you want to try
4. Run `node -p 'require("@kintone/rest-api-client/package.json");'`

To check regression:
1. checkout this pull request
2. Run `npm link` in js-sdk/packages/rest-api-client directory
3. Run `npm link @kintone/rest-api-client` in the directory you want to try
4. Run `node -p 'require("@kintone/rest-api-client").KintoneRestAPIClient.version;'`
5. Bundle rest-api-client with webpack, Rollup, and other bundlers to check `pkg.exports["."].browser`.

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
