### PR TITLE
chore: clean dependencies for plugin-manifest-validator

### DIFF
--- a/packages/plugin-manifest-validator/package.json
+++ b/packages/plugin-manifest-validator/package.json
@@ -24,14 +24,12 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "@types/bytes": "^3.1.0",
     "ajv": "^6.12.6",
-    "bytes": "^3.1.0",
-    "rimraf": "^3.0.2",
-    "ts-node": "^9.1.1"
+    "bytes": "^3.1.0"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.12.7",
+    "@types/bytes": "^3.1.0",
     "intelli-espower-loader": "^1.0.1",
     "json-schema-to-typescript": "^10.1.3",
     "power-assert": "^1.6.1"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Maybe `ts-node` and` rimraf` do not have to be in the `dependencies` of plugin-manifest-validator.
`@types/bytes` should be in the `devDependencies`, not `dependencies`

## What

<!-- What is a solution you want to add? -->

- Remove `ts-node` and `rimraf` from `dependencies`.
- Move `@types/bytes` to `devDependencies` from `dependencies`.

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
