### PR TITLE
fix(data-loader): add defaultDescription to hide actual default value

### DIFF
--- a/packages/data-loader/README.md
+++ b/packages/data-loader/README.md
@@ -32,17 +32,23 @@ import \
 
 #### Options
 
+Some options use enviroment variables starting `KINTONE_` as default values.
+
 ```
 Options:
-  --base-url             Kintone Base Url            [default: process.env.KINTONE_BASE_URL]
-  --username, -u         Kintone Username            [default: process.env.KINTONE_USERNAME]
-  --password, -p         Kintone Password            [default: process.env.KINTONE_PASSWORD]
-  --api-token            App's API token             [default: process.env.KINTONE_API_TOKEN]
-  --basic-auth-username  Kintone Basic Auth Username [default: process.env.KINTONE_BASIC_AUTH_USERNAME]
-  --basic-auth-password  Kintone Basic Auth Password [default: process.env.KINTONE_BASIC_AUTH_PASSWORD]
+  --version              Show version number                           [boolean]
+  --help                 Show help                                     [boolean]
+  --base-url             Kintone Base Url            [default: KINTONE_BASE_URL]
+  --username, -u         Kintone Username            [default: KINTONE_USERNAME]
+  --password, -p         Kintone Password            [default: KINTONE_PASSWORD]
+  --api-token            App's API token            [default: KINTONE_API_TOKEN]
+  --basic-auth-username  Kintone Basic Auth Username
+                                          [default: KINTONE_BASIC_AUTH_USERNAME]
+  --basic-auth-password  Kintone Basic Auth Password
+                                          [default: KINTONE_BASIC_AUTH_PASSWORD]
   --app                  The ID of the app
-  --guest-space-id       The ID of guest space       [default: process.env.KINTONE_GUEST_SPACE_ID]
-  --file-path            File path
+  --guest-space-id       The ID of guest space [default: KINTONE_GUEST_SPACE_ID]
+  --file-path            file path
   --pfx-file-path        The path to client certificate file
   --pfx-file-password    The password of client certificate file
 ```
@@ -63,18 +69,24 @@ export \
 
 #### Options
 
