### PR TITLE
feat(data-loader): enhance CLI help message (type and requirement of arguments)

### DIFF
--- a/packages/data-loader/README.md
+++ b/packages/data-loader/README.md
@@ -60,20 +60,24 @@ Some options use enviroment variables starting `KINTONE_` as default values.
 Options:
       --version              Show version number                       [boolean]
       --help                 Show help                                 [boolean]
-      --base-url             Kintone Base Url        [default: KINTONE_BASE_URL]
-  -u, --username             Kintone Username        [default: KINTONE_USERNAME]
-  -p, --password             Kintone Password        [default: KINTONE_PASSWORD]
-      --api-token            App's API token        [default: KINTONE_API_TOKEN]
+      --base-url             Kintone Base Url
+                                 [string] [required] [default: KINTONE_BASE_URL]
+  -u, --username             Kintone Username
+                                            [string] [default: KINTONE_USERNAME]
+  -p, --password             Kintone Password
+                                            [string] [default: KINTONE_PASSWORD]
+      --api-token            App's API token[array] [default: KINTONE_API_TOKEN]
       --basic-auth-username  Kintone Basic Auth Username
-                                          [default: KINTONE_BASIC_AUTH_USERNAME]
+                                 [string] [default: KINTONE_BASIC_AUTH_USERNAME]
       --basic-auth-password  Kintone Basic Auth Password
-                                          [default: KINTONE_BASIC_AUTH_PASSWORD]
-      --app                  The ID of the app
+                                 [string] [default: KINTONE_BASIC_AUTH_PASSWORD]
+      --app                  The ID of the app               [string] [required]
       --guest-space-id       The ID of guest space
-                                               [default: KINTONE_GUEST_SPACE_ID]
+                                      [string] [default: KINTONE_GUEST_SPACE_ID]
       --file-path            The path to source file. ".json" or ".csv"
-      --pfx-file-path        The path to client certificate file
-      --pfx-file-password    The password of client certificate file
+                                                             [string] [required]
+      --pfx-file-path        The path to client certificate file        [string]
+      --pfx-file-password    The password of client certificate file    [string]
 ```
 
 ### export
@@ -98,22 +102,26 @@ Some options use enviroment variables starting `KINTONE_` as default values.
 Options:
       --version              Show version number                       [boolean]
       --help                 Show help                                 [boolean]
-      --base-url             Kintone Base Url        [default: KINTONE_BASE_URL]
-  -u, --username             Kintone Username        [default: KINTONE_USERNAME]
-  -p, --password             Kintone Password        [default: KINTONE_PASSWORD]
-      --api-token            App's API token        [default: KINTONE_API_TOKEN]
+      --base-url             Kintone Base Url
+                                 [string] [required] [default: KINTONE_BASE_URL]
+  -u, --username             Kintone Username
+                                            [string] [default: KINTONE_USERNAME]
+  -p, --password             Kintone Password
+                                            [string] [default: KINTONE_PASSWORD]
+      --api-token            App's API token[array] [default: KINTONE_API_TOKEN]
       --basic-auth-username  Kintone Basic Auth Username
-                                          [default: KINTONE_BASIC_AUTH_USERNAME]
+                                 [string] [default: KINTONE_BASIC_AUTH_USERNAME]
       --basic-auth-password  Kintone Basic Auth Password
-                                          [default: KINTONE_BASIC_AUTH_PASSWORD]
-      --app                  The ID of the app
+                                 [string] [default: KINTONE_BASIC_AUTH_PASSWORD]
+      --app                  The ID of the app               [string] [required]
       --guest-space-id       The ID of guest space
-                                               [default: KINTONE_GUEST_SPACE_ID]
+                                      [string] [default: KINTONE_GUEST_SPACE_ID]
       --attachment-dir       Attachment file directory                  [string]
-      --format               Output format. "json" or "csv"    [default: "json"]
-  -q, --query                The query string
-      --pfx-file-path        The path to client certificate file
-      --pfx-file-password    The password of client certificate file
+      --format               Output format. "json" or "csv"
+                                      [choices: "json", "csv"] [default: "json"]
+  -q, --query                The query string                           [string]
+      --pfx-file-path        The path to client certificate file        [string]
+      --pfx-file-password    The password of client certificate file    [string]
 ```
 
 ## Supported file formats

