### PR TITLE
feat(create-plugin): update all dependencies in scaffolding projects

### DIFF
--- a/packages/create-plugin/templates/minimum/package.json.tmpl
+++ b/packages/create-plugin/templates/minimum/package.json.tmpl
@@ -13,12 +13,12 @@
     "lint": "eslint src"
   },
   "devDependencies": {
-    "@cybozu/eslint-config": "^4.0.1",
-    "@kintone/plugin-packer": "^3.0.0",
+    "@cybozu/eslint-config": "^12.0.1",
+    "@kintone/plugin-packer": "^4.0.3",
     <% if (enablePluginUploader) { %>
-    "@kintone/plugin-uploader": "^2.4.8",
+    "@kintone/plugin-uploader": "^4.3.0",
     "npm-run-all": "^4.1.5",
     <% } %>
-    "eslint": "^5.16.0"
+    "eslint": "^7.23.0"
   }
 }

--- a/packages/create-plugin/templates/modern/package.json.tmpl
+++ b/packages/create-plugin/templates/modern/package.json.tmpl
@@ -16,27 +16,27 @@
     "lint": "eslint src"
   },
   "dependencies": {
-    "core-js": "^3.6.5",
-    "@kintone/rest-api-client": "^1.4.2"
+    "core-js": "^3.10.1",
+    "@kintone/rest-api-client": "^1.12.2"
   },
   "devDependencies": {
-    "@babel/core": "^7.10.5",
-    "@babel/preset-env": "^7.10.4",
-    "@babel/preset-react": "^7.10.4",
-    "@babel/preset-typescript": "^7.10.4",
-    "@cybozu/eslint-config": "^11.0.0",
-    "@kintone/dts-gen": "^3.0.5",
+    "@babel/core": "^7.13.15",
+    "@babel/preset-env": "^7.13.5",
+    "@babel/preset-react": "^7.13.3",
+    "@babel/preset-typescript": "^7.13.0",
+    "@cybozu/eslint-config": "^12.0.1",
+    "@kintone/dts-gen": "^3.1.9",
     <% if (enablePluginUploader) { %>
-    "@kintone/plugin-uploader": "^4.1.0",
+    "@kintone/plugin-uploader": "^4.3.0",
     <% } %>
-    "@kintone/webpack-plugin-kintone-plugin": "^4.0.4",
-    "babel-loader": "^8.1.0",
-    "cross-env": "^7.0.2",
-    "eslint": "^7.5.0",
+    "@kintone/webpack-plugin-kintone-plugin": "^4.0.19",
+    "babel-loader": "^8.2.2",
+    "cross-env": "^7.0.3",
+    "eslint": "^7.23.0",
     "npm-run-all": "^4.1.5",
-    "prettier": "^2.0.5",
-    "typescript": "^3.9.7",
-    "webpack": "^4.44.0",
-    "webpack-cli": "^3.3.12"
+    "prettier": "^2.2.1",
+    "typescript": "^4.2.4",
+    "webpack": "^5.31.0",
+    "webpack-cli": "^4.6.0"
   }
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Dependencies in projects generated by `create-plugin` are outdated, so I'd like to update the versions to the latest.
I think the `package.json` should be managed by Renovate, so I'll work on that in the future.

## What

<!-- What is a solution you want to add? -->

I've bumped the versions for the dependencies to the latest versions.


## How to test

<!-- How can we test this pull request? -->

You can create a project by the following commands.

```shell
node packages/create-plugin/bin/cli.js ${target}
// modern template
node packages/create-plugin/bin/cli.js ${target} --template modern
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `yarn lint` and `yarn test` on the root directory.
