### PR TITLE
test(data-loader): fix flaky tests by extending timeout

### DIFF
--- a/packages/data-loader/src/__tests__/main.test.ts
+++ b/packages/data-loader/src/__tests__/main.test.ts
@@ -10,6 +10,10 @@ const mainFilePath = path.resolve(
   packageJson.bin["kintone-data-loader"]
 );
 
+beforeEach(() => {
+  jest.setTimeout(10000);
+});
+
 const checkRejectArg = ({
   arg,
   errorMessage,


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

some tests are flaky because of its long execution time.

## What

<!-- What is a solution you want to add? -->

- [x] extend timeout duration of tests

I set 10,000 milliseconds as the new timeout duration (twice of the default).

## How to test

<!-- How can we test this pull request? -->

```sh
$ yarn build
$ yarn test
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