+Some options use enviroment variables starting `KINTONE_` as default values.
+
 ```
 Options:
-  --base-url             Kintone Base Url            [default: process.env.KINTONE_BASE_URL]
-  --username, -u         Kintone Username            [default: process.env.KINTONE_USERNAME]
-  --password, -p         Kintone Password            [default: process.env.KINTONE_PASSWORD]
-  --api-token            App's API token             [default: process.env.KINTONE_API_TOKEN]
-  --basic-auth-username  Kintone Basic Auth Username [default: process.env.KINTONE_BASIC_AUTH_USERNAME]
-  --basic-auth-password  Kintone Basic Auth Password [default: process.env.KINTONE_BASIC_AUTH_PASSWORD]
+  --version              Show version number                           [boolean]
+  --help                 Show help                                     [boolean]
+  --base-url             Kintone Base Url            [default: KINTONE_BASE_URL]
+  --username, -u         Kintone Username            [default: KINTONE_USERNAME]
+  --password, -p         Kintone Password            [default: KINTONE_PASSWORD]
+  --api-token            App's API token            [default: KINTONE_API_TOKEN]
+  --basic-auth-username  Kintone Basic Auth Username
+                                          [default: KINTONE_BASIC_AUTH_USERNAME]
+  --basic-auth-password  Kintone Basic Auth Password
+                                          [default: KINTONE_BASIC_AUTH_PASSWORD]
   --app                  The ID of the app
-  --guest-space-id       The ID of guest space       [default: process.env.KINTONE_GUEST_SPACE_ID]
-  --attachment-dir       Attachment file directory   [string]
-  --format               Output format               [default: "json"]
+  --guest-space-id       The ID of guest space [default: KINTONE_GUEST_SPACE_ID]
+  --attachment-dir       Attachment file directory                      [string]
+  --format               Output format                         [default: "json"]
   --query, -q            The query string
   --pfx-file-path        The path to client certificate file
   --pfx-file-password    The password of client certificate file

--- a/packages/data-loader/src/commands/export.ts
+++ b/packages/data-loader/src/commands/export.ts
@@ -12,28 +12,34 @@ export const builder = (yargs: any) =>
     .option("base-url", {
       describe: "Kintone Base Url",
       default: process.env.KINTONE_BASE_URL,
+      defaultDescription: "KINTONE_BASE_URL",
     })
     .option("username", {
       alias: "u",
       describe: "Kintone Username",
       default: process.env.KINTONE_USERNAME,
+      defaultDescription: "KINTONE_USERNAME",
     })
     .option("password", {
       alias: "p",
       describe: "Kintone Password",
       default: process.env.KINTONE_PASSWORD,
+      defaultDescription: "KINTONE_PASSWORD",
     })
     .option("api-token", {
       describe: "App's API token",
       default: process.env.KINTONE_API_TOKEN,
+      defaultDescription: "KINTONE_API_TOKEN",
     })
     .option("basic-auth-username", {
       describe: "Kintone Basic Auth Username",
       default: process.env.KINTONE_BASIC_AUTH_USERNAME,
+      defaultDescription: "KINTONE_BASIC_AUTH_USERNAME",
     })
     .option("basic-auth-password", {
       describe: "Kintone Basic Auth Password",
       default: process.env.KINTONE_BASIC_AUTH_PASSWORD,
+      defaultDescription: "KINTONE_BASIC_AUTH_PASSWORD",
     })
     .option("app", {
       describe: "The ID of the app",
@@ -41,6 +47,7 @@ export const builder = (yargs: any) =>
     .option("guest-space-id", {
       describe: "The ID of guest space",
       default: process.env.KINTONE_GUEST_SPACE_ID,
+      defaultDescription: "KINTONE_GUEST_SPACE_ID",
     })
     .option("attachment-dir", {
       describe: "Attachment file directory",

--- a/packages/data-loader/src/commands/import.ts
+++ b/packages/data-loader/src/commands/import.ts
@@ -12,28 +12,34 @@ export const builder = (yargs: any) =>
     .option("base-url", {
       describe: "Kintone Base Url",
       default: process.env.KINTONE_BASE_URL,
+      defaultDescription: "KINTONE_BASE_URL",
     })
     .option("username", {
       alias: "u",
       describe: "Kintone Username",
       default: process.env.KINTONE_USERNAME,
+      defaultDescription: "KINTONE_USERNAME",
     })
     .option("password", {
       alias: "p",
       describe: "Kintone Password",
       default: process.env.KINTONE_PASSWORD,
+      defaultDescription: "KINTONE_PASSWORD",
     })
     .option("api-token", {
       describe: "App's API token",
       default: process.env.KINTONE_API_TOKEN,
+      defaultDescription: "KINTONE_API_TOKEN",
     })
     .option("basic-auth-username", {
       describe: "Kintone Basic Auth Username",
       default: process.env.KINTONE_BASIC_AUTH_USERNAME,
+      defaultDescription: "KINTONE_BASIC_AUTH_USERNAME",
     })
     .option("basic-auth-password", {
       describe: "Kintone Basic Auth Password",
       default: process.env.KINTONE_BASIC_AUTH_PASSWORD,
+      defaultDescription: "KINTONE_BASIC_AUTH_PASSWORD",
     })
     .option("app", {
       describe: "The ID of the app",
@@ -41,6 +47,7 @@ export const builder = (yargs: any) =>
     .option("guest-space-id", {
       describe: "The ID of guest space",
       default: process.env.KINTONE_GUEST_SPACE_ID,
+      defaultDescription: "KINTONE_GUEST_SPACE_ID",
     })
     .option("file-path", {
       describe: "file path",


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
Fix #701 

## What

<!-- What is a solution you want to add? -->
add defaultDescription properties into the options.

## How to test

<!-- How can we test this pull request? -->

Open terminal and run the following command.
```
$ yarn start
```

Open another terminal and run the following commands.
```
$ cd packages/data-loader
$ node ./cli.js export --help
```

To show the help descriptions for import command, run the following commands.

```
$ cd packages/data-laoder
$ node ./cli.js import --help
```

Finally, please check if actual default values are not shown in the help description.


## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
