### PR TITLE
chore: fix target files for Yamory

### DIFF
--- a/.github/workflows/yamory.yml
+++ b/.github/workflows/yamory.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - yamory-*
 jobs:
   build:
     name: Node.js ubuntu-latest 14.x
@@ -17,8 +18,8 @@ jobs:
         node-version: 14.x
     - name: run Yamory
       run: |
-        ls -1 packages | xargs -I {} bash -c "$(curl -sSf -L https://localscanner.yamory.io/script/yarn)" --  --manifest ./packages/{}/package.json
-        ls -1 examples | xargs -I {} bash -c "$(curl -sSf -L https://localscanner.yamory.io/script/yarn)" -- --manifest ./examples/{}/package.json
+        ls -1 -d packages/*/ | xargs -I {} bash -c "$(curl -sSf -L https://localscanner.yamory.io/script/yarn)" --  --manifest {}/package.json
+        ls -1 -d examples/*/ | xargs -I {} bash -c "$(curl -sSf -L https://localscanner.yamory.io/script/yarn)" -- --manifest {}/package.json
       env:
         CI: true
         PROJECT_GROUP_KEY: js-sdk


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

After #671 has been merged, Yamory starts failing because I've added `tsconfig.json` for the TypeScript Project References into the `packages/`.

## What

- I've fixed the GitHub Actions to filter out the `tsconfig.json`.
- I've allowed to run Yamory for branches have the `yamory-` prefix for testing the GitHub Actions.

<!-- What is a solution you want to add? -->

## How to test

You can run Yamory on your local machine or see the result of GitHub Actions for this PR.
https://github.com/kintone/js-sdk/runs/1915165528

<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `yarn lint` and `yarn test` on the root directory.
