### PR TITLE
chore(data-loader): download attachments sequentially

### DIFF
--- a/packages/data-loader/package.json
+++ b/packages/data-loader/package.json
@@ -62,7 +62,6 @@
   "dependencies": {
     "@kintone/rest-api-client": "^1.9.0",
     "csv-parse": "^4.15.1",
-    "p-queue": "^6.6.2",
     "yargs": "^15.4.1"
   }
 }

--- a/packages/data-loader/src/controllers/export.ts
+++ b/packages/data-loader/src/controllers/export.ts
@@ -1,6 +1,5 @@
 import { promises as fs } from "fs";
 import path from "path";
-import PQueue from "p-queue";
 
 import { KintoneRestAPIClient } from "@kintone/rest-api-client";
 import { AppID, Record } from "@kintone/rest-api-client/lib/client/types";
@@ -43,21 +42,15 @@ export async function exportRecords(
   if (!attachmentDir) {
     return records;
   }
+
   // download attachments if exists
-  const fetchFiles = async (record: Record) => {
+  for (const record of records) {
     const fileInfos = getFileInfos(record);
     for (const fileInfo of fileInfos) {
       await downloadAttachments(apiClient, record, attachmentDir, fileInfo);
     }
-  };
-  const queue = new PQueue({ concurrency: 5 });
-  await queue.addAll(
-    records.map((record: Record) => {
-      return () => {
-        return fetchFiles(record);
-      };
-    })
-  );
+  }
+
   return records;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5828,7 +5828,7 @@ eventemitter3@^3.1.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
   integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
-eventemitter3@^4.0.0, eventemitter3@^4.0.4:
+eventemitter3@^4.0.0:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
@@ -9769,14 +9769,6 @@ p-queue@^4.0.0:
   dependencies:
     eventemitter3 "^3.1.0"
 
-p-queue@^6.6.2:
-  version "6.6.2"
-  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
-  integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==
-  dependencies:
-    eventemitter3 "^4.0.4"
-    p-timeout "^3.2.0"
-
 p-reduce@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
@@ -9788,13 +9780,6 @@ p-retry@^3.0.1:
   integrity sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==
   dependencies:
     retry "^0.12.0"
-
-p-timeout@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
-  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
-  dependencies:
-    p-finally "^1.0.0"
 
 p-try@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
For performance reason, we want to avoid downloading attachments concurrently.

## What

<!-- What is a solution you want to add? -->


## How to test

- Create a Kintone app, insert records, and upload attachments to some of the records
- Run the following commands:

```zsh
$ cd packages/data-loader
$ yarn build
$ node cli.js export --app=<APP_ID> --attachment-dir=foo # and username, password, base-url
```

- Then check the attachments are downloaded

<!-- How can we test this pull request? -->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `yarn lint` and `yarn test` on the root directory.
