### PR TITLE
feat(data-loader): generate attachment metadata when export (JSON)

### DIFF
--- a/packages/data-loader/src/controllers/__tests__/export.test.ts
+++ b/packages/data-loader/src/controllers/__tests__/export.test.ts
@@ -140,7 +140,7 @@ describe("export", () => {
         type: "SINGLE_LINE_TEXT",
         value: "value1",
       },
-      subTable: {
+      subtable: {
         type: "SUBTABLE",
         value: [
           {
@@ -182,7 +182,7 @@ describe("export", () => {
 
     const attachmentMetadataList = [
       {
-        subTable: [{ attachmentInSubtable: ["test.txt"] }],
+        subtable: [{ attachmentInSubtable: ["test.txt"] }],
       },
       {},
     ];
@@ -208,7 +208,7 @@ describe("export", () => {
       path.join(
         tempDir,
         recordWithAttachment.$id.value,
-        recordWithAttachment.subTable.value[0].value.attachmentInSubtable
+        recordWithAttachment.subtable.value[0].value.attachmentInSubtable
           .value[0].name
       )
     );
@@ -253,7 +253,7 @@ describe("export", () => {
           },
         ],
       },
-      subTable: {
+      subtable: {
         type: "SUBTABLE",
         value: [
           {
@@ -317,7 +317,7 @@ describe("export", () => {
       {
         attachment: ["test.txt", "test-1.txt"],
         attachment2: ["test-2.txt", "test-3.txt"],
-        subTable: [
+        subtable: [
           {
             attachmentInSubtable: ["test-4.txt", "test-5.txt"],
             attachmentInSubtable2: ["test-6.txt", "test-7.txt"],

--- a/packages/data-loader/src/controllers/__tests__/export.test.ts
+++ b/packages/data-loader/src/controllers/__tests__/export.test.ts
@@ -98,7 +98,7 @@ describe("export", () => {
       },
     ];
 
-    const attachmentMetaDataList = [
+    const attachmentMetadataList = [
       {
         attachment: ["test.txt"],
       },
@@ -120,7 +120,7 @@ describe("export", () => {
       path.join(tempDir, "attachments.json")
     );
     expect(JSON.parse(attachmentsJson.toString())).toStrictEqual(
-      attachmentMetaDataList
+      attachmentMetadataList
     );
     const downloadedFile = await fs.readFile(
       path.join(
@@ -180,7 +180,7 @@ describe("export", () => {
       },
     ];
 
-    const attachmentMetaDataList = [
+    const attachmentMetadataList = [
       {
         subTable: [{ attachmentInSubtable: ["test.txt"] }],
       },
@@ -202,7 +202,7 @@ describe("export", () => {
       path.join(tempDir, "attachments.json")
     );
     expect(JSON.parse(attachmentsJson.toString())).toStrictEqual(
-      attachmentMetaDataList
+      attachmentMetadataList
     );
     const downloadedFile = await fs.readFile(
       path.join(
@@ -313,7 +313,7 @@ describe("export", () => {
       },
     ];
 
-    const attachmentMetaDataList = [
+    const attachmentMetadataList = [
       {
         attachment: ["test.txt", "test-1.txt"],
         attachment2: ["test-2.txt", "test-3.txt"],
@@ -342,7 +342,7 @@ describe("export", () => {
       path.join(tempDir, "attachments.json")
     );
     expect(JSON.parse(attachmentsJson.toString())).toStrictEqual(
-      attachmentMetaDataList
+      attachmentMetadataList
     );
   });
   it("should throw error when API response is error", () => {

--- a/packages/data-loader/src/controllers/__tests__/export.test.ts
+++ b/packages/data-loader/src/controllers/__tests__/export.test.ts
@@ -98,6 +98,13 @@ describe("export", () => {
       },
     ];
 
+    const attachmentMetaDataList = [
+      {
+        attachment: ["test.txt"],
+      },
+      {},
+    ];
+
     const tempDir = await fs.mkdtemp(
       path.join(os.tmpdir(), "kintone-data-loader-")
     );
@@ -109,14 +116,20 @@ describe("export", () => {
       attachmentDir: tempDir,
     });
     expect(actual).toStrictEqual(records);
-    const downloadFile = await fs.readFile(
+    const attachmentsJson = await fs.readFile(
+      path.join(tempDir, "attachments.json")
+    );
+    expect(JSON.parse(attachmentsJson.toString())).toStrictEqual(
+      attachmentMetaDataList
+    );
+    const downloadedFile = await fs.readFile(
       path.join(
         tempDir,
         recordWithAttachment.$id.value,
         recordWithAttachment.attachment.value[0].name
       )
     );
-    expect(downloadFile.toString()).toBe(testFileData);
+    expect(downloadedFile.toString()).toBe(testFileData);
   });
   it("can download files of subtable to a specified directory", async () => {
     const recordWithAttachment = {
@@ -137,7 +150,7 @@ describe("export", () => {
                 type: "SINGLE_LINE_TEXT",
                 value: "value1",
               },
-              attachment: {
+              attachmentInSubtable: {
                 type: "FILE",
                 value: [
                   {
@@ -167,6 +180,13 @@ describe("export", () => {
       },
     ];
 
+    const attachmentMetaDataList = [
+      {
+        subTable: [{ attachmentInSubtable: ["test.txt"] }],
+      },
+      {},
+    ];
+
     const tempDir = await fs.mkdtemp(
       path.join(os.tmpdir(), "kintone-data-loader-")
     );
@@ -178,14 +198,21 @@ describe("export", () => {
       attachmentDir: tempDir,
     });
     expect(actual).toStrictEqual(records);
-    const downloadFile = await fs.readFile(
+    const attachmentsJson = await fs.readFile(
+      path.join(tempDir, "attachments.json")
+    );
+    expect(JSON.parse(attachmentsJson.toString())).toStrictEqual(
+      attachmentMetaDataList
+    );
+    const downloadedFile = await fs.readFile(
       path.join(
         tempDir,
         recordWithAttachment.$id.value,
-        recordWithAttachment.subTable.value[0].value.attachment.value[0].name
+        recordWithAttachment.subTable.value[0].value.attachmentInSubtable
+          .value[0].name
       )
     );
-    expect(downloadFile.toString()).toBe(testFileData);
+    expect(downloadedFile.toString()).toBe(testFileData);
   });
   it("should throw error when API response is error", () => {
     const error = new Error("error for test");

--- a/packages/data-loader/src/controllers/attachments.ts
+++ b/packages/data-loader/src/controllers/attachments.ts
@@ -1,4 +1,12 @@
-export type AttachmentMetadata = Record;
+import path from "path";
+import {
+  KintoneRestAPIClient,
+  KintoneRecordField,
+} from "@kintone/rest-api-client";
+import { Record as KintoneRecord } from "@kintone/rest-api-client/lib/client/types";
+import { promises as fs } from "fs";
+
+type AttachmentMetadata = Record;
 
 type Record = {
   [fieldCode: string]: Field;
@@ -12,4 +20,168 @@ export type SubtableField = SubtableRow[];
 
 export type SubtableRow = {
   [fieldCode: string]: FileField;
+};
+//
+// export type AttachmentMetadata = AttachmentMetadataPerRecord;
+//
+// type AttachmentMetadataPerRecord = {
+//   [fieldCode: string]: AttachmentMetadataPerField;
+// };
+//
+// type AttachmentMetadataPerField =
+//   | FilePathList
+//   | AttachmentMetadataPerSubtableField;
+//
+// type FilePathList = string[];
+//
+// export type AttachmentMetadataPerSubtableField =
+//   AttachmentMetadataPerSubtableRow[];
+//
+// export type AttachmentMetadataPerSubtableRow = {
+//   [fieldCode: string]: FilePathList;
+// };
+
+type FilePathAndKeyPair = {
+  filePath: string;
+  fileKey: string;
+};
+
+export const downloadAttachments = async (
+  apiClient: KintoneRestAPIClient,
+  records: KintoneRecord[],
+  attachmentDir: string
+) => {
+  const attachmentMetadataList = [];
+  for (const record of records) {
+    const attachmentMetadata = generateAttachmentMetadata(record);
+    const fileInfos = getFileInfos(record, attachmentMetadata);
+    for (const fileInfo of fileInfos) {
+      const { fileKey, filePath } = fileInfo;
+      const file = await apiClient.file.downloadFile({ fileKey });
+
+      const recordId = record.$id.value as string;
+      const dir = path.resolve(attachmentDir, recordId);
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(path.resolve(dir, filePath), Buffer.from(file));
+    }
+    attachmentMetadataList.push(attachmentMetadata);
+  }
+  await fs.writeFile(
+    path.resolve(attachmentDir, "attachments.json"),
+    JSON.stringify(attachmentMetadataList, null, 2)
+  );
+};
+
+const generateAttachmentMetadata = (
+  record: KintoneRecord
+): AttachmentMetadata => {
+  const localFileNameSet = new Set<string>();
+  return Object.entries(record).reduce<AttachmentMetadata>(
+    (acc, [fieldCode, field]) => {
+      if (field.type === "FILE") {
+        acc[fieldCode] = field.value.map((fileInformation) =>
+          generateUniqueLocalFileName(fileInformation.name, localFileNameSet)
+        );
+      } else if (field.type === "SUBTABLE") {
+        acc[fieldCode] = generateAttachmentMetadataInSubtable(
+          field,
+          localFileNameSet
+        );
+      }
+      return acc;
+    },
+    {}
+  );
+};
+
+const generateAttachmentMetadataInSubtable = <
+  T extends { [field: string]: KintoneRecordField.InSubtable }
+>(
+  subtableField: KintoneRecordField.Subtable<T>,
+  localFileNameSet: Set<string>
+) => {
+  return subtableField.value.map((row) => {
+    return Object.entries(row.value).reduce<SubtableRow>(
+      (acc, [fieldCode, field]) => {
+        if (field.type === "FILE") {
+          acc[fieldCode] = field.value.map((fileInformation) =>
+            generateUniqueLocalFileName(fileInformation.name, localFileNameSet)
+          );
+        }
+        return acc;
+      },
+      {}
+    );
+  });
+};
+
+const getFileInfos = (
+  record: KintoneRecord,
+  attachmentMetadata: AttachmentMetadata
+): FilePathAndKeyPair[] => {
+  return Object.entries(record).reduce<FilePathAndKeyPair[]>(
+    (acc, [fieldCode, field]) => {
+      if (field.type === "FILE") {
+        const fileInfos = field.value.map(
+          (fileInformation, index): FilePathAndKeyPair => ({
+            fileKey: fileInformation.fileKey,
+            filePath: attachmentMetadata[fieldCode][index] as string,
+          })
+        );
+        acc.push(...fileInfos);
+      } else if (field.type === "SUBTABLE") {
+        const fileInfosInSubtable = getFileInfosInSubtable(
+          field,
+          attachmentMetadata[fieldCode] as SubtableField
+        );
+        acc.push(...fileInfosInSubtable);
+      }
+      return acc;
+    },
+    []
+  );
+};
+
+const getFileInfosInSubtable = <
+  T extends { [field: string]: KintoneRecordField.InSubtable }
+>(
+  subtableField: KintoneRecordField.Subtable<T>,
+  attachmentMetadataInSubtable: SubtableField
+): FilePathAndKeyPair[] => {
+  const rows = subtableField.value;
+  return rows
+    .map((row, rowIndex) => {
+      const fieldsInRow = Object.entries(row.value);
+      return fieldsInRow.reduce<FilePathAndKeyPair[]>(
+        (acc, [fieldCode, field]) => {
+          if (field.type === "FILE") {
+            const fileInfos = field.value.map((fileInformation, index) => ({
+              fileKey: fileInformation.fileKey,
+              filePath:
+                attachmentMetadataInSubtable[rowIndex][fieldCode][index],
+            }));
+            acc.push(...fileInfos);
+          }
+          return acc;
+        },
+        []
+      );
+    })
+    .reduce((acc, fileInfos) => acc.concat(fileInfos), []);
+};
+
+const generateUniqueLocalFileName = (
+  fileName: string,
+  localFileNameSet: Set<string>
+) => {
+  let localFileName = fileName;
+  for (let i = 1; localFileNameSet.has(localFileName); i++) {
+    localFileName =
+      path.basename(fileName, path.extname(fileName)) +
+      "-" +
+      i +
+      path.extname(fileName);
+  }
+  localFileNameSet.add(localFileName);
+  return localFileName;
 };

--- a/packages/data-loader/src/controllers/attachments.ts
+++ b/packages/data-loader/src/controllers/attachments.ts
@@ -1,0 +1,31 @@
+export type AttachmentMetaData = Record;
+
+type Record = {
+  id: string;
+  fields: {
+    [fieldCode: string]: Field;
+  };
+};
+
+type Field = FileField | SubTableField;
+
+export type FileField = {
+  type: "FILE";
+  value: FileInfo[];
+};
+
+export type SubTableField = {
+  type: "SUBTABLE";
+  value: SubTableRow[];
+};
+
+export type SubTableRow = {
+  id: string;
+  fields: { [fieldCode: string]: FileField };
+};
+
+type FileInfo = {
+  name: string;
+  filePath: string;
+  fileKey: string;
+};

--- a/packages/data-loader/src/controllers/attachments.ts
+++ b/packages/data-loader/src/controllers/attachments.ts
@@ -4,12 +4,12 @@ type Record = {
   [fieldCode: string]: Field;
 };
 
-type Field = FileField | SubTableField;
+type Field = FileField | SubtableField;
 
 type FileField = string[];
 
-export type SubTableField = SubTableRow[];
+export type SubtableField = SubtableRow[];
 
-export type SubTableRow = {
+export type SubtableRow = {
   [fieldCode: string]: FileField;
 };

--- a/packages/data-loader/src/controllers/attachments.ts
+++ b/packages/data-loader/src/controllers/attachments.ts
@@ -1,31 +1,15 @@
 export type AttachmentMetaData = Record;
 
 type Record = {
-  id: string;
-  fields: {
-    [fieldCode: string]: Field;
-  };
+  [fieldCode: string]: Field;
 };
 
 type Field = FileField | SubTableField;
 
-export type FileField = {
-  type: "FILE";
-  value: FileInfo[];
-};
+type FileField = string[];
 
-export type SubTableField = {
-  type: "SUBTABLE";
-  value: SubTableRow[];
-};
+export type SubTableField = SubTableRow[];
 
 export type SubTableRow = {
-  id: string;
-  fields: { [fieldCode: string]: FileField };
-};
-
-type FileInfo = {
-  name: string;
-  filePath: string;
-  fileKey: string;
+  [fieldCode: string]: FileField;
 };

--- a/packages/data-loader/src/controllers/attachments.ts
+++ b/packages/data-loader/src/controllers/attachments.ts
@@ -34,8 +34,8 @@ export const downloadAttachments = async (
 ) => {
   const recordMetadataList = [];
   for (const record of records) {
-    const recordMetadata = generateRecordMetadata(record);
-    const filePathAndKeys = generateFilePathAndKeys(record, recordMetadata);
+    const recordMetadata = buildRecordMetadata(record);
+    const filePathAndKeys = buildFilePathAndKeys(record, recordMetadata);
     for (const filePathAndKey of filePathAndKeys) {
       const { fileKey, filePath } = filePathAndKey;
       const file = await apiClient.file.downloadFile({ fileKey });
@@ -53,14 +53,14 @@ export const downloadAttachments = async (
   );
 };
 
-const generateRecordMetadata = (record: KintoneRecord): RecordMetadata => {
+const buildRecordMetadata = (record: KintoneRecord): RecordMetadata => {
   const localFileNameSet = new Set<string>();
   return Object.entries(record).reduce<RecordMetadata>(
     (acc, [fieldCode, field]) => {
       if (field.type === "FILE") {
-        acc[fieldCode] = generateFileFieldMetadata(field, localFileNameSet);
+        acc[fieldCode] = buildFileFieldMetadata(field, localFileNameSet);
       } else if (field.type === "SUBTABLE") {
-        acc[fieldCode] = generateSubtableFieldMetadata(field, localFileNameSet);
+        acc[fieldCode] = buildSubtableFieldMetadata(field, localFileNameSet);
       }
       return acc;
     },
@@ -68,7 +68,7 @@ const generateRecordMetadata = (record: KintoneRecord): RecordMetadata => {
   );
 };
 
-const generateFileFieldMetadata = (
+const buildFileFieldMetadata = (
   fileField: KintoneRecordField.File,
   localFileNameSet: Set<string>
 ): FileFieldMetadata => {
@@ -77,7 +77,7 @@ const generateFileFieldMetadata = (
   );
 };
 
-const generateSubtableFieldMetadata = <
+const buildSubtableFieldMetadata = <
   T extends { [field: string]: KintoneRecordField.InSubtable }
 >(
   subtableField: KintoneRecordField.Subtable<T>,
@@ -98,7 +98,7 @@ const generateSubtableFieldMetadata = <
   });
 };
 
-const generateFilePathAndKeys = (
+const buildFilePathAndKeys = (
   record: KintoneRecord,
   attachmentMetadata: RecordMetadata
 ): FilePathAndKey[] => {
@@ -113,7 +113,7 @@ const generateFilePathAndKeys = (
         );
         acc.push(...fileInfos);
       } else if (field.type === "SUBTABLE") {
-        const fileInfosInSubtable = generateFilePathAndKeysInSubtable(
+        const fileInfosInSubtable = buildFilePathAndKeysInSubtable(
           field,
           attachmentMetadata[fieldCode] as SubtableFieldMetadata
         );
@@ -125,7 +125,7 @@ const generateFilePathAndKeys = (
   );
 };
 
-const generateFilePathAndKeysInSubtable = <
+const buildFilePathAndKeysInSubtable = <
   T extends { [field: string]: KintoneRecordField.InSubtable }
 >(
   subtableField: KintoneRecordField.Subtable<T>,

--- a/packages/data-loader/src/controllers/attachments.ts
+++ b/packages/data-loader/src/controllers/attachments.ts
@@ -1,4 +1,4 @@
-export type AttachmentMetaData = Record;
+export type AttachmentMetadata = Record;
 
 type Record = {
   [fieldCode: string]: Field;

--- a/packages/data-loader/src/controllers/attachments.ts
+++ b/packages/data-loader/src/controllers/attachments.ts
@@ -6,43 +6,24 @@ import {
 import { Record as KintoneRecord } from "@kintone/rest-api-client/lib/client/types";
 import { promises as fs } from "fs";
 
-type AttachmentMetadata = Record;
-
-type Record = {
-  [fieldCode: string]: Field;
+type RecordMetadata = {
+  [fieldCode: string]: FieldMetadata;
 };
 
-type Field = FileField | SubtableField;
+type FilePath = string;
 
-type FileField = string[];
+type FieldMetadata = FileFieldMetadata | SubtableFieldMetadata;
 
-export type SubtableField = SubtableRow[];
+type FileFieldMetadata = FilePath[];
 
-export type SubtableRow = {
-  [fieldCode: string]: FileField;
+type SubtableFieldMetadata = SubtableRowMetadata[];
+
+type SubtableRowMetadata = {
+  [fieldCode: string]: FileFieldMetadata;
 };
-//
-// export type AttachmentMetadata = AttachmentMetadataPerRecord;
-//
-// type AttachmentMetadataPerRecord = {
-//   [fieldCode: string]: AttachmentMetadataPerField;
-// };
-//
-// type AttachmentMetadataPerField =
-//   | FilePathList
-//   | AttachmentMetadataPerSubtableField;
-//
-// type FilePathList = string[];
-//
-// export type AttachmentMetadataPerSubtableField =
-//   AttachmentMetadataPerSubtableRow[];
-//
-// export type AttachmentMetadataPerSubtableRow = {
-//   [fieldCode: string]: FilePathList;
-// };
 
-type FilePathAndKeyPair = {
-  filePath: string;
+type FilePathAndKey = {
+  filePath: FilePath;
   fileKey: string;
 };
 
@@ -51,12 +32,12 @@ export const downloadAttachments = async (
   records: KintoneRecord[],
   attachmentDir: string
 ) => {
-  const attachmentMetadataList = [];
+  const recordMetadataList = [];
   for (const record of records) {
-    const attachmentMetadata = generateAttachmentMetadata(record);
-    const fileInfos = getFileInfos(record, attachmentMetadata);
-    for (const fileInfo of fileInfos) {
-      const { fileKey, filePath } = fileInfo;
+    const recordMetadata = generateRecordMetadata(record);
+    const filePathAndKeys = generateFilePathAndKeys(record, recordMetadata);
+    for (const filePathAndKey of filePathAndKeys) {
+      const { fileKey, filePath } = filePathAndKey;
       const file = await apiClient.file.downloadFile({ fileKey });
 
       const recordId = record.$id.value as string;
@@ -64,29 +45,22 @@ export const downloadAttachments = async (
       await fs.mkdir(dir, { recursive: true });
       await fs.writeFile(path.resolve(dir, filePath), Buffer.from(file));
     }
-    attachmentMetadataList.push(attachmentMetadata);
+    recordMetadataList.push(recordMetadata);
   }
   await fs.writeFile(
     path.resolve(attachmentDir, "attachments.json"),
-    JSON.stringify(attachmentMetadataList, null, 2)
+    JSON.stringify(recordMetadataList, null, 2)
   );
 };
 
-const generateAttachmentMetadata = (
-  record: KintoneRecord
-): AttachmentMetadata => {
+const generateRecordMetadata = (record: KintoneRecord): RecordMetadata => {
   const localFileNameSet = new Set<string>();
-  return Object.entries(record).reduce<AttachmentMetadata>(
+  return Object.entries(record).reduce<RecordMetadata>(
     (acc, [fieldCode, field]) => {
       if (field.type === "FILE") {
-        acc[fieldCode] = field.value.map((fileInformation) =>
-          generateUniqueLocalFileName(fileInformation.name, localFileNameSet)
-        );
+        acc[fieldCode] = generateFileFieldMetadata(field, localFileNameSet);
       } else if (field.type === "SUBTABLE") {
-        acc[fieldCode] = generateAttachmentMetadataInSubtable(
-          field,
-          localFileNameSet
-        );
+        acc[fieldCode] = generateSubtableFieldMetadata(field, localFileNameSet);
       }
       return acc;
     },
@@ -94,14 +68,23 @@ const generateAttachmentMetadata = (
   );
 };
 
-const generateAttachmentMetadataInSubtable = <
+const generateFileFieldMetadata = (
+  fileField: KintoneRecordField.File,
+  localFileNameSet: Set<string>
+): FileFieldMetadata => {
+  return fileField.value.map((fileInformation) =>
+    generateUniqueLocalFileName(fileInformation.name, localFileNameSet)
+  );
+};
+
+const generateSubtableFieldMetadata = <
   T extends { [field: string]: KintoneRecordField.InSubtable }
 >(
   subtableField: KintoneRecordField.Subtable<T>,
   localFileNameSet: Set<string>
 ) => {
   return subtableField.value.map((row) => {
-    return Object.entries(row.value).reduce<SubtableRow>(
+    return Object.entries(row.value).reduce<SubtableRowMetadata>(
       (acc, [fieldCode, field]) => {
         if (field.type === "FILE") {
           acc[fieldCode] = field.value.map((fileInformation) =>
@@ -115,24 +98,24 @@ const generateAttachmentMetadataInSubtable = <
   });
 };
 
-const getFileInfos = (
+const generateFilePathAndKeys = (
   record: KintoneRecord,
-  attachmentMetadata: AttachmentMetadata
-): FilePathAndKeyPair[] => {
-  return Object.entries(record).reduce<FilePathAndKeyPair[]>(
+  attachmentMetadata: RecordMetadata
+): FilePathAndKey[] => {
+  return Object.entries(record).reduce<FilePathAndKey[]>(
     (acc, [fieldCode, field]) => {
       if (field.type === "FILE") {
         const fileInfos = field.value.map(
-          (fileInformation, index): FilePathAndKeyPair => ({
+          (fileInformation, index): FilePathAndKey => ({
             fileKey: fileInformation.fileKey,
             filePath: attachmentMetadata[fieldCode][index] as string,
           })
         );
         acc.push(...fileInfos);
       } else if (field.type === "SUBTABLE") {
-        const fileInfosInSubtable = getFileInfosInSubtable(
+        const fileInfosInSubtable = generateFilePathAndKeysInSubtable(
           field,
-          attachmentMetadata[fieldCode] as SubtableField
+          attachmentMetadata[fieldCode] as SubtableFieldMetadata
         );
         acc.push(...fileInfosInSubtable);
       }
@@ -142,30 +125,26 @@ const getFileInfos = (
   );
 };
 
-const getFileInfosInSubtable = <
+const generateFilePathAndKeysInSubtable = <
   T extends { [field: string]: KintoneRecordField.InSubtable }
 >(
   subtableField: KintoneRecordField.Subtable<T>,
-  attachmentMetadataInSubtable: SubtableField
-): FilePathAndKeyPair[] => {
+  attachmentMetadataInSubtable: SubtableFieldMetadata
+): FilePathAndKey[] => {
   const rows = subtableField.value;
   return rows
     .map((row, rowIndex) => {
       const fieldsInRow = Object.entries(row.value);
-      return fieldsInRow.reduce<FilePathAndKeyPair[]>(
-        (acc, [fieldCode, field]) => {
-          if (field.type === "FILE") {
-            const fileInfos = field.value.map((fileInformation, index) => ({
-              fileKey: fileInformation.fileKey,
-              filePath:
-                attachmentMetadataInSubtable[rowIndex][fieldCode][index],
-            }));
-            acc.push(...fileInfos);
-          }
-          return acc;
-        },
-        []
-      );
+      return fieldsInRow.reduce<FilePathAndKey[]>((acc, [fieldCode, field]) => {
+        if (field.type === "FILE") {
+          const fileInfos = field.value.map((fileInformation, index) => ({
+            fileKey: fileInformation.fileKey,
+            filePath: attachmentMetadataInSubtable[rowIndex][fieldCode][index],
+          }));
+          acc.push(...fileInfos);
+        }
+        return acc;
+      }, []);
     })
     .reduce((acc, fileInfos) => acc.concat(fileInfos), []);
 };

--- a/packages/data-loader/src/controllers/attachments.ts
+++ b/packages/data-loader/src/controllers/attachments.ts
@@ -4,17 +4,17 @@ import {
   KintoneRecordField,
 } from "@kintone/rest-api-client";
 import { Record as KintoneRecord } from "@kintone/rest-api-client/lib/client/types";
-import { promises as fs } from "fs";
+import { promises as fs, existsSync } from "fs";
 
 type RecordMetadata = {
   [fieldCode: string]: FieldMetadata;
 };
 
-type FilePath = string;
+type FileName = string;
 
 type FieldMetadata = FileFieldMetadata | SubtableFieldMetadata;
 
-type FileFieldMetadata = FilePath[];
+type FileFieldMetadata = FileName[];
 
 type SubtableFieldMetadata = SubtableRowMetadata[];
 
@@ -22,145 +22,107 @@ type SubtableRowMetadata = {
   [fieldCode: string]: FileFieldMetadata;
 };
 
-type FilePathAndKey = {
-  filePath: FilePath;
-  fileKey: string;
-};
-
 export const downloadAttachments = async (
   apiClient: KintoneRestAPIClient,
   records: KintoneRecord[],
   attachmentDir: string
 ) => {
-  const recordMetadataList = [];
+  const metadataList = [];
   for (const record of records) {
-    const recordMetadata = buildRecordMetadata(record);
-    const filePathAndKeys = buildFilePathAndKeys(record, recordMetadata);
-    for (const filePathAndKey of filePathAndKeys) {
-      const { fileKey, filePath } = filePathAndKey;
-      const file = await apiClient.file.downloadFile({ fileKey });
-
-      const recordId = record.$id.value as string;
-      const dir = path.resolve(attachmentDir, recordId);
-      await fs.mkdir(dir, { recursive: true });
-      await fs.writeFile(path.resolve(dir, filePath), Buffer.from(file));
-    }
-    recordMetadataList.push(recordMetadata);
+    const recordId = record.$id.value as string;
+    const dir = path.resolve(attachmentDir, recordId);
+    const metadata = await downloadRecordAttachments(apiClient, record, dir);
+    metadataList.push(metadata);
   }
   await fs.writeFile(
     path.resolve(attachmentDir, "attachments.json"),
-    JSON.stringify(recordMetadataList, null, 2)
+    JSON.stringify(metadataList, null, 2)
   );
 };
 
-const buildRecordMetadata = (record: KintoneRecord): RecordMetadata => {
-  const localFileNameSet = new Set<string>();
-  return Object.entries(record).reduce<RecordMetadata>(
-    (acc, [fieldCode, field]) => {
-      if (field.type === "FILE") {
-        acc[fieldCode] = buildFileFieldMetadata(field, localFileNameSet);
-      } else if (field.type === "SUBTABLE") {
-        acc[fieldCode] = buildSubtableFieldMetadata(field, localFileNameSet);
-      }
-      return acc;
-    },
-    {}
-  );
-};
-
-const buildFileFieldMetadata = (
-  fileField: KintoneRecordField.File,
-  localFileNameSet: Set<string>
-): FileFieldMetadata => {
-  return fileField.value.map((fileInformation) =>
-    generateUniqueLocalFileName(fileInformation.name, localFileNameSet)
-  );
-};
-
-const buildSubtableFieldMetadata = <
-  T extends { [field: string]: KintoneRecordField.InSubtable }
->(
-  subtableField: KintoneRecordField.Subtable<T>,
-  localFileNameSet: Set<string>
-) => {
-  return subtableField.value.map((row) => {
-    return Object.entries(row.value).reduce<SubtableRowMetadata>(
-      (acc, [fieldCode, field]) => {
-        if (field.type === "FILE") {
-          acc[fieldCode] = field.value.map((fileInformation) =>
-            generateUniqueLocalFileName(fileInformation.name, localFileNameSet)
-          );
-        }
-        return acc;
-      },
-      {}
-    );
-  });
-};
-
-const buildFilePathAndKeys = (
+const downloadRecordAttachments = async (
+  apiClient: KintoneRestAPIClient,
   record: KintoneRecord,
-  attachmentMetadata: RecordMetadata
-): FilePathAndKey[] => {
-  return Object.entries(record).reduce<FilePathAndKey[]>(
-    (acc, [fieldCode, field]) => {
-      if (field.type === "FILE") {
-        const fileInfos = field.value.map(
-          (fileInformation, index): FilePathAndKey => ({
-            fileKey: fileInformation.fileKey,
-            filePath: attachmentMetadata[fieldCode][index] as string,
-          })
-        );
-        acc.push(...fileInfos);
-      } else if (field.type === "SUBTABLE") {
-        const fileInfosInSubtable = buildFilePathAndKeysInSubtable(
-          field,
-          attachmentMetadata[fieldCode] as SubtableFieldMetadata
-        );
-        acc.push(...fileInfosInSubtable);
-      }
-      return acc;
-    },
-    []
-  );
+  attachmentDir: string
+): Promise<RecordMetadata> => {
+  const metadata: RecordMetadata = {};
+  for (const [fieldCode, field] of Object.entries(record)) {
+    if (field.type === "FILE") {
+      metadata[fieldCode] = await downloadFileFieldAttachments(
+        apiClient,
+        field,
+        attachmentDir
+      );
+    } else if (field.type === "SUBTABLE") {
+      metadata[fieldCode] = await downloadSubtableFieldAttachments(
+        apiClient,
+        field,
+        attachmentDir
+      );
+    }
+  }
+  return metadata;
 };
 
-const buildFilePathAndKeysInSubtable = <
+const downloadFileFieldAttachments = async (
+  apiClient: KintoneRestAPIClient,
+  field: KintoneRecordField.File,
+  attachmentDir: string
+): Promise<FileFieldMetadata> => {
+  const metadata: FileFieldMetadata = [];
+  for (const { fileKey, name: fileName } of field.value) {
+    const filePath = path.resolve(attachmentDir, fileName);
+    const file = await apiClient.file.downloadFile({ fileKey });
+    const savedFilePath = await saveFileWithoutOverwrite(filePath, file);
+    metadata.push(path.basename(savedFilePath));
+  }
+  return metadata;
+};
+
+const downloadSubtableFieldAttachments = async <
   T extends { [field: string]: KintoneRecordField.InSubtable }
 >(
-  subtableField: KintoneRecordField.Subtable<T>,
-  attachmentMetadataInSubtable: SubtableFieldMetadata
-): FilePathAndKey[] => {
-  const rows = subtableField.value;
-  return rows
-    .map((row, rowIndex) => {
-      const fieldsInRow = Object.entries(row.value);
-      return fieldsInRow.reduce<FilePathAndKey[]>((acc, [fieldCode, field]) => {
-        if (field.type === "FILE") {
-          const fileInfos = field.value.map((fileInformation, index) => ({
-            fileKey: fileInformation.fileKey,
-            filePath: attachmentMetadataInSubtable[rowIndex][fieldCode][index],
-          }));
-          acc.push(...fileInfos);
-        }
-        return acc;
-      }, []);
-    })
-    .reduce((acc, fileInfos) => acc.concat(fileInfos), []);
+  apiClient: KintoneRestAPIClient,
+  field: KintoneRecordField.Subtable<T>,
+  attachmentDir: string
+): Promise<SubtableFieldMetadata> => {
+  const subtableFieldMetadata: SubtableFieldMetadata = [];
+  for (const row of field.value) {
+    const subtableRowMetadata: SubtableRowMetadata = {};
+    for (const [fieldCodeInRow, fieldInRow] of Object.entries(row.value)) {
+      if (fieldInRow.type === "FILE") {
+        subtableRowMetadata[fieldCodeInRow] =
+          await downloadFileFieldAttachments(
+            apiClient,
+            fieldInRow,
+            attachmentDir
+          );
+      }
+    }
+    subtableFieldMetadata.push(subtableRowMetadata);
+  }
+  return subtableFieldMetadata;
 };
 
-const generateUniqueLocalFileName = (
-  fileName: string,
-  localFileNameSet: Set<string>
-) => {
-  let localFileName = fileName;
-  for (let i = 1; localFileNameSet.has(localFileName); i++) {
-    localFileName =
-      path.basename(fileName, path.extname(fileName)) +
+const saveFileWithoutOverwrite = async (
+  filePath: string,
+  file: any
+): Promise<FileName> => {
+  const uniqueFilePath = generateUniqueLocalFilePath(filePath);
+  await fs.mkdir(path.dirname(uniqueFilePath), { recursive: true });
+  await fs.writeFile(uniqueFilePath, Buffer.from(file));
+  return uniqueFilePath;
+};
+
+const generateUniqueLocalFilePath = (filePath: string) => {
+  let newFilePath = filePath;
+  for (let i = 1; existsSync(newFilePath); i++) {
+    const newFileName =
+      path.basename(filePath, path.extname(filePath)) +
       "-" +
       i +
-      path.extname(fileName);
+      path.extname(filePath);
+    newFilePath = path.resolve(path.dirname(newFilePath), newFileName);
   }
-  localFileNameSet.add(localFileName);
-  return localFileName;
+  return newFilePath;
 };

--- a/packages/data-loader/src/controllers/export.ts
+++ b/packages/data-loader/src/controllers/export.ts
@@ -109,7 +109,6 @@ function generateUniqueLocalFileName(
 ) {
   let localFileName = fileName;
   for (let i = 1; localFileNameSet.has(localFileName); i++) {
-    console.log(localFileName);
     localFileName =
       path.basename(fileName, path.extname(fileName)) +
       "-" +

--- a/packages/data-loader/src/controllers/export.ts
+++ b/packages/data-loader/src/controllers/export.ts
@@ -9,7 +9,7 @@ import { buildRestAPIClient, RestAPIClientOptions } from "../api";
 import { KintoneRecordForResponse } from "../types";
 import { printAsJson } from "../printers/printAsJson";
 import { printAsCsv } from "../printers/printAsCsv";
-import { AttachmentMetadata, SubTableField, SubTableRow } from "./attachments";
+import { AttachmentMetadata, SubtableField, SubtableRow } from "./attachments";
 
 export type Options = {
   app: AppID;
@@ -88,7 +88,7 @@ const generateAttachmentMetadataInSubtable = <
   localFileNameSet: Set<string>
 ) => {
   return subtableField.value.map((row) => {
-    return Object.entries(row.value).reduce<SubTableRow>(
+    return Object.entries(row.value).reduce<SubtableRow>(
       (acc, [fieldCode, field]) => {
         if (field.type === "FILE") {
           acc[fieldCode] = field.value.map((fileInformation) =>
@@ -137,7 +137,7 @@ const getFileInfos = (
       if (field.type === "SUBTABLE") {
         const fileInfosInSubtable = getFileInfosInSubtable(
           field,
-          attachmentMetadata[fieldCode] as SubTableField
+          attachmentMetadata[fieldCode] as SubtableField
         );
         return acc.concat(fileInfosInSubtable);
       }
@@ -151,7 +151,7 @@ const getFileInfosInSubtable = <
   T extends { [field: string]: Field.InSubtable }
 >(
   subtableField: Field.Subtable<T>,
-  attachmentMetadataInSubtable: SubTableField
+  attachmentMetadataInSubtable: SubtableField
 ): FileInfo[] => {
   const rows = subtableField.value;
   return rows

--- a/packages/data-loader/src/controllers/export.ts
+++ b/packages/data-loader/src/controllers/export.ts
@@ -66,14 +66,11 @@ const generateAttachmentMetadata = (record: Record): AttachmentMetadata => {
         acc[fieldCode] = field.value.map((fileInformation) =>
           generateUniqueLocalFileName(fileInformation.name, localFileNameSet)
         );
-        return acc;
-      }
-      if (field.type === "SUBTABLE") {
+      } else if (field.type === "SUBTABLE") {
         acc[fieldCode] = generateAttachmentMetadataInSubtable(
           field,
           localFileNameSet
         );
-        return acc;
       }
       return acc;
     },
@@ -94,7 +91,6 @@ const generateAttachmentMetadataInSubtable = <
           acc[fieldCode] = field.value.map((fileInformation) =>
             generateUniqueLocalFileName(fileInformation.name, localFileNameSet)
           );
-          return acc;
         }
         return acc;
       },
@@ -126,20 +122,19 @@ const getFileInfos = (
   return Object.entries(record).reduce<FileInfo[]>(
     (acc, [fieldCode, field]) => {
       if (field.type === "FILE") {
-        const fileInfos = field.value.map((fileInformation, index) => {
-          return {
+        const fileInfos = field.value.map(
+          (fileInformation, index): FileInfo => ({
             fileKey: fileInformation.fileKey,
             filePath: attachmentMetadata[fieldCode][index] as string,
-          };
-        });
-        return acc.concat(fileInfos);
-      }
-      if (field.type === "SUBTABLE") {
+          })
+        );
+        acc.push(...fileInfos);
+      } else if (field.type === "SUBTABLE") {
         const fileInfosInSubtable = getFileInfosInSubtable(
           field,
           attachmentMetadata[fieldCode] as SubtableField
         );
-        return acc.concat(fileInfosInSubtable);
+        acc.push(...fileInfosInSubtable);
       }
       return acc;
     },
@@ -159,14 +154,11 @@ const getFileInfosInSubtable = <
       const fieldsInRow = Object.entries(row.value);
       return fieldsInRow.reduce<FileInfo[]>((acc, [fieldCode, field]) => {
         if (field.type === "FILE") {
-          const fileInfos = field.value.map((fileInformation, index) => {
-            return {
-              fileKey: fileInformation.fileKey,
-              filePath:
-                attachmentMetadataInSubtable[rowIndex][fieldCode][index],
-            };
-          });
-          return acc.concat(fileInfos);
+          const fileInfos = field.value.map((fileInformation, index) => ({
+            fileKey: fileInformation.fileKey,
+            filePath: attachmentMetadataInSubtable[rowIndex][fieldCode][index],
+          }));
+          acc.push(...fileInfos);
         }
         return acc;
       }, []);

--- a/packages/data-loader/src/controllers/export.ts
+++ b/packages/data-loader/src/controllers/export.ts
@@ -1,15 +1,10 @@
-import { promises as fs } from "fs";
-import path from "path";
-import {
-  KintoneRecordField as Field,
-  KintoneRestAPIClient,
-} from "@kintone/rest-api-client";
-import { AppID, Record } from "@kintone/rest-api-client/lib/client/types";
+import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import { AppID } from "@kintone/rest-api-client/lib/client/types";
 import { buildRestAPIClient, RestAPIClientOptions } from "../api";
 import { KintoneRecordForResponse } from "../types";
 import { printAsJson } from "../printers/printAsJson";
 import { printAsCsv } from "../printers/printAsCsv";
-import { AttachmentMetadata, SubtableField, SubtableRow } from "./attachments";
+import { downloadAttachments } from "./attachments";
 
 export type Options = {
   app: AppID;
@@ -20,11 +15,6 @@ export type Options = {
 };
 
 export type ExportFileFormat = "json" | "csv";
-
-type FileInfo = {
-  filePath: string;
-  fileKey: string;
-};
 
 export const run = async (argv: RestAPIClientOptions & Options) => {
   const apiClient = buildRestAPIClient(argv);
@@ -57,140 +47,6 @@ export async function exportRecords(
 
   return records;
 }
-
-const generateAttachmentMetadata = (record: Record): AttachmentMetadata => {
-  const localFileNameSet = new Set<string>();
-  return Object.entries(record).reduce<AttachmentMetadata>(
-    (acc, [fieldCode, field]) => {
-      if (field.type === "FILE") {
-        acc[fieldCode] = field.value.map((fileInformation) =>
-          generateUniqueLocalFileName(fileInformation.name, localFileNameSet)
-        );
-      } else if (field.type === "SUBTABLE") {
-        acc[fieldCode] = generateAttachmentMetadataInSubtable(
-          field,
-          localFileNameSet
-        );
-      }
-      return acc;
-    },
-    {}
-  );
-};
-
-const generateAttachmentMetadataInSubtable = <
-  T extends { [field: string]: Field.InSubtable }
->(
-  subtableField: Field.Subtable<T>,
-  localFileNameSet: Set<string>
-) => {
-  return subtableField.value.map((row) => {
-    return Object.entries(row.value).reduce<SubtableRow>(
-      (acc, [fieldCode, field]) => {
-        if (field.type === "FILE") {
-          acc[fieldCode] = field.value.map((fileInformation) =>
-            generateUniqueLocalFileName(fileInformation.name, localFileNameSet)
-          );
-        }
-        return acc;
-      },
-      {}
-    );
-  });
-};
-
-function generateUniqueLocalFileName(
-  fileName: string,
-  localFileNameSet: Set<string>
-) {
-  let localFileName = fileName;
-  for (let i = 1; localFileNameSet.has(localFileName); i++) {
-    localFileName =
-      path.basename(fileName, path.extname(fileName)) +
-      "-" +
-      i +
-      path.extname(fileName);
-  }
-  localFileNameSet.add(localFileName);
-  return localFileName;
-}
-
-const getFileInfos = (
-  record: Record,
-  attachmentMetadata: AttachmentMetadata
-): FileInfo[] => {
-  return Object.entries(record).reduce<FileInfo[]>(
-    (acc, [fieldCode, field]) => {
-      if (field.type === "FILE") {
-        const fileInfos = field.value.map(
-          (fileInformation, index): FileInfo => ({
-            fileKey: fileInformation.fileKey,
-            filePath: attachmentMetadata[fieldCode][index] as string,
-          })
-        );
-        acc.push(...fileInfos);
-      } else if (field.type === "SUBTABLE") {
-        const fileInfosInSubtable = getFileInfosInSubtable(
-          field,
-          attachmentMetadata[fieldCode] as SubtableField
-        );
-        acc.push(...fileInfosInSubtable);
-      }
-      return acc;
-    },
-    []
-  );
-};
-
-const getFileInfosInSubtable = <
-  T extends { [field: string]: Field.InSubtable }
->(
-  subtableField: Field.Subtable<T>,
-  attachmentMetadataInSubtable: SubtableField
-): FileInfo[] => {
-  const rows = subtableField.value;
-  return rows
-    .map((row, rowIndex) => {
-      const fieldsInRow = Object.entries(row.value);
-      return fieldsInRow.reduce<FileInfo[]>((acc, [fieldCode, field]) => {
-        if (field.type === "FILE") {
-          const fileInfos = field.value.map((fileInformation, index) => ({
-            fileKey: fileInformation.fileKey,
-            filePath: attachmentMetadataInSubtable[rowIndex][fieldCode][index],
-          }));
-          acc.push(...fileInfos);
-        }
-        return acc;
-      }, []);
-    })
-    .reduce((acc, fileInfos) => acc.concat(fileInfos), []);
-};
-
-const downloadAttachments = async (
-  apiClient: KintoneRestAPIClient,
-  records: Record[],
-  attachmentDir: string
-) => {
-  const attachmentMetadataList = [];
-  for (const record of records) {
-    const attachmentMetadata = generateAttachmentMetadata(record);
-    const fileInfos = getFileInfos(record, attachmentMetadata);
-    for (const fileInfo of fileInfos) {
-      const { fileKey, filePath } = fileInfo;
-      const file = await apiClient.file.downloadFile({ fileKey });
-
-      const recordId = record.$id.value as string;
-      const dir = path.resolve(attachmentDir, recordId);
-      await fs.mkdir(dir, { recursive: true });
-      await fs.writeFile(path.resolve(dir, filePath), Buffer.from(file));
-    }
-    attachmentMetadataList.push(attachmentMetadata);
-  }
-  await fs.writeFile(
-    path.resolve(attachmentDir, "attachments.json"),
-    JSON.stringify(attachmentMetadataList, null, 2)
-  );
-};
 
 async function printRecords({
   records,


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Refer to #950.

This PR resolves two tasks of #950.
- Design the format of the value of attachment file in JSON
- Consider duplicate name of attachments in the same field

## What

<!-- What is a solution you want to add? -->

- [x] generate `attachments.json` when export
- [x] fix existing tests
- [x] add tests

### Metadata spec

- Attachment metadata will be written to `<attachment-dir>/attachments.json`
- Attachment schema is written in [attachment.ts](https://github.com/kintone/js-sdk/pull/887/files#diff-827e45a0ece2af288fafa1cb00e89dd8603b38cdbebecfed2f77cd4c49ea1af9)
- Duplicate file names in a record will be renamed with the index as `<original filename>-<index>.<extension>`

#### Schema example

<details>

If the following records are exported,

```json
[
  {
    "Attachment_0": {
      "type": "FILE",
      "value": [
        {
          "fileKey": "...",
          "name": "image.png",
          "contentType": "image/png",
          "size": "..."
        },
        {
          "fileKey": "...",
          "name": "image.png",
          "contentType": "image/png",
          "size": "..."
        }
      ]
    },
    "Table_0": {
      "type": "SUBTABLE",
      "value": [
        {
          "id": "...",
          "value": {
            "添付ファイル": {
              "type": "FILE",
              "value": [
                {
                  "fileKey": "...",
                  "name": "image.png",
                  "contentType": "image/png",
                  "size": "..."
                },
                {
                  "fileKey": "...",
                  "name": "image.png",
                  "contentType": "image/png",
                  "size": "..."
                }
              ]
            }
          }
        }
      ]
    },
  }
]

```

`attachments.json` will be like this.

```json
[
  {
    "Attachment_0": [
      "image.png",
      "image-1.png"
    ],
    "Table_0": [
      {
        "添付ファイル": [
          "image-2.png",
          "image-3.png"
        ]
      }
    ]
  }
]
```

</details>

## How to test

<!-- How can we test this pull request? -->

```sh
$ yarn build
$ yarn test
```

```sh
$ cd packages/data-loader
$ yarn build
$ node cli.js export --app=<APP_ID> --attachment-dir=foo # and username, password, base-url
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