--- a/packages/data-loader/src/__tests__/main.test.ts
+++ b/packages/data-loader/src/__tests__/main.test.ts
@@ -35,6 +35,13 @@ describe("main", () => {
       errorMessage: "Unknown argument: dummy",
     });
   });
+  it("should throw error when an undefined argument is passed", () => {
+    return checkRejectArg({
+      arg:
+        "import --base-url https://your.domain.example --app 1 --file-path /your/file/path --dummy",
+      errorMessage: "Unknown argument: dummy",
+    });
+  });
   it("should throw error when required arguments are missing", () => {
     return checkRejectArg({
       arg: "import",

--- a/packages/data-loader/src/__tests__/main.test.ts
+++ b/packages/data-loader/src/__tests__/main.test.ts
@@ -15,7 +15,7 @@ const checkRejectArg = ({
   errorMessage,
 }: {
   arg: string;
-  errorMessage: string;
+  errorMessage: string | RegExp;
 }) => {
   return expect(
     exec(`cross-env LC_ALL='en_US' node ${mainFilePath} ${arg}`)
@@ -35,10 +35,10 @@ describe("main", () => {
       errorMessage: "Unknown argument: dummy",
     });
   });
-  it("should throw error when an undefined argument is passed", () => {
+  it("should throw error when required arguments are missing", () => {
     return checkRejectArg({
-      arg: "import --dummy",
-      errorMessage: "Unknown argument: dummy",
+      arg: "import",
+      errorMessage: /Missing required arguments:/,
     });
   });
 });

--- a/packages/data-loader/src/__tests__/main.test.ts
+++ b/packages/data-loader/src/__tests__/main.test.ts
@@ -38,7 +38,7 @@ describe("main", () => {
   it("should throw error when an undefined argument is passed", () => {
     return checkRejectArg({
       arg:
-        "import --base-url https://your.domain.example --app 1 --file-path /your/file/path --dummy",
+        "import --base-url https://example.com --app 1 --file-path /your/file/path --dummy",
       errorMessage: "Unknown argument: dummy",
     });
   });

--- a/packages/data-loader/src/commands/export.ts
+++ b/packages/data-loader/src/commands/export.ts
@@ -1,7 +1,9 @@
-import { run, Options } from "../controllers/export";
+import { run, Options, ExportFileFormat } from "../controllers/export";
 import { RestAPIClientOptions } from "../api";
 
 type Argv = RestAPIClientOptions & Options;
+
+const formats: ExportFileFormat[] = ["json", "csv"];
 
 export const command = "export";
 
@@ -13,41 +15,51 @@ export const builder = (yargs: any) =>
       describe: "Kintone Base Url",
       default: process.env.KINTONE_BASE_URL,
       defaultDescription: "KINTONE_BASE_URL",
+      type: "string",
+      demandOption: true,
     })
     .option("username", {
       alias: "u",
       describe: "Kintone Username",
       default: process.env.KINTONE_USERNAME,
       defaultDescription: "KINTONE_USERNAME",
+      type: "string",
     })
     .option("password", {
       alias: "p",
       describe: "Kintone Password",
       default: process.env.KINTONE_PASSWORD,
       defaultDescription: "KINTONE_PASSWORD",
+      type: "string",
     })
     .option("api-token", {
       describe: "App's API token",
       default: process.env.KINTONE_API_TOKEN,
       defaultDescription: "KINTONE_API_TOKEN",
+      type: "array",
     })
     .option("basic-auth-username", {
       describe: "Kintone Basic Auth Username",
       default: process.env.KINTONE_BASIC_AUTH_USERNAME,
       defaultDescription: "KINTONE_BASIC_AUTH_USERNAME",
+      type: "string",
     })
     .option("basic-auth-password", {
       describe: "Kintone Basic Auth Password",
       default: process.env.KINTONE_BASIC_AUTH_PASSWORD,
       defaultDescription: "KINTONE_BASIC_AUTH_PASSWORD",
+      type: "string",
     })
     .option("app", {
       describe: "The ID of the app",
+      type: "string",
+      demandOption: true,
     })
     .option("guest-space-id", {
       describe: "The ID of guest space",
       default: process.env.KINTONE_GUEST_SPACE_ID,
       defaultDescription: "KINTONE_GUEST_SPACE_ID",
+      type: "string",
     })
     .option("attachment-dir", {
       describe: "Attachment file directory",
@@ -55,17 +67,21 @@ export const builder = (yargs: any) =>
     })
     .option("format", {
       describe: 'Output format. "json" or "csv"',
-      default: "json",
+      default: "json" as ExportFileFormat,
+      choices: formats,
     })
     .option("query", {
       alias: "q",
       describe: "The query string",
+      type: "string",
     })
     .option("pfx-file-path", {
       describe: "The path to client certificate file",
+      type: "string",
     })
     .option("pfx-file-password", {
       describe: "The password of client certificate file",
+      type: "string",
     });
 
 export const handler = (argv: Argv) => run(argv);

--- a/packages/data-loader/src/commands/import.ts
+++ b/packages/data-loader/src/commands/import.ts
@@ -13,50 +13,64 @@ export const builder = (yargs: any) =>
       describe: "Kintone Base Url",
       default: process.env.KINTONE_BASE_URL,
       defaultDescription: "KINTONE_BASE_URL",
+      type: "string",
+      demandOption: true,
     })
     .option("username", {
       alias: "u",
       describe: "Kintone Username",
       default: process.env.KINTONE_USERNAME,
       defaultDescription: "KINTONE_USERNAME",
+      type: "string",
     })
     .option("password", {
       alias: "p",
       describe: "Kintone Password",
       default: process.env.KINTONE_PASSWORD,
       defaultDescription: "KINTONE_PASSWORD",
+      type: "string",
     })
     .option("api-token", {
       describe: "App's API token",
       default: process.env.KINTONE_API_TOKEN,
       defaultDescription: "KINTONE_API_TOKEN",
+      type: "array",
     })
     .option("basic-auth-username", {
       describe: "Kintone Basic Auth Username",
       default: process.env.KINTONE_BASIC_AUTH_USERNAME,
       defaultDescription: "KINTONE_BASIC_AUTH_USERNAME",
+      type: "string",
     })
     .option("basic-auth-password", {
       describe: "Kintone Basic Auth Password",
       default: process.env.KINTONE_BASIC_AUTH_PASSWORD,
       defaultDescription: "KINTONE_BASIC_AUTH_PASSWORD",
+      type: "string",
     })
     .option("app", {
       describe: "The ID of the app",
+      type: "string",
+      demandOption: true,
     })
     .option("guest-space-id", {
       describe: "The ID of guest space",
       default: process.env.KINTONE_GUEST_SPACE_ID,
       defaultDescription: "KINTONE_GUEST_SPACE_ID",
+      type: "string",
     })
     .option("file-path", {
       describe: 'The path to source file. ".json" or ".csv"',
+      type: "string",
+      demandOption: true,
     })
     .option("pfx-file-path", {
       describe: "The path to client certificate file",
+      type: "string",
     })
     .option("pfx-file-password", {
       describe: "The password of client certificate file",
-    }).argv;
+      type: "string",
+    });
 
 export const handler = (argv: Argv) => run(argv);

