### PR TITLE
docs: add data-loader to root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repository is a monorepo for Kintone development tools!
 | [@kintone/webpack-plugin-kintone-plugin](packages/webpack-plugin-kintone-plugin) | A webpack plugin to create a plugin zip of Kintone | [![npm version](https://badge.fury.io/js/%40kintone%2Fwebpack-plugin-kintone-plugin.svg)](https://badge.fury.io/js/%40kintone%2Fwebpack-plugin-kintone-plugin) |
 | [@kintone/plugin-uploader](packages/plugin-uploader) | A kintone plugin uploader using puppeteer | [![npm version](https://badge.fury.io/js/%40kintone%2Fplugin-uploader.svg)](https://badge.fury.io/js/%40kintone%2Fplugin-uploader) |
 | [@kintone/dts-gen](packages/dts-gen) | A tool for generating type definitions for your Kintone apps | [![npm version](https://badge.fury.io/js/%40kintone%2Fdts-gen.svg)](https://badge.fury.io/js/%40kintone%2Fdts-gen) |
+| [@kintone/data-loader](packages/data-loader) | A kintone record importer and exporter. | [![npm version](https://badge.fury.io/js/%40kintone%2Fdata-loader.svg)](https://badge.fury.io/js/%40kintone%2Fdata-loader) |
 
 ## Contribution Guide
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
data-loader has already been published. That's why the data-loader can be listed in root README.

## What

<!-- What is a solution you want to add? -->
The link for the data-loader directory is added to root README.

## How to test

<!-- How can we test this pull request? -->

```
yarn lint
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
