### PR TITLE
feat(data-loader): add `--order-by` of export option (BREAKING CHANGE)

### DIFF
--- a/packages/data-loader/README.md
+++ b/packages/data-loader/README.md
@@ -118,7 +118,7 @@ Options:
       --attachment-dir       Attachment file directory                  [string]
       --format               Output format. "json" or "csv"
                                       [choices: "json", "csv"] [default: "json"]
-  -q, --query                The query string                           [string]
+  -c, --condition            The query string                           [string]
       --order-by             The sort order as a query                  [string]
       --pfx-file-path        The path to client certificate file        [string]
       --pfx-file-password    The password of client certificate file    [string]

--- a/packages/data-loader/README.md
+++ b/packages/data-loader/README.md
@@ -119,6 +119,7 @@ Options:
       --format               Output format. "json" or "csv"
                                       [choices: "json", "csv"] [default: "json"]
   -q, --query                The query string                           [string]
+      --order-by             The sort order as a query                  [string]
       --pfx-file-path        The path to client certificate file        [string]
       --pfx-file-password    The password of client certificate file    [string]
 ```

--- a/packages/data-loader/src/commands/export.ts
+++ b/packages/data-loader/src/commands/export.ts
@@ -71,6 +71,10 @@ export const builder = (args: yargs.Argv) =>
       describe: "The query string",
       type: "string",
     })
+    .option("order-by", {
+      description: "The sort order as a query",
+      type: "string",
+    })
     .option("pfx-file-path", {
       describe: "The path to client certificate file",
       type: "string",
@@ -102,6 +106,7 @@ export const handler = (args: Args) => {
     attachmentDir: args["attachment-dir"],
     format: args.format,
     query: args.query,
+    orderBy: args["order-by"],
     pfxFilePath: args["pfx-file-path"],
     pfxFilePassword: args["pfx-file-password"],
   });

--- a/packages/data-loader/src/commands/export.ts
+++ b/packages/data-loader/src/commands/export.ts
@@ -66,8 +66,8 @@ export const builder = (args: yargs.Argv) =>
       default: "json" as ExportFileFormat,
       choices: formats,
     })
-    .option("query", {
-      alias: "q",
+    .option("condition", {
+      alias: "c",
       describe: "The query string",
       type: "string",
     })
@@ -105,7 +105,7 @@ export const handler = (args: Args) => {
     guestSpaceId: args["guest-space-id"],
     attachmentDir: args["attachment-dir"],
     format: args.format,
-    query: args.query,
+    condition: args.condition,
     orderBy: args["order-by"],
     pfxFilePath: args["pfx-file-path"],
     pfxFilePassword: args["pfx-file-password"],

--- a/packages/data-loader/src/controllers/__tests__/export.test.ts
+++ b/packages/data-loader/src/controllers/__tests__/export.test.ts
@@ -24,19 +24,19 @@ describe("export", () => {
     const getAllRecordsMockFn = jest.fn().mockResolvedValue([{}]);
     apiClient.record.getAllRecords = getAllRecordsMockFn;
     const APP_ID = 1;
-    const QUERY = 'Customer like "foo"';
+    const CONDITION = 'Customer like "foo"';
     const ORDER_BY = "Customer desc";
 
     await exportRecords(apiClient, {
       app: APP_ID,
       attachmentDir: "",
-      query: QUERY,
+      condition: CONDITION,
       orderBy: ORDER_BY,
     });
 
     expect(getAllRecordsMockFn.mock.calls[0][0]).toStrictEqual({
       app: APP_ID,
-      condition: QUERY,
+      condition: CONDITION,
       orderBy: ORDER_BY,
     });
   });

--- a/packages/data-loader/src/controllers/__tests__/export.test.ts
+++ b/packages/data-loader/src/controllers/__tests__/export.test.ts
@@ -25,16 +25,19 @@ describe("export", () => {
     apiClient.record.getAllRecords = getAllRecordsMockFn;
     const APP_ID = 1;
     const QUERY = 'Customer like "foo"';
+    const ORDER_BY = "Customer desc";
 
     await exportRecords(apiClient, {
       app: APP_ID,
       attachmentDir: "",
       query: QUERY,
+      orderBy: ORDER_BY,
     });
 
     expect(getAllRecordsMockFn.mock.calls[0][0]).toStrictEqual({
       app: APP_ID,
       condition: QUERY,
+      orderBy: ORDER_BY,
     });
   });
 

--- a/packages/data-loader/src/controllers/export.ts
+++ b/packages/data-loader/src/controllers/export.ts
@@ -12,6 +12,7 @@ export type Options = {
   attachmentDir?: string;
   format?: ExportFileFormat;
   query?: string;
+  orderBy?: string;
 };
 
 export type ExportFileFormat = "json" | "csv";
@@ -35,10 +36,11 @@ export async function exportRecords(
   apiClient: KintoneRestAPIClient,
   options: Options
 ) {
-  const { app, attachmentDir, query } = options;
+  const { app, attachmentDir, query, orderBy } = options;
   const records = await apiClient.record.getAllRecords({
     app,
     condition: query,
+    orderBy,
   });
 
   // TODO: filter fields

--- a/packages/data-loader/src/controllers/export.ts
+++ b/packages/data-loader/src/controllers/export.ts
@@ -11,7 +11,7 @@ export type Options = {
   app: AppID;
   attachmentDir?: string;
   format?: ExportFileFormat;
-  query?: string;
+  condition?: string;
   orderBy?: string;
 };
 
@@ -36,10 +36,10 @@ export async function exportRecords(
   apiClient: KintoneRestAPIClient,
   options: Options
 ) {
-  const { app, attachmentDir, query, orderBy } = options;
+  const { app, attachmentDir, condition, orderBy } = options;
   const records = await apiClient.record.getAllRecords({
     app,
-    condition: query,
+    condition,
     orderBy,
   });
 


### PR DESCRIPTION
## Why

I want to export records which to sort by any field. 

## What

- add `--order-by` option
- rename an export option as `--query` (`-q`) -> `--condition` (`-c`)

## How to test

```shell
$ yarn build
$ node lib/main.js export --app APP_ID --order-by "Customer desc"
```

The result is sort by `Customer` field in descending order.


## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
