### PR TITLE
fix: undefined check for guestSpaceId of rest-api-client

### DIFF
--- a/packages/rest-api-client/src/url.ts
+++ b/packages/rest-api-client/src/url.ts
@@ -4,7 +4,7 @@ export const buildPath = (params: {
   preview?: boolean;
 }) => {
   const { endpointName, guestSpaceId, preview } = params;
-  const guestPath = guestSpaceId !== undefined ? `/guest/${guestSpaceId}` : "";
+  const guestPath = guestSpaceId ? `/guest/${guestSpaceId}` : "";
   const previewPath = preview ? "/preview" : "";
   return `/k${guestPath}/v1${previewPath}/${endpointName}.json`;
 };


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

In our team, we often write code that looks like this

```js
const Apps = {
  isGuestSpace: false,
  spaceId: 32,

  user: 126,
  order: 127,
  billing: 128,
};
const client = new KintoneRestAPIClient({ guestSpaceId: Apps.isGuestSpace ? Apps.spaceId : undefined })
```

We want you to treat not only `undefined`, but also `null` and `''` in the same way.

```js
const client = new KintoneRestAPIClient({ guestSpaceId: Apps.isGuestSpace ? Apps.spaceId : null })
const client = new KintoneRestAPIClient({ guestSpaceId: Apps.isGuestSpace ? Apps.spaceId : '' })
```

## What

```diff
-  guestSpaceId !== undefined ? xxx : yyy
+  guestSpaceId ? xxx : yyy
```

## How to test

```js
expect(new KintoneRestAPIClient().record.client.guestSpaceId).toBe(undefined)
expect(new KintoneRestAPIClient({ guestSpaceId: undefined }).record.client.guestSpaceId).toBe(undefined)
expect(new KintoneRestAPIClient({ guestSpaceId: null }).record.client.guestSpaceId).toBe(undefined)
expect(new KintoneRestAPIClient({ guestSpaceId: '' }).record.client.guestSpaceId).toBe(undefined)
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
