### PR TITLE
chore(data-loader): set a User-Agent string for data-loader

### DIFF
--- a/packages/data-loader/src/__tests__/api.test.ts
+++ b/packages/data-loader/src/__tests__/api.test.ts
@@ -1,6 +1,8 @@
 import { buildRestAPIClient } from "../api";
 
 import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+const packageJson = require("../../package.json");
+const expectedUa = `${packageJson.name}@${packageJson.version}`;
 
 jest.mock("@kintone/rest-api-client");
 
@@ -25,6 +27,7 @@ describe("api", () => {
         username: USERNAME,
         password: PASSWORD,
       },
+      userAgent: expectedUa,
     });
   });
 
@@ -45,6 +48,7 @@ describe("api", () => {
         password: PASSWORD,
       },
       guestSpaceId: GUEST_SPACE_ID,
+      userAgent: expectedUa,
     });
   });
 
@@ -57,6 +61,7 @@ describe("api", () => {
     expect(KintoneRestAPIClient).toHaveBeenCalledWith({
       baseUrl: BASE_URL,
       auth: { apiToken: API_TOKEN },
+      userAgent: expectedUa,
     });
   });
 
@@ -74,6 +79,7 @@ describe("api", () => {
         username: USERNAME,
         password: PASSWORD,
       },
+      userAgent: expectedUa,
     });
   });
 
@@ -98,6 +104,7 @@ describe("api", () => {
         username: BASIC_AUTH_USERNAME,
         password: BASIC_AUTH_PASSWORD,
       },
+      userAgent: expectedUa,
     });
   });
   it("should pass information of client certificate to the apiClient correctly", () => {
@@ -119,6 +126,7 @@ describe("api", () => {
         pfxFilePath: PFX_FILE_PATH,
         password: PFX_FILE_PASSWORD,
       },
+      userAgent: expectedUa,
     });
   });
 });

--- a/packages/data-loader/src/api.ts
+++ b/packages/data-loader/src/api.ts
@@ -1,4 +1,5 @@
 import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+const packageJson = require("../package.json");
 
 export type RestAPIClientOptions = {
   baseUrl: string;
@@ -10,6 +11,7 @@ export type RestAPIClientOptions = {
   guestSpaceId?: string;
   pfxFilePath?: string;
   pfxFilePassword?: string;
+  userAgent?: string;
 };
 
 const buildAuthParam = (options: RestAPIClientOptions) => {
@@ -52,5 +54,6 @@ export const buildRestAPIClient = (options: RestAPIClientOptions) => {
     ...buildBasicAuthParam(options),
     ...buildClientCertAuth(options),
     ...(options.guestSpaceId ? { guestSpaceId: options.guestSpaceId } : {}),
+    userAgent: `${packageJson.name}@${packageJson.version}`,
   });
 };


### PR DESCRIPTION
## Why

According to https://developer.kintone.io/hc/en-us/articles/212494698#consideration, it announces that set an appropriate value in the User-Agent header.
I want that data-loader sets a custom User-Agent string.

## What

set a custom User-Agent string as `data-loader@version`

## How to test

`yarn test`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
