### PR TITLE
feat(dts-gen): print deprecating messages for --host, --proxyHost, and --proxyPort

### DIFF
--- a/packages/dts-gen/src/cli-parser.test.ts
+++ b/packages/dts-gen/src/cli-parser.test.ts
@@ -72,7 +72,6 @@ describe("parse", () => {
                 "node", "index.js",
                 "--base-url", "https://example2.kintone.com",
                 "--demo",
-                "--host", "HOST",
                 "--username", "USERNAME",
                 "--password", "PASSWORD",
                 "--api-token", "API_TOKEN",
@@ -82,8 +81,6 @@ describe("parse", () => {
                 "--preview",
                 "--type-name", "TYPE_NAME",
                 "--namespace", "NAMESPACE",
-                "--proxy-host", "PROXY_HOST",
-                "--proxy-port", "PROXY_PORT",
                 "--basic-auth-username", "BASIC_AUTH_USERNAME",
                 "--basic-auth-password", "BASIC_AUTH_PASSWORD",
                 "--output", "OUTPUT"
@@ -104,8 +101,6 @@ describe("parse", () => {
             expect(args.preview).toBe(true);
             expect(args.typeName).toBe("TYPE_NAME");
             expect(args.namespace).toBe("NAMESPACE");
-            expect(args.proxyHost).toBe("PROXY_HOST");
-            expect(args.proxyPort).toBe("PROXY_PORT");
             expect(args.basicAuthUsername).toBe(
                 "BASIC_AUTH_USERNAME"
             );
@@ -136,6 +131,60 @@ describe("parse", () => {
                 parse(["node", "index.js"]);
             }).toThrow(
                 "--base-url (KINTONE_BASE_URL) must be specified"
+            );
+        });
+    });
+    describe("deprecated options", () => {
+        let spy;
+        beforeEach(() => {
+            spy = jest
+                .spyOn(console, "warn")
+                .mockImplementation();
+        });
+        afterEach(() => {
+            spy.mockRestore();
+        });
+        test("should print the deprecating message with --host", () => {
+            const args = parse([
+                "node",
+                "index.js",
+                "--host",
+                "https://example.kintone.com",
+                "--username",
+                "USERNAME",
+                "--password",
+                "PASSWORD",
+                "--app-id",
+                "APP_ID",
+            ]);
+            expect(args.baseUrl).toBe(
+                "https://example.kintone.com"
+            );
+            expect(spy).toHaveBeenCalledWith(
+                "--host option will be deprecated, please use the --base-url option instead."
+            );
+        });
+        test("should print the deprecating message with --proxyHost and --proxyPort", () => {
+            const args = parse([
+                "node",
+                "index.js",
+                "--base-url",
+                "https://example2.kintone.com",
+                "--username",
+                "USERNAME",
+                "--password",
+                "PASSWORD",
+                "--app-id",
+                "APP_ID",
+                "--proxy-host",
+                "PROXY_HOST",
+                "--proxy-port",
+                "PROXY_PORT",
+            ]);
+            expect(args.proxyHost).toBe("PROXY_HOST");
+            expect(args.proxyPort).toBe("PROXY_PORT");
+            expect(spy).toHaveBeenCalledWith(
+                "--proxy-host and --proxy-port options will be deprecated, please use the --proxy option instead"
             );
         });
     });

--- a/packages/dts-gen/src/cli-parser.ts
+++ b/packages/dts-gen/src/cli-parser.ts
@@ -85,12 +85,12 @@ export function parse(argv: string[]): ParsedArgs {
             "kintone.types"
         )
         .option(
-            "--proxy-host [proxyHost]",
+            "--proxy-host [proxyHost]. This will be replaced with the --proxy option",
             "proxy host",
             null
         )
         .option(
-            "--proxy-port [proxyPort]",
+            "--proxy-port [proxyPort]. This will be replaced with the --proxy option",
             "proxy port",
             null
         )
@@ -134,6 +134,18 @@ export function parse(argv: string[]): ParsedArgs {
         namespace,
         output,
     } = options;
+
+    // warn deprecated options
+    if (host) {
+        console.warn(
+            "--host option will be deprecated, please use the --base-url option instead."
+        );
+    }
+    if (proxyHost || proxyPort) {
+        console.warn(
+            "--proxy-host and --proxy-port options will be deprecated, please use the --proxy option instead"
+        );
+    }
 
     const baseUrl = options.baseUrl || host;
     if (baseUrl === null) {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

This introduces new warning messages for the deprecation of `--host`, `--proxyHost`, and `--proxyPort`.
We'll remove these options in the future, so we have to print warning messages for the options.

## What

<!-- What is a solution you want to add? -->

I've added deprecating messages for the usage of the options.

## How to test

<!-- How can we test this pull request? -->

I've added tests for this, and you can test this by running the cli command of `dts-gen`.

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
