### PR TITLE
fix(rest-api-client): remove unnecessary props from Notification APIs

### DIFF
--- a/examples/rest-api-client-demo/src/app.ts
+++ b/examples/rest-api-client-demo/src/app.ts
@@ -471,7 +471,6 @@ export class App {
         commentAdded: false,
         statusChanged: true,
         fileImported: false,
-        notifyToCommenter: true,
       },
       {
         entity: {
@@ -484,7 +483,6 @@ export class App {
         commentAdded: true,
         statusChanged: false,
         fileImported: true,
-        notifyToCommenter: false,
       },
     ];
     try {

--- a/packages/rest-api-client/src/client/__tests__/AppClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/AppClient.test.ts
@@ -1035,7 +1035,6 @@ describe("AppClient", () => {
           ],
         },
       ],
-      notifyToCommenter: true,
       revision: 1,
     };
 
@@ -1109,7 +1108,6 @@ describe("AppClient", () => {
           commentAdded: true,
           statusChanged: true,
           fileImported: true,
-          notifyToCommenter: true,
         },
       ],
       notifyToCommenter: true,

--- a/packages/rest-api-client/src/client/types/app/notification.ts
+++ b/packages/rest-api-client/src/client/types/app/notification.ts
@@ -13,7 +13,6 @@ export type GeneralNotificationForParameter = {
   commentAdded?: boolean;
   statusChanged?: boolean;
   fileImported?: boolean;
-  notifyToCommenter?: boolean;
 };
 
 export type GeneralNotificationForResponse = {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Fixes #728 

## What

<!-- What is a solution you want to add? -->

- removes prop `notifications[].notifyToCommenter` from `updateGeneralNotifications`
- fixes tests `updateAppUpdateGeneralNotifications` and `updatePerRecordNotifications` (`AppClient.test.ts`)
- fixes demo script  `updateGeneralNotifications`

## How to test

<!-- How can we test this pull request? -->

```sh
% yarn build
% yarn test
% yarn lint

# run demo script
% cd examples/rest-api-client-demo
% yarn run-script app updateGeneralNotifications
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
