### PR TITLE
chore(plugin-packer): run `build` before `lint` & `test` in `prerelease`

### DIFF
--- a/packages/plugin-packer/package.json
+++ b/packages/plugin-packer/package.json
@@ -29,7 +29,7 @@
     "js": "webpack --mode production",
     "js:dev": "webpack serve --mode development",
     "jest": "jest",
-    "prerelease": "run-p lint test build",
+    "prerelease": "npm-run-all build -p lint test",
     "site": "run-p js css",
     "site:dev": "run-p css js:dev",
     "site:test": "jest --config site/jest.config.js"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
Now, `yarn release` or `yarn prerelease` fails because of running `lint`, `test`, and `build` commands in parallel.
Actually, the `build` command must be executed before `lint` because `lint` depends on `build`.

## What

<!-- What is a solution you want to add? -->
Fix to run `build` before `lint` in `prerelease` command.

## How to test

<!-- How can we test this pull request? -->
Run `yarn prerelease` on the project root.

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
