### PR TITLE
refactor: update JSON Schema version from draft4 to draft7

### DIFF
--- a/packages/plugin-manifest-validator/manifest-schema.json
+++ b/packages/plugin-manifest-validator/manifest-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "kintone plugin manifest.json",
   "type": "object",
   "additionalProperties": false,
@@ -153,7 +153,7 @@
   ],
   "definitions": {
     "resources": {
-      "id": "#resources",
+      "$id": "#resources",
       "type": "array",
       "uniqueItems": true,
       "items": {

--- a/packages/plugin-manifest-validator/src/index.ts
+++ b/packages/plugin-manifest-validator/src/index.ts
@@ -1,7 +1,6 @@
 "use strict";
 
 import Ajv from "ajv";
-import v4metaSchema from "ajv/lib/refs/json-schema-draft-04.json";
 import bytes from "bytes";
 import jsonSchema from "../manifest-schema.json";
 import validateUrl from "./validate-https-url";
@@ -29,8 +28,6 @@ module.exports = function (
     maxFileSize = options.maxFileSize;
   }
   const ajv = new Ajv({
-    schemaId: "auto", // for draft-04
-    meta: false, // don't load draft-07 meta schema
     allErrors: true,
     unknownFormats: true,
     errorDataPath: "property",
@@ -41,11 +38,6 @@ module.exports = function (
     },
   });
 
-  // Using draft-04 schemas
-  // https://github.com/epoberezkin/ajv/releases/tag/5.0.0
-  ajv.addMetaSchema(v4metaSchema);
-  // @ts-expect-error TODO: capture ajv-validator/ajv issue(https://github.com/ajv-validator/ajv/issues/1253)
-  ajv._opts.defaultMeta = v4metaSchema.id;
   ajv.removeKeyword("propertyNames");
   ajv.removeKeyword("contains");
   ajv.removeKeyword("const");


### PR DESCRIPTION
**BREAKING CHANGE: bump the JSON Schema version from draft4 to draft7**
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

`ajv` has dropped the support for JSON Schema draft4, so we have to update the version.

https://ajv.js.org/

## What

I'v updated the version from `draft4` to `draft7`.

<!-- What is a solution you want to add? -->

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
