### PR TITLE
ci: run GitHub Actions for branch push by Renovate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,9 @@ name: lint
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - 'renovate/**'
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,9 @@ name: test
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - 'renovate/**'
   pull_request:
 
 jobs:


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Currently, Renovate doesn't work as I expected. The reason is that we only run GItHub Actions for branches that has a PR, which causes a pending commit status and Renovate skips creating a PR due to the status.

## What

I've changed to run GitHub Actions for branches that Renovate creates.

<!-- What is a solution you want to add? -->


## How to test

<!-- How can we test this pull request? -->

## Checklist

- [x ] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [] Updated documentation if it is required.
- [] Added tests if it is required.
- [] Passed `yarn lint` and `yarn test` on the root directory.
