### PR TITLE
feat: export error classes to allow users to import them

### DIFF
--- a/packages/rest-api-client/docs/errorHandling.md
+++ b/packages/rest-api-client/docs/errorHandling.md
@@ -2,7 +2,18 @@
 
 - [KintoneRestAPIError](#kintonerestapierror)
 - [KintoneAllRecordsError](#kintoneallrecordserror)
+- [KintoneAbortSearchError](#kintoneabortsearcherror)
 
+
+These errors are exported so that it is available to import and use them like the following.
+
+```javascript
+import {
+  KintoneRestAPIError,
+  KintoneAllRecordsError,
+  KintoneAbortSearchError
+} from "@kintone/rest-api-client";
+```
 ## KintoneRestAPIError
 
 When the API request responds with a status code other than 200, the client raises [`KintoneRestAPIError`](../src/KintoneRestAPIError.ts).

--- a/packages/rest-api-client/docs/errorHandling.md
+++ b/packages/rest-api-client/docs/errorHandling.md
@@ -4,16 +4,16 @@
 - [KintoneAllRecordsError](#kintoneallrecordserror)
 - [KintoneAbortSearchError](#kintoneabortsearcherror)
 
-
 These errors are exported so that it is available to import and use them like the following.
 
 ```javascript
 import {
   KintoneRestAPIError,
   KintoneAllRecordsError,
-  KintoneAbortSearchError
+  KintoneAbortSearchError,
 } from "@kintone/rest-api-client";
 ```
+
 ## KintoneRestAPIError
 
 When the API request responds with a status code other than 200, the client raises [`KintoneRestAPIError`](../src/KintoneRestAPIError.ts).

--- a/packages/rest-api-client/index.mjs
+++ b/packages/rest-api-client/index.mjs
@@ -2,4 +2,9 @@ import module from "module";
 // eslint-disable-next-line node/no-unsupported-features/node-builtins
 const require = module.createRequire(import.meta.url);
 
-export const { KintoneRestAPIClient } = require(".");
+export const {
+  KintoneRestAPIClient,
+  KintoneAbortSearchError,
+  KintoneAllRecordsError,
+  KintoneRestAPIError,
+} = require(".");

--- a/packages/rest-api-client/src/__tests__/index.browser.test.ts
+++ b/packages/rest-api-client/src/__tests__/index.browser.test.ts
@@ -11,5 +11,5 @@ describe("index.browser", () => {
     expect(browser.KintoneAllRecordsError).toBe(KintoneAllRecordsError);
     expect(browser.KintoneRestAPIError).not.toBeUndefined();
     expect(browser.KintoneRestAPIError).toBe(KintoneRestAPIError);
-  })
-})
+  });
+});

--- a/packages/rest-api-client/src/__tests__/index.browser.test.ts
+++ b/packages/rest-api-client/src/__tests__/index.browser.test.ts
@@ -1,0 +1,15 @@
+import * as browser from "../index.browser";
+import { KintoneAbortSearchError } from "../error/KintoneAbortSearchError";
+import { KintoneAllRecordsError } from "../error/KintoneAllRecordsError";
+import { KintoneRestAPIError } from "../error/KintoneRestAPIError";
+
+describe("index.browser", () => {
+  it("should export each error class properly", () => {
+    expect(browser.KintoneAbortSearchError).not.toBeUndefined();
+    expect(browser.KintoneAbortSearchError).toBe(KintoneAbortSearchError);
+    expect(browser.KintoneAllRecordsError).not.toBeUndefined();
+    expect(browser.KintoneAllRecordsError).toBe(KintoneAllRecordsError);
+    expect(browser.KintoneRestAPIError).not.toBeUndefined();
+    expect(browser.KintoneRestAPIError).toBe(KintoneRestAPIError);
+  })
+})

--- a/packages/rest-api-client/src/__tests__/index.test.ts
+++ b/packages/rest-api-client/src/__tests__/index.test.ts
@@ -11,5 +11,5 @@ describe("index", () => {
     expect(index.KintoneAllRecordsError).toBe(KintoneAllRecordsError);
     expect(index.KintoneRestAPIError).not.toBeUndefined();
     expect(index.KintoneRestAPIError).toBe(KintoneRestAPIError);
-  })
-})
+  });
+});

--- a/packages/rest-api-client/src/__tests__/index.test.ts
+++ b/packages/rest-api-client/src/__tests__/index.test.ts
@@ -1,0 +1,15 @@
+import * as index from "../index";
+import { KintoneAbortSearchError } from "../error/KintoneAbortSearchError";
+import { KintoneAllRecordsError } from "../error/KintoneAllRecordsError";
+import { KintoneRestAPIError } from "../error/KintoneRestAPIError";
+
+describe("index", () => {
+  it("should export each error class properly", () => {
+    expect(index.KintoneAbortSearchError).not.toBeUndefined();
+    expect(index.KintoneAbortSearchError).toBe(KintoneAbortSearchError);
+    expect(index.KintoneAllRecordsError).not.toBeUndefined();
+    expect(index.KintoneAllRecordsError).toBe(KintoneAllRecordsError);
+    expect(index.KintoneRestAPIError).not.toBeUndefined();
+    expect(index.KintoneRestAPIError).toBe(KintoneRestAPIError);
+  })
+})

--- a/packages/rest-api-client/src/error/index.ts
+++ b/packages/rest-api-client/src/error/index.ts
@@ -1,0 +1,3 @@
+export * from "./KintoneAbortSearchError";
+export * from "./KintoneAllRecordsError";
+export * from "./KintoneRestAPIError";

--- a/packages/rest-api-client/src/index.browser.ts
+++ b/packages/rest-api-client/src/index.browser.ts
@@ -4,3 +4,4 @@ import * as browserDeps from "./platform/browser";
 injectPlatformDeps(browserDeps);
 
 export { KintoneRestAPIClient } from "./KintoneRestAPIClient";
+export * from "./error";

--- a/packages/rest-api-client/src/index.ts
+++ b/packages/rest-api-client/src/index.ts
@@ -4,6 +4,7 @@ import * as nodeDeps from "./platform/node";
 injectPlatformDeps(nodeDeps);
 
 export { KintoneRestAPIClient } from "./KintoneRestAPIClient";
+export * from "./error";
 export * as KintoneRecordField from "./KintoneFields/exportTypes/field";
 export * as KintoneFormLayout from "./KintoneFields/exportTypes/layout";
 export * as KintoneFormFieldProperty from "./KintoneFields/exportTypes/property";


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## TODO
- [x] add tests for error exported from index.ts
- [x] add documents to indicate how to import error classes

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
This allows users to import error classes like KintoneRestAPIError so that they can use them to check which error like the following code and to do other things.

```javascript
import { KintoneRestAPIClient, KintoneRestAPIError } from "@kintone/rest-api-client";

try {
  const client = new KintoneRestAPIClient(baseUrl, auth);
  const records = client.record.getRecord({ app, id });
  // do something with the records variables
} catch (e) {
  if (e instanceof KintoneRestAPIError) {
    // do something if the error is KintoneRestAPIError
  }
}
```

## What

<!-- What is a solution you want to add? -->
Classes in `src/error` are exported as a named export in index.ts or some entry points.

## How to test

<!-- How can we test this pull request? -->

```
yarn test
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
