### PR TITLE
fix(rest-api-client): `baseUrl` is not used when `location` is undefined

### DIFF
--- a/packages/rest-api-client/src/platform/browser.ts
+++ b/packages/rest-api-client/src/platform/browser.ts
@@ -44,9 +44,10 @@ export const buildFormDataValue = (data: unknown) => {
 };
 
 export const buildBaseUrl = (baseUrl?: string) => {
-  // We assume that location always exists in a browser environment
+  if (baseUrl) return baseUrl;
+
   const { host, protocol } = location!;
-  return baseUrl ?? `${protocol}//${host}`;
+  return `${protocol}//${host}`;
 };
 
 export const getVersion = () => {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
Occured error "location undefined" at React Native.
React Nativeでlocation undefinedエラーが発生します。


## What

<!-- What is a solution you want to add? -->
If baseUrl is passed, location is not used.
baseUrlが渡された場合はlocationを利用しない。


## How to test

<!-- How can we test this pull request? -->
Execute REST API from browser, Node, React Native.
ブラウザやNode、React NativeからREST APIを実行します。

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
