### PR TITLE
fix(rest-api-client): prevent infinite loop when `condition` contains OR clause

### DIFF
--- a/packages/rest-api-client/src/client/RecordClient.ts
+++ b/packages/rest-api-client/src/client/RecordClient.ts
@@ -271,7 +271,7 @@ export class RecordClient {
     const GET_RECORDS_LIMIT = 500;
 
     const { condition, ...rest } = params;
-    const conditionQuery = condition ? `${condition} and ` : "";
+    const conditionQuery = condition ? `(${condition}) and ` : "";
     const query = `${conditionQuery}$id > ${id} order by $id asc limit ${GET_RECORDS_LIMIT}`;
     const result = await this.getRecords<T>({ ...rest, query });
     const allRecords = records.concat(result.records);

--- a/packages/rest-api-client/src/client/__tests__/RecordClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/RecordClient.test.ts
@@ -481,9 +481,9 @@ describe("RecordClient", () => {
           params: {
             app: params.app,
             fields: params.fields,
-            query: `${
+            query: `(${
               params.condition || ""
-            } and $id > 0 order by $id asc limit 500`,
+            }) and $id > 0 order by $id asc limit 500`,
           },
         });
         expect(mockClient.getLogs()[1]).toEqual({
@@ -492,9 +492,9 @@ describe("RecordClient", () => {
           params: {
             app: params.app,
             fields: params.fields,
-            query: `${
+            query: `(${
               params.condition || ""
-            } and $id > 500 order by $id asc limit 500`,
+            }) and $id > 500 order by $id asc limit 500`,
           },
         });
 

--- a/packages/rest-api-client/src/client/__tests__/RecordClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/RecordClient.test.ts
@@ -481,9 +481,7 @@ describe("RecordClient", () => {
           params: {
             app: params.app,
             fields: params.fields,
-            query: `(${
-              params.condition || ""
-            }) and $id > 0 order by $id asc limit 500`,
+            query: `(${params.condition}) and $id > 0 order by $id asc limit 500`,
           },
         });
         expect(mockClient.getLogs()[1]).toEqual({
@@ -492,9 +490,7 @@ describe("RecordClient", () => {
           params: {
             app: params.app,
             fields: params.fields,
-            query: `(${
-              params.condition || ""
-            }) and $id > 500 order by $id asc limit 500`,
+            query: `(${params.condition}) and $id > 500 order by $id asc limit 500`,
           },
         });
 
@@ -638,7 +634,7 @@ describe("RecordClient", () => {
           params: {
             app: params.app,
             fields: params.fields,
-            query: `${params.condition || ""} limit 500 offset 0`,
+            query: `${params.condition} limit 500 offset 0`,
           },
         });
         expect(mockClient.getLogs()[1]).toEqual({
@@ -647,7 +643,7 @@ describe("RecordClient", () => {
           params: {
             app: params.app,
             fields: params.fields,
-            query: `${params.condition || ""} limit 500 offset 500`,
+            query: `${params.condition} limit 500 offset 500`,
           },
         });
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
Fixes #716 .

## What

<!-- What is a solution you want to add? -->

Enclose `condition` parameter of `getAllRecords()` and `getAllRecordsWithId()` with parenthesis (`()`). (See e634fb4)
NOTE: I didn't enclose the `conditionit` parameter of `getAllRecordsWithOffset()`.

## How to test

<!-- How can we test this pull request? -->

1. Create a kintone app, insert more than 500 records
2. Call `getAllRecords()` with `condition` parameter that meets the following conditions:
    - `condition` contains `or` clause (e.g. `'Customer != "foo" or Status in ("Completed")'` )
    -  the number of filtered records also exceeds 500 records
3. Confirm that all expected records are returned, and the process finishes correctly

You can test it easily using [`getAllRecords()` demo script](https://github.com/kintone/js-sdk/blob/%40kintone/rest-api-client%401.10.0/examples/rest-api-client-demo/src/record.ts#L161) with modified `condition` parameter.

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added tests if it is required. => See 0c810bc
- [x] Passed `yarn lint` and `yarn test` on the root directory.
