### PR TITLE
fix(customize-uploader): pass guestSpaceId to KintoneRestAPIClient

### DIFF
--- a/packages/customize-uploader/src/KintoneApiClient.ts
+++ b/packages/customize-uploader/src/KintoneApiClient.ts
@@ -46,6 +46,10 @@ export default class KintoneApiClient {
         password: basicAuthPassword,
       };
     }
+    let guestSpaceId;
+    if (options.guestSpaceId) {
+      guestSpaceId = options.guestSpaceId;
+    }
     this.restApiClient = new KintoneRestAPIClient({
       baseUrl: kintoneUrl,
       auth,
@@ -53,6 +57,7 @@ export default class KintoneApiClient {
       featureFlags: {
         enableAbortSearchError: false,
       },
+      guestSpaceId,
     });
   }
 


### PR DESCRIPTION

## Why

`@kintone/customize-uploader` can not  apply customize to an app in a guest space.
Refer to https://github.com/kintone/js-sdk/issues/792.


## What

`guestSpaceId` pass to `KintoneRestAPIClient`

## How to test

```shell
yarn install
cd packages/customize-uploader
yarn build
bin/cli.js sample/customize-manifest.json --guest-space-id GUEST_SPACE_ID
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
