### PR TITLE
fix: Fixed deprecated waitFor ()

### DIFF
--- a/packages/plugin-uploader/src/index.ts
+++ b/packages/plugin-uploader/src/index.ts
@@ -41,7 +41,7 @@ async function readyForUpload(
   console.log(`Open ${loginUrl}`);
   await page.goto(loginUrl);
   try {
-    await page.waitFor(".form-username-slash", { timeout: TIMEOUT_MS });
+    await page.waitForSelector(".form-username-slash", { timeout: TIMEOUT_MS });
   } catch (e) {
     throw chalk.red(m("Error_cannotOpenLogin"));
   }


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
waitFor has been deprecated in puppeteer.

See https://github.com/puppeteer/puppeteer/issues/6214


## Checklist

- [X] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [X] Updated documentation if it is required.
- [X] Added tests if it is required.
- [X] Passed `yarn lint` and `yarn test` on the root directory.
