### PR TITLE
chore(plugin-uploader): fix typo in package.json

### DIFF
--- a/packages/plugin-uploader/package.json
+++ b/packages/plugin-uploader/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kintone/plugin-uploader",
   "version": "5.0.1",
-  "description": "A kintone plugin uploader using puppetieer",
+  "description": "A kintone plugin uploader using puppeteer",
   "bin": {
     "kintone-plugin-uploader": "bin/cli.js"
   },


### PR DESCRIPTION

## Why

find a typo at `description` in `package.json`

## What

fix typo

## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `yarn lint` and `yarn test` on the root directory.
