### PR TITLE
fix(rest-api-client): fix ReminderNotificationForResponse type

### DIFF
--- a/packages/rest-api-client/src/client/types/app/notification.ts
+++ b/packages/rest-api-client/src/client/types/app/notification.ts
@@ -71,12 +71,17 @@ export type ReminderNotificationForParameter = {
 };
 
 export type ReminderNotificationForResponse = {
-  timing: {
-    code: string;
-    daysLater: string;
-    hoursLater?: string;
-    time?: string;
-  };
+  timing:
+    | {
+      code: string;
+      daysLater: string;
+      hoursLater: string;
+    }
+  | {
+      code: string;
+      daysLater: string;
+      time: string;
+    };
   filterCond: string;
   title: string;
   targets: [

--- a/packages/rest-api-client/src/client/types/app/notification.ts
+++ b/packages/rest-api-client/src/client/types/app/notification.ts
@@ -73,15 +73,15 @@ export type ReminderNotificationForParameter = {
 export type ReminderNotificationForResponse = {
   timing:
     | {
-      code: string;
-      daysLater: string;
-      hoursLater: string;
-    }
-  | {
-      code: string;
-      daysLater: string;
-      time: string;
-    };
+        code: string;
+        daysLater: string;
+        hoursLater: string;
+      }
+    | {
+        code: string;
+        daysLater: string;
+        time: string;
+      };
   filterCond: string;
   title: string;
   targets: [


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
According to the documentation, hoursLater and time appear to be returned exclusively in the response as well as the Request.
Also, being compatible with the request type means that the response can be passed to the request.

## Checklist

- [X] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [X] Updated documentation if it is required.
- [X] Added tests if it is required.
- [ ] Passed `yarn lint` and `yarn test` on the root directory.
