### PR TITLE
docs(data-loader): options in data-loader's readme

### DIFF
--- a/packages/data-loader/README.md
+++ b/packages/data-loader/README.md
@@ -36,7 +36,8 @@ import \
 Options:
   --base-url             Kintone Base Url           [default: process.env.KINTONE_BASE_URL]
   --username, -u         Kintone Username           [default: process.env.KINTONE_USERNAME]
-  --password, -p         Kintone Password           [default: process.env.KINTONE_USERNAME]
+  --password, -p         Kintone Password           [default: process.env.KINTONE_PASSWORD]
+  --api-token            App's API token
   --basic-auth-username  Kintone Basic Auth Username
   --basic-auth-password  Kintone Basic Auth Password
   --app                  The ID of the app
@@ -66,12 +67,13 @@ export \
 Options:
   --base-url             Kintone Base Url           [default: process.env.KINTONE_BASE_URL]
   --username, -u         Kintone Username           [default: process.env.KINTONE_USERNAME]
-  --password, -p         Kintone Password           [default: process.env.KINTONE_USERNAME]
+  --password, -p         Kintone Password           [default: process.env.KINTONE_PASSWORD]
+  --api-token            App's API token
   --basic-auth-username  Kintone Basic Auth Username
   --basic-auth-password  Kintone Basic Auth Password
   --app                  The ID of the app
   --guest-space-id       The ID of guest space
-  --attachment-dir       Attachment file directory
+  --attachment-dir       Attachment file directory  [string]
   --format               Output format              [default: "json"]
   --query, -q            The query string
   --pfx-file-path        The path to client certificate file

--- a/packages/data-loader/README.md
+++ b/packages/data-loader/README.md
@@ -68,7 +68,6 @@ Options:
   --base-url             Kintone Base Url            [default: process.env.KINTONE_BASE_URL]
   --username, -u         Kintone Username            [default: process.env.KINTONE_USERNAME]
   --password, -p         Kintone Password            [default: process.env.KINTONE_PASSWORD]
-  --api-token            App's API token
   --api-token            App's API token             [default: process.env.KINTONE_API_TOKEN]
   --basic-auth-username  Kintone Basic Auth Username [default: process.env.KINTONE_BASIC_AUTH_USERNAME]
   --basic-auth-password  Kintone Basic Auth Password [default: process.env.KINTONE_BASIC_AUTH_PASSWORD]

--- a/packages/data-loader/README.md
+++ b/packages/data-loader/README.md
@@ -34,14 +34,14 @@ import \
 
 ```
 Options:
-  --base-url             Kintone Base Url           [default: process.env.KINTONE_BASE_URL]
-  --username, -u         Kintone Username           [default: process.env.KINTONE_USERNAME]
-  --password, -p         Kintone Password           [default: process.env.KINTONE_PASSWORD]
-  --api-token            App's API token
-  --basic-auth-username  Kintone Basic Auth Username
-  --basic-auth-password  Kintone Basic Auth Password
+  --base-url             Kintone Base Url            [default: process.env.KINTONE_BASE_URL]
+  --username, -u         Kintone Username            [default: process.env.KINTONE_USERNAME]
+  --password, -p         Kintone Password            [default: process.env.KINTONE_PASSWORD]
+  --api-token            App's API token             [default: process.env.KINTONE_API_TOKEN]
+  --basic-auth-username  Kintone Basic Auth Username [default: process.env.KINTONE_BASIC_AUTH_USERNAME]
+  --basic-auth-password  Kintone Basic Auth Password [default: process.env.KINTONE_BASIC_AUTH_PASSWORD]
   --app                  The ID of the app
-  --guest-space-id       The ID of guest space
+  --guest-space-id       The ID of guest space       [default: process.env.KINTONE_GUEST_SPACE_ID]
   --file-path            File path
   --pfx-file-path        The path to client certificate file
   --pfx-file-password    The password of client certificate file
@@ -65,16 +65,17 @@ export \
 
 ```
 Options:
-  --base-url             Kintone Base Url           [default: process.env.KINTONE_BASE_URL]
-  --username, -u         Kintone Username           [default: process.env.KINTONE_USERNAME]
-  --password, -p         Kintone Password           [default: process.env.KINTONE_PASSWORD]
+  --base-url             Kintone Base Url            [default: process.env.KINTONE_BASE_URL]
+  --username, -u         Kintone Username            [default: process.env.KINTONE_USERNAME]
+  --password, -p         Kintone Password            [default: process.env.KINTONE_PASSWORD]
   --api-token            App's API token
-  --basic-auth-username  Kintone Basic Auth Username
-  --basic-auth-password  Kintone Basic Auth Password
+  --api-token            App's API token             [default: process.env.KINTONE_API_TOKEN]
+  --basic-auth-username  Kintone Basic Auth Username [default: process.env.KINTONE_BASIC_AUTH_USERNAME]
+  --basic-auth-password  Kintone Basic Auth Password [default: process.env.KINTONE_BASIC_AUTH_PASSWORD]
   --app                  The ID of the app
-  --guest-space-id       The ID of guest space
-  --attachment-dir       Attachment file directory  [string]
-  --format               Output format              [default: "json"]
+  --guest-space-id       The ID of guest space       [default: process.env.KINTONE_GUEST_SPACE_ID]
+  --attachment-dir       Attachment file directory   [string]
+  --format               Output format               [default: "json"]
   --query, -q            The query string
   --pfx-file-path        The path to client certificate file
   --pfx-file-password    The password of client certificate file


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
The default value for the `--password` option indicated in README is incorrect.
Also, the `--api-token` option is not listed in README even though it exists as an option.

## What

<!-- What is a solution you want to add? -->
The default value for the `--password` option in README was fixed.
The `--api-token` option was listed.

## How to test

<!-- How can we test this pull request? -->

```
$ yarn lint
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
