### PR TITLE
test: run build script before tests in main.test.ts of data-loader

### DIFF
--- a/packages/data-loader/src/__tests__/main.test.ts
+++ b/packages/data-loader/src/__tests__/main.test.ts
@@ -23,10 +23,8 @@ const checkRejectArg = ({
 };
 
 describe("main", () => {
-  beforeEach(() => {
-    if (!fs.existsSync(mainFilePath)) {
-      execSync("npm run build");
-    }
+  beforeAll(() => {
+    execSync("npm run build");
   });
   it("should throw error when no commands are passed", () => {
     return checkRejectArg({


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
Test for data-loader fails if it is not built.

## What

<!-- What is a solution you want to add? -->
main.test.ts is fixed to run `npm run build` before tests in the test suite"

## How to test

<!-- How can we test this pull request? -->

```
yarn test
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
