### PR TITLE
chore: drop Node v10 support because of the EOL (BREAKING CHANGE)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/examples/rest-api-client-demo/package.json
+++ b/examples/rest-api-client-demo/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/kintone/js-sdk/issues"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12"
   },
   "dependencies": {
     "@kintone/profile-loader": "^1.1.2",

--- a/packages/create-plugin/package.json
+++ b/packages/create-plugin/package.json
@@ -8,7 +8,7 @@
   },
   "main": "dist/src/index.js",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "repository": {
     "type": "git",

--- a/packages/customize-uploader/package.json
+++ b/packages/customize-uploader/package.json
@@ -7,7 +7,7 @@
   },
   "main": "dist/index.js",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "prebuild": "yarn clean",

--- a/packages/data-loader/package.json
+++ b/packages/data-loader/package.json
@@ -47,7 +47,7 @@
   },
   "homepage": "https://github.com/kintone/js-sdk/tree/master/packages/data-loader#readme",
   "engines": {
-    "node": "^10.17.0 || >=11.14"
+    "node": ">=12"
   },
   "devDependencies": {
     "@types/yargs": "^16.0.1",

--- a/packages/dts-gen/package.json
+++ b/packages/dts-gen/package.json
@@ -20,7 +20,7 @@
     "build:integration": "webpack --mode development --config webpack.config.js"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "author": {
     "name": "Cybozu, Inc.",

--- a/packages/plugin-manifest-validator/package.json
+++ b/packages/plugin-manifest-validator/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.2",
   "author": "Teppei Sato <teppeis@gmail.com>",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "main": "dist/src/index.js",
   "files": [

--- a/packages/plugin-packer/package.json
+++ b/packages/plugin-packer/package.json
@@ -4,7 +4,7 @@
   "version": "4.0.6",
   "author": "Teppei Sato <teppeis@gmail.com>",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "main": "dist/index.js",
   "bin": {

--- a/packages/plugin-uploader/package.json
+++ b/packages/plugin-uploader/package.json
@@ -7,7 +7,7 @@
   },
   "main": "dist/index.js",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "start": "yarn build --watch",

--- a/packages/profile-loader/package.json
+++ b/packages/profile-loader/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/kintone/js-sdk/tree/master/packages/profile-loader#readme",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12"
   },
   "scripts": {
     "prebuild": "yarn clean",

--- a/packages/rest-api-client/package.json
+++ b/packages/rest-api-client/package.json
@@ -54,7 +54,7 @@
   },
   "homepage": "https://github.com/kintone/js-sdk/tree/master/packages/rest-api-client#readme",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12"
   },
   "devDependencies": {
     "@rollup/plugin-babel": "^5.3.0",

--- a/packages/webpack-plugin-kintone-plugin/package.json
+++ b/packages/webpack-plugin-kintone-plugin/package.json
@@ -4,7 +4,7 @@
   "description": "A webpack plugin to generate a plugin zip",
   "main": "dist/index.js",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "start": "yarn build --watch",


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Node v10 is now in EOL, so we can remove supporting the version.

## What

<!-- What is a solution you want to add? -->

I've updated each engine version from v10 to v12 and have updated the versions for the `test` GitHub Actions.
This did not update any implementation, so I expected to be able to use `kintone/js-sdk` with Node v10.
But it won't work in the future.

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `yarn lint` and `yarn test` on the root directory.
