### PR TITLE
docs: add short description of rest-api-client on README

### DIFF
--- a/packages/rest-api-client/README.md
+++ b/packages/rest-api-client/README.md
@@ -2,6 +2,9 @@
 
 [![npm version](https://badge.fury.io/js/%40kintone%2Frest-api-client.svg)](https://badge.fury.io/js/%40kintone%2Frest-api-client)
 
+API client for Kintone REST API.
+It supports both browser environment (Kintone customization & plugin) and Node.js environment.
+
 - [Installation](#installation)
 - [Browsers support](#browsers-support)
 - [Usage](#usage)


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
Since README is displayed in [npm package's page](https://www.npmjs.com/package/@kintone/rest-api-client),
it's useful for users to add short description on top of README so that they can quickly know what this library is.


<!-- Why do you want the feature and why does it make sense for the package? -->

## What

<!-- What is a solution you want to add? -->
Added short description on top of README 


## How to test

<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `yarn lint` and `yarn test` on the root directory.
