### PR TITLE
chore: print a warning message about deprecated of customize uploader

### DIFF
--- a/packages/customize-uploader/README.md
+++ b/packages/customize-uploader/README.md
@@ -15,7 +15,7 @@ A kintone customize uploader
 dest/customize-manifest.json file has been created
 
 % ./node_modules/.bin/kintone-customize-uploader import dest/customize-manifest.json
-? Input your kintone's domain (example.cybozu.com): {yourDomain}
+? Input your kintone's base URL (https://example.cybozu.com): {kintoneBaseUrl}
 ? Input your username: {userLoginName}
 ? Input your password: [input is hidden] {yourPassword}
 
@@ -38,7 +38,7 @@ or
 dest/customize-manifest.json file has been created
 
 % kintone-customize-uploader import dest/customize-manifest.json
-? Input your kintone's domain (example.cybozu.com): {yourDomain}
+? Input your kintone's base URL (https://example.cybozu.com): {kintoneBaseUrl}
 ? Input your username: {userLoginName}
 ? Input your password: [input is hidden] {yourPassword}
 
@@ -61,7 +61,7 @@ If you want to upload the customize files automatically when a file is updated, 
     $ kintone-customize-uploader <manifestFile>
   Options
     --base-url Base-url of your kintone
-    --domain Domain of your kintone (If you set --base-url, this value is not necessary.)
+    --domain Domain of your kintone (This value is deprecated. Please you use --base-url.)
     --username Login username
     --password User's password
     --oauth-token OAuth access token (If you set a set of --username and --password, this value is not necessary.)
@@ -82,7 +82,7 @@ If you want to upload the customize files automatically when a file is updated, 
 
     You can set the values through environment variables
     base-url: KINTONE_BASE_URL
-    domain: KINTONE_DOMAIN (If you set `base-url`, this value is not necessary.)
+    domain: KINTONE_DOMAIN (This value is deprecated. Please you use KINTONE_BASE_URL.)
     username: KINTONE_USERNAME
     password: KINTONE_PASSWORD
     oauth-token: KINTONE_OAUTH_TOKEN (If you set a set of username and password, this value is not necessary.)
@@ -94,7 +94,7 @@ If you want to upload the customize files automatically when a file is updated, 
 If you omit the options, you can input the options interactively.
 ```
 % kintone-customize-uploader dest/customize-manifest.json
-? Input your domain: example.cybozu.com
+? Input your kintone's base URL: https://example.cybozu.com
 ? Input your username: sato
 ? Input your password: [hidden]
 ```
