### PR TITLE
chore: add Node.js 14.x as a target version on CI

### DIFF
--- a/.github/workflows/compile-data-loader-binary.yml
+++ b/.github/workflows/compile-data-loader-binary.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 12.x
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 14.x
       - name: yarn install, and yarn workspace @kintone/data-loader pkg
         run: |
           yarn install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,14 +10,14 @@ on:
 
 jobs:
   build:
-    name: Node.js ubuntu-latest 12.x
+    name: Node.js ubuntu-latest 14.x
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v2
       with:
-        node-version: 12.x
+        node-version: 14.x
     - name: yarn install, and yarn lint
       run: |
         yarn install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
         os: [ubuntu-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

Ref. #733

## What

- Update CI settings.
  - Add Node.js v14: test
  - Update v12 to v14: lint and compile data-loader-binary


## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
