### PR TITLE
feat(plugin-manifest-validator): Generate declaration file for TS interface

### DIFF
--- a/packages/plugin-manifest-validator/babel.config.js
+++ b/packages/plugin-manifest-validator/babel.config.js
@@ -3,4 +3,5 @@ module.exports = {
     ["@babel/preset-env", { targets: { node: "current" } }],
     "@babel/preset-typescript",
   ],
+  plugins: ["babel-plugin-replace-ts-export-assignment"]
 };

--- a/packages/plugin-manifest-validator/package.json
+++ b/packages/plugin-manifest-validator/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@babel/preset-typescript": "^7.12.13",
     "@types/bytes": "^3.1.0",
+    "babel-plugin-replace-ts-export-assignment": "^0.0.2",
     "intelli-espower-loader": "^1.0.1",
     "json-schema-to-typescript": "^10.1.3",
     "power-assert": "^1.6.1"

--- a/packages/plugin-manifest-validator/package.json
+++ b/packages/plugin-manifest-validator/package.json
@@ -11,6 +11,7 @@
     "manifest-schema.json",
     "dist"
   ],
+  "types": "dist/src/index.d.ts",
   "scripts": {
     "start": "tsc -w",
     "build": "yarn clean && tsc",

--- a/packages/plugin-manifest-validator/src/index.ts
+++ b/packages/plugin-manifest-validator/src/index.ts
@@ -16,7 +16,7 @@ type ValidateResult = {
  * @param {Object=} options
  * @return {{valid: boolean, errors: Array<!Object>}} errors is null if valid
  */
-module.exports = function (
+export = function (
   json: Record<string, any>,
   options: { [s: string]: (...args: any) => boolean } = {}
 ): ValidateResult {

--- a/packages/plugin-manifest-validator/tsconfig.json
+++ b/packages/plugin-manifest-validator/tsconfig.json
@@ -8,7 +8,7 @@
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -3373,6 +3373,11 @@ babel-plugin-jest-hoist@^26.6.2:
     "@types/babel__core" "^7.0.0"
     "@types/babel__traverse" "^7.0.6"
 
+babel-plugin-replace-ts-export-assignment@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-replace-ts-export-assignment/-/babel-plugin-replace-ts-export-assignment-0.0.2.tgz#927a30ba303fcf271108980a8d4f80a693e1d53f"
+  integrity sha512-BiTEG2Ro+O1spuheL5nB289y37FFmz0ISE6GjpNCG2JuA/WNcuEHSYw01+vN8quGf208sID3FnZFDwVyqX18YQ==
+
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.0.tgz#cf5feef29551253471cfa82fc8e0f5063df07a77"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Because it's Nodejs API is inconvenient when using from TypeScript.

## What

<!-- What is a solution you want to add? -->

Generate and ship type definition file via `declaration` option in `tsconfig.json`.

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
