### PR TITLE
feat(dts-gen): Support Get Space Element API

### DIFF
--- a/packages/dts-gen/kintone.d.ts
+++ b/packages/dts-gen/kintone.d.ts
@@ -174,6 +174,12 @@ declare namespace kintone {
         namespace portal {
             function getContentSpaceElement(): HTMLElement | null;
         }
+
+        namespace space {
+            namespace portal {
+                function getContentSpaceElement(): HTMLElement | null;
+            }
+        }
     }
 
     namespace plugin {

--- a/packages/dts-gen/kintone.d.ts
+++ b/packages/dts-gen/kintone.d.ts
@@ -241,6 +241,12 @@ declare namespace kintone {
         function getContentSpaceElement(): HTMLElement | null;
     }
 
+    namespace space {
+        namespace portal {
+            function getContentSpaceElement(): HTMLElement | null;
+        }
+    }
+
     interface LoginUser {
         id: string;
         code: string;

--- a/packages/dts-gen/src/integration-tests/dts-gen-api-test.ts
+++ b/packages/dts-gen/src/integration-tests/dts-gen-api-test.ts
@@ -129,6 +129,14 @@ function assertKintoneBuiltinFunctions() {
     // kintone.$PLUGIN_ID
     assert.ok(kintone.$PLUGIN_ID);
     assert.ok(typeof kintone.$PLUGIN_ID === "string");
+
+    // Space API
+    assertFunction(
+        kintone.space.portal.getContentSpaceElement
+    );
+    assertFunction(
+        kintone.mobile.space.portal.getContentSpaceElement
+    );
 }
 
 function assertFunction(ref) {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

[Get Space Element](https://developer.kintone.io/hc/en-us/articles/900006264623)  API was released in 2021 Apr update!
- release note: https://kintone.cybozu.co.jp/update/main/2021-04.html#point3
- spec: https://developer.kintone.io/hc/en-us/articles/900006264623
  - Desktop: `kintone.space.portal.getContentSpaceElement()`
  - Mobile: `kintone.mobile.space.portal.getContentSpaceElement()`

## What

<!-- What is a solution you want to add? -->

- [x] implement type definition of `kintone.space.portal.getContentSpaceElement()`
- [x] implement type definition of `kintone.mobile.space.portal.getContentSpaceElement()`
- [x] add tests

## How to test

<!-- How can we test this pull request? -->

```sh
$ yarn build
$ yarn lint
$ yarn test
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
