### PR TITLE
chore: fix the way to use cybozu/renovate-config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "@cybozu"
+    "github>cybozu/renovate-config"
   ],
   "ignorePaths": [
     "**/node_modules/**",


### PR DESCRIPTION

<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

We use `cybozu/renovate-config` as `@cybozu`, but it's not an official way that the document describes.
https://docs.renovatebot.com/config-presets/

So I've updated the way.

## What

<!-- What is a solution you want to add? -->


## How to test

<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `yarn lint` and `yarn test` on the root directory.
