### PR TITLE
fix(data-loader): apply accurated types to CLI command builder

### DIFF
--- a/packages/data-loader/src/commands/export.ts
+++ b/packages/data-loader/src/commands/export.ts
@@ -83,7 +83,7 @@ export const builder = (args: yargs.Argv) =>
     });
 
 type Args = yargs.Arguments<
-  ReturnType<typeof builder> extends yargs.Argv<infer U> ? U : unknown
+  ReturnType<typeof builder> extends yargs.Argv<infer U> ? U : never
 >;
 
 export const handler = (args: Args) => {

--- a/packages/data-loader/src/commands/export.ts
+++ b/packages/data-loader/src/commands/export.ts
@@ -14,7 +14,6 @@ export const builder = (args: yargs.Argv) =>
       default: process.env.KINTONE_BASE_URL,
       defaultDescription: "KINTONE_BASE_URL",
       type: "string",
-      demandOption: true,
     })
     .option("username", {
       alias: "u",
@@ -51,7 +50,6 @@ export const builder = (args: yargs.Argv) =>
     .option("app", {
       describe: "The ID of the app",
       type: "string",
-      demandOption: true,
     })
     .option("guest-space-id", {
       describe: "The ID of guest space",
@@ -80,7 +78,9 @@ export const builder = (args: yargs.Argv) =>
     .option("pfx-file-password", {
       describe: "The password of client certificate file",
       type: "string",
-    });
+    })
+    // NOTE: Unexpected `undefined` in inferred type by `option()`.
+    .demandOption(["base-url", "app"]);
 
 type Args = yargs.Arguments<
   ReturnType<typeof builder> extends yargs.Argv<infer U> ? U : never
@@ -88,7 +88,7 @@ type Args = yargs.Arguments<
 
 export const handler = (args: Args) => {
   return run({
-    baseUrl: args["base-url"] as string,
+    baseUrl: args["base-url"],
     username: args.username,
     password: args.password,
     apiToken: args["api-token"],

--- a/packages/data-loader/src/commands/export.ts
+++ b/packages/data-loader/src/commands/export.ts
@@ -1,8 +1,5 @@
-import { run, Options, ExportFileFormat } from "../controllers/export";
-import { RestAPIClientOptions } from "../api";
+import { run, ExportFileFormat } from "../controllers/export";
 import * as yargs from "yargs";
-
-type Argv = Partial<RestAPIClientOptions & Options>;
 
 const formats: ExportFileFormat[] = ["json", "csv"];
 
@@ -10,8 +7,8 @@ export const command = "export";
 
 export const desc = "export the records of the specified app";
 
-export const builder = (argv: yargs.Argv) =>
-  argv
+export const builder = (args: yargs.Argv) =>
+  args
     .option("base-url", {
       describe: "Kintone Base Url",
       default: process.env.KINTONE_BASE_URL,
@@ -85,7 +82,24 @@ export const builder = (argv: yargs.Argv) =>
       type: "string",
     });
 
-export const handler = (argv: Argv) => {
-  const { app, baseUrl, ...options } = argv;
-  return run({ app: app as string, baseUrl: baseUrl as string, ...options });
+type Args = yargs.Arguments<
+  ReturnType<typeof builder> extends yargs.Argv<infer U> ? U : unknown
+>;
+
+export const handler = (args: Args) => {
+  return run({
+    baseUrl: args["base-url"] as string,
+    username: args.username,
+    password: args.password,
+    apiToken: args["api-token"],
+    basicAuthUsername: args["basic-auth-username"],
+    basicAuthPassword: args["basic-auth-password"],
+    app: args.app,
+    guestSpaceId: args["guest-space-id"],
+    attachmentDir: args["attachment-dir"],
+    format: args.format,
+    query: args.query,
+    pfxFilePath: args["pfx-file-path"],
+    pfxFilePassword: args["pfx-file-password"],
+  });
 };

--- a/packages/data-loader/src/commands/export.ts
+++ b/packages/data-loader/src/commands/export.ts
@@ -1,7 +1,8 @@
 import { run, Options, ExportFileFormat } from "../controllers/export";
 import { RestAPIClientOptions } from "../api";
+import * as yargs from "yargs";
 
-type Argv = RestAPIClientOptions & Options;
+type Argv = Partial<RestAPIClientOptions & Options>;
 
 const formats: ExportFileFormat[] = ["json", "csv"];
 
@@ -9,8 +10,8 @@ export const command = "export";
 
 export const desc = "export the records of the specified app";
 
-export const builder = (yargs: any) =>
-  yargs
+export const builder = (argv: yargs.Argv) =>
+  argv
     .option("base-url", {
       describe: "Kintone Base Url",
       default: process.env.KINTONE_BASE_URL,
@@ -84,4 +85,7 @@ export const builder = (yargs: any) =>
       type: "string",
     });
 
-export const handler = (argv: Argv) => run(argv);
+export const handler = (argv: Argv) => {
+  const { app, baseUrl, ...options } = argv;
+  return run({ app: app as string, baseUrl: baseUrl as string, ...options });
+};

--- a/packages/data-loader/src/commands/export.ts
+++ b/packages/data-loader/src/commands/export.ts
@@ -79,7 +79,10 @@ export const builder = (args: yargs.Argv) =>
       describe: "The password of client certificate file",
       type: "string",
     })
-    // NOTE: Unexpected `undefined` in inferred type by `option()`.
+    // NOTE: Since yargs doesn't detect the type correctly by adding `demandOption: true` in `option()`,
+    // (inferred type always contains `| undefined`)
+    // related issue: https://github.com/yargs/yargs/issues/1928
+    // we declare the required params later as a workaround.
     .demandOption(["base-url", "app"]);
 
 type Args = yargs.Arguments<

--- a/packages/data-loader/src/commands/import.ts
+++ b/packages/data-loader/src/commands/import.ts
@@ -12,7 +12,6 @@ export const builder = (args: yargs.Argv) =>
       default: process.env.KINTONE_BASE_URL,
       defaultDescription: "KINTONE_BASE_URL",
       type: "string",
-      demandOption: true,
     })
     .option("username", {
       alias: "u",
@@ -49,7 +48,6 @@ export const builder = (args: yargs.Argv) =>
     .option("app", {
       describe: "The ID of the app",
       type: "string",
-      demandOption: true,
     })
     .option("guest-space-id", {
       describe: "The ID of guest space",
@@ -60,7 +58,6 @@ export const builder = (args: yargs.Argv) =>
     .option("file-path", {
       describe: 'The path to source file. ".json" or ".csv"',
       type: "string",
-      demandOption: true,
     })
     .option("pfx-file-path", {
       describe: "The path to client certificate file",
@@ -69,7 +66,9 @@ export const builder = (args: yargs.Argv) =>
     .option("pfx-file-password", {
       describe: "The password of client certificate file",
       type: "string",
-    });
+    })
+    // NOTE: Unexpected `undefined` in inferred type by `option()`.
+    .demandOption(["base-url", "app", "file-path"]);
 
 type Args = yargs.Arguments<
   ReturnType<typeof builder> extends yargs.Argv<infer U> ? U : never
@@ -77,7 +76,7 @@ type Args = yargs.Arguments<
 
 export const handler = (args: Args) => {
   return run({
-    baseUrl: args["base-url"] as string,
+    baseUrl: args["base-url"],
     username: args.username,
     password: args.password,
     apiToken: args["api-token"],

--- a/packages/data-loader/src/commands/import.ts
+++ b/packages/data-loader/src/commands/import.ts
@@ -1,14 +1,15 @@
 import { run, Options } from "../controllers/import";
 import { RestAPIClientOptions } from "../api";
+import * as yargs from "yargs";
 
-type Argv = RestAPIClientOptions & Options;
+type Argv = Partial<RestAPIClientOptions & Options>;
 
 export const command = "import";
 
 export const desc = "import the records of the specified app";
 
-export const builder = (yargs: any) =>
-  yargs
+export const builder = (argv: yargs.Argv) =>
+  argv
     .option("base-url", {
       describe: "Kintone Base Url",
       default: process.env.KINTONE_BASE_URL,
@@ -73,4 +74,12 @@ export const builder = (yargs: any) =>
       type: "string",
     });
 
-export const handler = (argv: Argv) => run(argv);
+export const handler = (argv: Argv) => {
+  const { app, baseUrl, filePath, ...options } = argv;
+  return run({
+    app: app as string,
+    baseUrl: baseUrl as string,
+    filePath: filePath as string,
+    ...options,
+  });
+};

--- a/packages/data-loader/src/commands/import.ts
+++ b/packages/data-loader/src/commands/import.ts
@@ -72,7 +72,7 @@ export const builder = (args: yargs.Argv) =>
     });
 
 type Args = yargs.Arguments<
-  ReturnType<typeof builder> extends yargs.Argv<infer U> ? U : unknown
+  ReturnType<typeof builder> extends yargs.Argv<infer U> ? U : never
 >;
 
 export const handler = (args: Args) => {

--- a/packages/data-loader/src/commands/import.ts
+++ b/packages/data-loader/src/commands/import.ts
@@ -67,7 +67,10 @@ export const builder = (args: yargs.Argv) =>
       describe: "The password of client certificate file",
       type: "string",
     })
-    // NOTE: Unexpected `undefined` in inferred type by `option()`.
+    // NOTE: Since yargs doesn't detect the type correctly by adding `demandOption: true` in `option()`,
+    // (inferred type always contains `| undefined`)
+    // related issue: https://github.com/yargs/yargs/issues/1928
+    // we declare the required params later as a workaround.
     .demandOption(["base-url", "app", "file-path"]);
 
 type Args = yargs.Arguments<

--- a/packages/data-loader/src/commands/import.ts
+++ b/packages/data-loader/src/commands/import.ts
@@ -1,15 +1,12 @@
-import { run, Options } from "../controllers/import";
-import { RestAPIClientOptions } from "../api";
+import { run } from "../controllers/import";
 import * as yargs from "yargs";
-
-type Argv = Partial<RestAPIClientOptions & Options>;
 
 export const command = "import";
 
 export const desc = "import the records of the specified app";
 
-export const builder = (argv: yargs.Argv) =>
-  argv
+export const builder = (args: yargs.Argv) =>
+  args
     .option("base-url", {
       describe: "Kintone Base Url",
       default: process.env.KINTONE_BASE_URL,
@@ -74,12 +71,22 @@ export const builder = (argv: yargs.Argv) =>
       type: "string",
     });
 
-export const handler = (argv: Argv) => {
-  const { app, baseUrl, filePath, ...options } = argv;
+type Args = yargs.Arguments<
+  ReturnType<typeof builder> extends yargs.Argv<infer U> ? U : unknown
+>;
+
+export const handler = (args: Args) => {
   return run({
-    app: app as string,
-    baseUrl: baseUrl as string,
-    filePath: filePath as string,
-    ...options,
+    baseUrl: args["base-url"] as string,
+    username: args.username,
+    password: args.password,
+    apiToken: args["api-token"],
+    basicAuthUsername: args["basic-auth-username"],
+    basicAuthPassword: args["basic-auth-password"],
+    app: args.app,
+    guestSpaceId: args["guest-space-id"],
+    filePath: args["file-path"],
+    pfxFilePath: args["pfx-file-path"],
+    pfxFilePassword: args["pfx-file-password"],
   });
 };

--- a/packages/data-loader/src/main.ts
+++ b/packages/data-loader/src/main.ts
@@ -1,4 +1,11 @@
 import yargs from "yargs";
+import * as commandExport from "./commands/export";
+import * as commandImport from "./commands/import";
 
 // eslint-disable-next-line no-unused-expressions
-yargs.commandDir("commands").demandCommand().strict().help().argv;
+yargs
+  .command(commandExport)
+  .command(commandImport)
+  .demandCommand()
+  .strict()
+  .help().argv;


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
In this PR, I apply accurated types to CLI command builder (`builder` function in `src/commands/*.ts`)
This resolves following problems.
- type inference does not work in command builder function because its parameter is `any`.
- type inference is breaking between `src/main.ts` and `src/commands/*.ts`bacause of using of `yargs.commandDir`.

## What

<!-- What is a solution you want to add? -->

- [x] remove `any` from CLI command builder
- [x] use `yargs.command` instead of `yargs.commandDir`
- [x] infer the parameter type of handler from return type of builder

## How to test

<!-- How can we test this pull request? -->

This PR doesn't affect on runtime.

```sh
$ yarn build
$ yarn lint
$ yarn test
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
