### PR TITLE
feat(data-loader): export attachment files of subtable

### DIFF
--- a/packages/data-loader/README.md
+++ b/packages/data-loader/README.md
@@ -6,7 +6,6 @@ A kintone record importer and exporter.
 
 **THIS IS EXPERIMENTAL, AND THESE FEATURES ARE NOT SUPPORTED YET.**
 
-- Export attachments of fields in table field
 - Import attachemnts
 - Update records when importing
 - When using CSV format, the following fields are not supported

--- a/packages/data-loader/src/controllers/__tests__/export.test.ts
+++ b/packages/data-loader/src/controllers/__tests__/export.test.ts
@@ -115,6 +115,75 @@ describe("export", () => {
     );
     expect(downloadFile.toString()).toBe(testFileData);
   });
+  it("can download files of subtable to a specified directory", async () => {
+    const recordWithAttachment = {
+      $id: {
+        value: "2",
+      },
+      fieldCode: {
+        type: "SINGLE_LINE_TEXT",
+        value: "value1",
+      },
+      subTable: {
+        type: "SUBTABLE",
+        value: [
+          {
+            id: "4",
+            value: {
+              singleLineText: {
+                type: "SINGLE_LINE_TEXT",
+                value: "value1",
+              },
+              attachment: {
+                type: "FILE",
+                value: [
+                  {
+                    contentType: "text/plain",
+                    fileKey: "test-file-key",
+                    name: "test.txt",
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    };
+    const testFileData = "test data";
+
+    const records = [
+      recordWithAttachment,
+      {
+        $id: {
+          value: "3",
+        },
+        fieldCode: {
+          type: "SINGLE_LINE_TEXT",
+          value: "value1",
+        },
+      },
+    ];
+
+    const tempDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "kintone-data-loader-")
+    );
+
+    apiClient.record.getAllRecords = jest.fn().mockResolvedValue(records);
+    apiClient.file.downloadFile = jest.fn().mockResolvedValue(testFileData);
+    const actual = await exportRecords(apiClient, {
+      app: "1",
+      attachmentDir: tempDir,
+    });
+    expect(actual).toStrictEqual(records);
+    const downloadFile = await fs.readFile(
+      path.join(
+        tempDir,
+        recordWithAttachment.$id.value,
+        recordWithAttachment.subTable.value[0].value.attachment.value[0].name
+      )
+    );
+    expect(downloadFile.toString()).toBe(testFileData);
+  });
   it("should throw error when API response is error", () => {
     const error = new Error("error for test");
     apiClient.record.getAllRecords = jest.fn().mockRejectedValueOnce(error);

--- a/packages/data-loader/src/controllers/export.ts
+++ b/packages/data-loader/src/controllers/export.ts
@@ -58,14 +58,18 @@ const getFileInfos = (record: Record): FileInfo[] => {
       return [...acc, ...field.value];
     }
     if (field.type === "SUBTABLE") {
-      const fileInfos = Object.values(field.value.map((f) => f.value))
-        .map((f) => f.value)
-        .reduce<FileInfo[]>((a, f) => {
-          if (f.type === "FILE") {
-            return [...acc, ...f.value];
-          }
-          return acc;
-        }, []);
+      const rows = field.value;
+      const fileInfos = rows
+        .map((r) => {
+          const fieldsInRow = Object.values(r.value);
+          return fieldsInRow.reduce<FileInfo[]>((a, f) => {
+            if (f.type === "FILE") {
+              return [...a, ...f.value];
+            }
+            return a;
+          }, []);
+        })
+        .reduce((a, f) => [...a, ...f], []);
       return [...acc, ...fileInfos];
     }
     return acc;


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

We want to download attachment files of subtable when exporting records.

## What

<!-- What is a solution you want to add? -->

- [x] download attachment files of subtable when exporting records
- [x] add test

## How to test

<!-- How can we test this pull request? -->

```sh
$ cd packages/data-loader
$ yarn build
$ node cli.js export --app=<APP_ID> --attachment-dir=foo # and username, password, base-url
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