@@ -138,7 +138,7 @@ This is an example of `customize-manifest.json` .
 To upload files, run `kintone-customize-uploader <manifestFile>`.
 ```
 % kintone-customize-uploader dest/customize-manifest.json
-? Input your domain: example.cybozu.com
+? Input your kintone's base URL: https://example.cybozu.com
 ? Input your username: sato
 ? Input your password: [hidden]
 

--- a/packages/customize-uploader/README.md
+++ b/packages/customize-uploader/README.md
@@ -61,7 +61,7 @@ If you want to upload the customize files automatically when a file is updated, 
     $ kintone-customize-uploader <manifestFile>
   Options
     --base-url Base-url of your kintone
-    --domain Domain of your kintone (This value is deprecated. Please you use --base-url.)
+    --domain Domain of your kintone (This value is deprecated. Please use --base-url.)
     --username Login username
     --password User's password
     --oauth-token OAuth access token (If you set a set of --username and --password, this value is not necessary.)
@@ -82,7 +82,7 @@ If you want to upload the customize files automatically when a file is updated, 
 
     You can set the values through environment variables
     base-url: KINTONE_BASE_URL
-    domain: KINTONE_DOMAIN (This value is deprecated. Please you use KINTONE_BASE_URL.)
+    domain: KINTONE_DOMAIN (This value is deprecated. Please use KINTONE_BASE_URL.)
     username: KINTONE_USERNAME
     password: KINTONE_PASSWORD
     oauth-token: KINTONE_OAUTH_TOKEN (If you set a set of username and password, this value is not necessary.)

--- a/packages/customize-uploader/bin/cli.js
+++ b/packages/customize-uploader/bin/cli.js
@@ -148,6 +148,10 @@ if (!isInitCommand && !manifestFile) {
   process.exit(1);
 }
 
+if (domain) {
+  console.warn(getMessage(lang, "W_Deprecated_domain"));
+}
+
 if (isInitCommand) {
   inquireInitParams(lang)
     .then((initParams) => {

--- a/packages/customize-uploader/bin/cli.js
+++ b/packages/customize-uploader/bin/cli.js
@@ -25,7 +25,7 @@ const cli = meow(
     $ kintone-customize-uploader <manifestFile>
   Options
     --base-url Base-url of your kintone
-    --domain Domain of your kintone (This value is deprecated. Please you use base-url.)
+    --domain Domain of your kintone (This value is deprecated. Please use --base-url.)
     --username Login username
     --password User's password
     --oauth-token OAuth access token (If you set a set of --username and --password, this value is not necessary.)
@@ -46,7 +46,7 @@ const cli = meow(
 
     You can set the values through environment variables
     base-url: KINTONE_BASE_URL
-    domain: KINTONE_DOMAIN (This value is deprecated. Please you use KINTONE_BASE_URL.)
+    domain: KINTONE_DOMAIN (This value is deprecated. Please use KINTONE_BASE_URL.)
     username: KINTONE_USERNAME
     password: KINTONE_PASSWORD
     oauth-token: KINTONE_OAUTH_TOKEN (If you set a set of username and password, this value is not necessary.)

--- a/packages/customize-uploader/bin/cli.js
+++ b/packages/customize-uploader/bin/cli.js
@@ -25,7 +25,7 @@ const cli = meow(
     $ kintone-customize-uploader <manifestFile>
   Options
     --base-url Base-url of your kintone
-    --domain Domain of your kintone (If you set --base-url, this value is not necessary.)
+    --domain Domain of your kintone (This value is deprecated. Please you use base-url.)
     --username Login username
     --password User's password
     --oauth-token OAuth access token (If you set a set of --username and --password, this value is not necessary.)
@@ -46,7 +46,7 @@ const cli = meow(
 
     You can set the values through environment variables
     base-url: KINTONE_BASE_URL
-    domain: KINTONE_DOMAIN (If you set base-url, this value is not necessary.)
+    domain: KINTONE_DOMAIN (This value is deprecated. Please you use KINTONE_BASE_URL.)
     username: KINTONE_USERNAME
     password: KINTONE_PASSWORD
     oauth-token: KINTONE_OAUTH_TOKEN (If you set a set of username and password, this value is not necessary.)

--- a/packages/customize-uploader/src/messages.ts
+++ b/packages/customize-uploader/src/messages.ts
@@ -105,6 +105,12 @@ const messages = {
     ja:
       "エラーが発生しました。引数の値と、マニフェストファイルに正しい値が入力されているか確認してください",
   },
+  W_Deprecated_domain: {
+    en:
+      "The --domain option and KINTONE_DOMAIN are deprecated and will be removed in the next major release. Please use --base-url or KINTONE_BASE_URL instead.",
+    ja:
+      "--domain オプションおよび KINTONE_DOMAIN は非推奨となり、次のメジャーリリースで削除されます。代わりに --base-url や KINTONE_BASE_URL を使用してください",
+  },
 } as const;
 
 /**

--- a/packages/customize-uploader/src/messages.ts
+++ b/packages/customize-uploader/src/messages.ts
@@ -5,11 +5,6 @@ const messages = {
     en: "Please specify manifest file",
     ja: "マニフェストファイルを指定してください",
   },
-  // TODO: remove Q_Domain when `domain` option is deprecated.
-  Q_Domain: {
-    en: "Input your kintone's domain (example.cybozu.com):",
-    ja: "kintoneのドメインを入力してください (example.cybozu.com):",
-  },
   Q_BaseUrl: {
     en: "Input your kintone's base URL (https://example.cybozu.com):",
     ja: "kintoneのベースURLを入力してください (https://example.cybozu.com):",

--- a/packages/customize-uploader/src/params/index.ts
+++ b/packages/customize-uploader/src/params/index.ts
@@ -21,21 +21,12 @@ export const inquireParams = ({
 }: Params) => {
   const m = getBoundMessage(lang);
   const questions = [
-    // TODO: remove domain when domain is deprecated
-    {
-      type: "input",
-      message: m("Q_Domain"),
-      name: "domain",
-      default: domain,
-      when: () => !baseUrl && !domain,
-      validate: (v: string) => !!v,
-    },
     {
       type: "input",
       message: m("Q_BaseUrl"),
       name: "baseUrl",
       default: baseUrl,
-      when: (v: inquirer.Answers) => !baseUrl && !domain && !v.domain,
+      when: () => !baseUrl && !domain,
       validate: (v: string) => !!v,
     },
     {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

This is a part of #530

## What

- print a warning message if user specifies `--domain` or `KINTONE_DOMAIN`.
- In interactive CLI, ask base-url instead of domain

## How to test

- execute `bin/cli.js dest/customize-manifest.json` with `--base-url` option or `KINTONE_DOMAIN`
- execute `bin/cli.js dest/customize-manifest.json` without setting of kintone environment 

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