--- a/packages/data-loader/src/controllers/export.ts
+++ b/packages/data-loader/src/controllers/export.ts
@@ -9,9 +9,11 @@ import { buildPrinter } from "../printers";
 export type Options = {
   app: AppID;
   attachmentDir?: string;
-  format?: "json" | "csv";
+  format?: ExportFileFormat;
   query?: string;
 };
+
+export type ExportFileFormat = "json" | "csv";
 
 type FileInfo = {
   name: string;


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

In this PR, I added type and requirement information of arguments to CLI help message.

## What

<!-- What is a solution you want to add? -->

- [x] show type information of arguments on help message
- [x] show requirement of arguments on help message
- [x] show error if required arguments are missing
- [x] fix and add tests

## How to test

<!-- How can we test this pull request? -->

```sh
$ yarn build
$ cd packages/data-loader

# show help message
$ node ./cli.js export --help
$ node ./cli.js import --help

# show error: required arguments are missing
$ node ./cli.js export
```

## Changes of help message

<details>

### export

before
```sh
node ./cli.js export --help
cli.js export

export the records of the specified app

Options:
      --version              Show version number                       [boolean]
      --help                 Show help                                 [boolean]
      --base-url             Kintone Base Url        [default: KINTONE_BASE_URL]
  -u, --username             Kintone Username        [default: KINTONE_USERNAME]
  -p, --password             Kintone Password        [default: KINTONE_PASSWORD]
      --api-token            App's API token        [default: KINTONE_API_TOKEN]
      --basic-auth-username  Kintone Basic Auth Username
                                          [default: KINTONE_BASIC_AUTH_USERNAME]
      --basic-auth-password  Kintone Basic Auth Password
                                          [default: KINTONE_BASIC_AUTH_PASSWORD]
      --app                  The ID of the app
      --guest-space-id       The ID of guest space
                                               [default: KINTONE_GUEST_SPACE_ID]
      --attachment-dir       Attachment file directory                  [string]
      --format               Output format. "json" or "csv"    [default: "json"]
  -q, --query                The query string
      --pfx-file-path        The path to client certificate file
      --pfx-file-password    The password of client certificate file
```

after
```sh
$ node ./cli.js export --help
cli.js export

export the records of the specified app

Options:
      --version              Show version number                       [boolean]
      --help                 Show help                                 [boolean]
      --base-url             Kintone Base Url
                                 [string] [required] [default: KINTONE_BASE_URL]
  -u, --username             Kintone Username
                                            [string] [default: KINTONE_USERNAME]
  -p, --password             Kintone Password
                                            [string] [default: KINTONE_PASSWORD]
      --api-token            App's API token[array] [default: KINTONE_API_TOKEN]
      --basic-auth-username  Kintone Basic Auth Username
                                 [string] [default: KINTONE_BASIC_AUTH_USERNAME]
      --basic-auth-password  Kintone Basic Auth Password
                                 [string] [default: KINTONE_BASIC_AUTH_PASSWORD]
      --app                  The ID of the app               [string] [required]
      --guest-space-id       The ID of guest space
                                      [string] [default: KINTONE_GUEST_SPACE_ID]
      --attachment-dir       Attachment file directory                  [string]
      --format               Output format. "json" or "csv"
                                      [choices: "json", "csv"] [default: "json"]
  -q, --query                The query string                           [string]
      --pfx-file-path        The path to client certificate file        [string]
      --pfx-file-password    The password of client certificate file    [string]
```

### import

before
```sh
$ node ./cli.js import --help
Options:
      --version              Show version number                       [boolean]
      --help                 Show help                                 [boolean]
      --base-url             Kintone Base Url        [default: KINTONE_BASE_URL]
  -u, --username             Kintone Username        [default: KINTONE_USERNAME]
  -p, --password             Kintone Password        [default: KINTONE_PASSWORD]
      --api-token            App's API token        [default: KINTONE_API_TOKEN]
      --basic-auth-username  Kintone Basic Auth Username
                                          [default: KINTONE_BASIC_AUTH_USERNAME]
      --basic-auth-password  Kintone Basic Auth Password
                                          [default: KINTONE_BASIC_AUTH_PASSWORD]
      --app                  The ID of the app
      --guest-space-id       The ID of guest space
                                               [default: KINTONE_GUEST_SPACE_ID]
      --file-path            The path to source file. ".json" or ".csv"
      --pfx-file-path        The path to client certificate file
      --pfx-file-password    The password of client certificate file
```

after
```sh
$ node ./cli.js import --help
cli.js import

import the records of the specified app

Options:
      --version              Show version number                       [boolean]
      --help                 Show help                                 [boolean]
      --base-url             Kintone Base Url
                                 [string] [required] [default: KINTONE_BASE_URL]
  -u, --username             Kintone Username
                                            [string] [default: KINTONE_USERNAME]
  -p, --password             Kintone Password
                                            [string] [default: KINTONE_PASSWORD]
      --api-token            App's API token[array] [default: KINTONE_API_TOKEN]
      --basic-auth-username  Kintone Basic Auth Username
                                 [string] [default: KINTONE_BASIC_AUTH_USERNAME]
      --basic-auth-password  Kintone Basic Auth Password
                                 [string] [default: KINTONE_BASIC_AUTH_PASSWORD]
      --app                  The ID of the app               [string] [required]
      --guest-space-id       The ID of guest space
                                      [string] [default: KINTONE_GUEST_SPACE_ID]
      --file-path            The path to source file. ".json" or ".csv"
                                                             [string] [required]
      --pfx-file-path        The path to client certificate file        [string]
      --pfx-file-password    The password of client certificate file    [string]
```
</details>

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
