### PR TITLE
feat(dts-gen): add type definition of `kintone.$PLUGIN_ID`

### DIFF
--- a/packages/dts-gen/kintone.d.ts
+++ b/packages/dts-gen/kintone.d.ts
@@ -256,6 +256,8 @@ declare namespace kintone {
     function getLoginUser(): LoginUser;
     function getUiVersion(): 1 | 2;
 
+    const $PLUGIN_ID: string;
+
     namespace fieldTypes {
         interface SingleLineText {
             type?: "SINGLE_LINE_TEXT";

--- a/packages/dts-gen/src/integration-tests/dts-gen-api-test.ts
+++ b/packages/dts-gen/src/integration-tests/dts-gen-api-test.ts
@@ -124,6 +124,10 @@ function assertKintoneBuiltinFunctions() {
     assertFunction(
         kintone.mobile.portal.getContentSpaceElement
     );
+
+    // kintone.$PLUGIN_ID
+    assert.ok(kintone.$PLUGIN_ID);
+    assert.ok(typeof kintone.$PLUGIN_ID === "string");
 }
 
 function assertFunction(ref) {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

`kintone.$PLUGIN_ID` is contained in `kintone` object, but dts-gen doesn't have the type definition of it currently.

> The variable kintone.$PLUGIN_ID will hold the Plug-in ID which will be needed.

https://developer.kintone.io/hc/en-us/articles/212495078-Steps-for-plug-in-development

## What

<!-- What is a solution you want to add? -->

- [x] add type definition of `kintone.$PLUGIN_ID`
- [x] add test

## How to test

<!-- How can we test this pull request? -->

```sh
$ yarn build
$ yarn lint
$ yarn test
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
