### PR TITLE
feat(plugin-uploader): print a deprecated message with warning

### DIFF
--- a/packages/plugin-uploader/README.md
+++ b/packages/plugin-uploader/README.md
@@ -9,7 +9,7 @@ A kintone plugin uploader using [puppeteer](https://github.com/GoogleChrome/pupp
 ```
 % npm install @kintone/plugin-uploader
 % ./node_modules/.bin/kintone-plugin-uploader
---domain ${yourDomain} \
+--base-url ${yourKintoneBaseUrl} \
 --username ${yourLoginName} \
 --password ${yourPassword} \
 ${pluginZipPath}
@@ -20,7 +20,7 @@ or
 ```
 % npm install -g @kintone/plugin-uploader
 % kintone-plugin-uploader \
---domain ${yourDomain} \
+--base-url ${yourKintoneBaseUrl} \
 --username ${yourLoginName} \
 --password ${yourPassword} \
 ${pluginZipPath}
@@ -30,7 +30,7 @@ If you want to upload the plugin automatically when the plugin is updated, you c
 
 ```
 % kintone-plugin-uploader \
---domain ${yourDomain} \
+--base-url ${yourKintoneBaseUrl} \
 --username ${yourLoginName} \
 --password ${yourPassword} \
 --watch \

--- a/packages/plugin-uploader/README.md
+++ b/packages/plugin-uploader/README.md
@@ -47,7 +47,7 @@ You can create a project based on `@kintone/plugin-packer` using [@kintone/creat
     $ kintone-plugin-uploader <pluginPath>
   Options
     --base-url Base-url of your kintone
-    --domain Domain of your kintone (If you set '--base-url', this value is not necessary.)
+    --domain Domain of your kintone (This value is deprecated. Please use --base-url.)
     --username Login username
     --password User's password
     --proxy Proxy server
@@ -58,7 +58,7 @@ You can create a project based on `@kintone/plugin-packer` using [@kintone/creat
 
     You can set the values through environment variables
     base-url: KINTONE_BASE_URL
-    domain: KINTONE_DOMAIN (If you set 'base-url', this value is not necessary.)
+    domain: KINTONE_DOMAIN (This value is deprecated. Please you KINTONE_BASE_URL.)
     username: KINTONE_USERNAME
     password: KINTONE_PASSWORD
     basic-auth-username: KINTONE_BASIC_AUTH_USERNAME
@@ -72,7 +72,7 @@ If you ommit the options, you can input the options interactively.
 % kintone-plugin-uploader plugin.zip
 ? Input your username: hoge
 ? Input your password: [hidden]
-? Input your domain: example.com
+? Input your kintone's base URL: https://example.cybozu.com
 ```
 
 ## LICENSE

--- a/packages/plugin-uploader/bin/cli.js
+++ b/packages/plugin-uploader/bin/cli.js
@@ -26,7 +26,7 @@ const cli = meow(
     $ kintone-plugin-uploader <pluginPath>
   Options
     --base-url Base-url of your kintone
-    --domain Domain of your kintone (If you set '--base-url', this value is not necessary.)
+    --domain Domain of your kintone (This value is deprecated. Please use --base-url.)
     --username Login username
     --password User's password
     --proxy Proxy server
@@ -38,7 +38,7 @@ const cli = meow(
 
     You can set the values through environment variables
     base-url: KINTONE_BASE_URL
-    domain: KINTONE_DOMAIN (If you set 'base-url', this value is not necessary.)
+    domain: KINTONE_DOMAIN (This value is deprecated. Please you KINTONE_BASE_URL.)
     username: KINTONE_USERNAME
     password: KINTONE_PASSWORD
     basic-auth-username: KINTONE_BASIC_AUTH_USERNAME

--- a/packages/plugin-uploader/bin/cli.js
+++ b/packages/plugin-uploader/bin/cli.js
@@ -124,6 +124,10 @@ if (!pluginPath) {
   cli.showHelp();
 }
 
+if (domain) {
+  console.warn(getMessage(lang, "Warning_Deprecated_domain"));
+}
+
 const wait = (ms) => new Promise((r) => setTimeout(r, ms));
 
 wait(waitingDialogMs)

--- a/packages/plugin-uploader/src/messages.ts
+++ b/packages/plugin-uploader/src/messages.ts
@@ -53,6 +53,12 @@ const messages = {
     en: "has been uploaded!",
     ja: "をアップロードしました!",
   },
+  Warning_Deprecated_domain: {
+    en:
+      "The --domain option and KINTONE_DOMAIN are deprecated and will be removed in the next major release. Please use --base-url or KINTONE_BASE_URL instead.",
+    ja:
+      "--domain オプションおよび KINTONE_DOMAIN は非推奨となり、次のメジャーリリースで削除されます。代わりに --base-url や KINTONE_BASE_URL を使用してください",
+  },
 };
 
 /**

--- a/packages/plugin-uploader/src/messages.ts
+++ b/packages/plugin-uploader/src/messages.ts
@@ -4,11 +4,6 @@ type LangMap = { [lang in Lang]: string };
 type MessageMap = { [key in keyof typeof messages]: LangMap };
 
 const messages = {
-  // TODO: remove Q_Domain when `domain` option is deprecated.
-  Q_Domain: {
-    en: "Input your Kintone subdomain (example.cybozu.com):",
-    ja: "kintoneのドメインを入力してください (example.cybozu.com):",
-  },
   Q_BaseUrl: {
     en: "Input your kintone's base URL (https://example.cybozu.com):",
     ja: "kintoneのベースURLを入力してください (https://example.cybozu.com):",

--- a/packages/plugin-uploader/src/params.ts
+++ b/packages/plugin-uploader/src/params.ts
@@ -19,21 +19,12 @@ export const inquireParams = ({
 }: Params) => {
   const m = getBoundMessage(lang);
   const questions: inquirer.Question[] = [
-    // TODO: remove an object of domain when `domain` option is deprecated
-    {
-      type: "input",
-      message: m("Q_Domain"),
-      name: "domain",
-      default: domain,
-      when: () => !baseUrl && !domain,
-      validate: (v: string) => !!v,
-    },
     {
       type: "input",
       message: m("Q_BaseUrl"),
       name: "baseUrl",
       default: baseUrl,
-      when: (v: inquirer.Answers) => !baseUrl && !domain && !v.domain,
+      when: () => !baseUrl && !domain,
       validate: (v: string) => !!v,
     },
     {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

This is a part of #530

## What

- print a warning message if user specifies `--domain` or `KINTONE_DOMAIN`.
- In interactive CLI, ask base-url instead of domain

## How to test

- execute `bin/cli.js` PLUGIN.zip`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
