### PR TITLE
fix(customize-uploader): upload customize files sequentially

### DIFF
--- a/packages/customize-uploader/src/commands/index.ts
+++ b/packages/customize-uploader/src/commands/index.ts
@@ -51,33 +51,32 @@ export async function upload(
     if (!updateBody) {
       console.log(m("M_StartUploading"));
       try {
-        const [desktopJS, desktopCSS, mobileJS, mobileCSS] = await Promise.all(
-          [
-            manifest.desktop.js,
-            manifest.desktop.css,
-            manifest.mobile.js,
-            manifest.mobile.css,
-          ].map((files) =>
-            Promise.all(
-              files.map((file: string) =>
-                kintoneApiClient.prepareCustomizeFile(file).then((result) => {
-                  if (result.type === "FILE") {
-                    console.log(`${file} ` + m("M_Uploaded"));
-                  }
-                  return result;
-                })
-              )
-            )
-          )
-        );
+        const uploadFilesResult = [];
+        for (const files of [
+          manifest.desktop.js,
+          manifest.desktop.css,
+          manifest.mobile.js,
+          manifest.mobile.css,
+        ]) {
+          const results = [];
+          for (const file of files) {
+            const result = await kintoneApiClient.prepareCustomizeFile(file);
+            if (result.type === "FILE") {
+              console.log(`${file} ` + m("M_Uploaded"));
+            }
+            results.push(result);
+          }
+          uploadFilesResult.push(results);
+        }
+
         updateBody = Object.assign({}, manifest, {
           desktop: {
-            js: desktopJS,
-            css: desktopCSS,
+            js: uploadFilesResult[0],
+            css: uploadFilesResult[1],
           },
           mobile: {
-            js: mobileJS,
-            css: mobileCSS,
+            js: uploadFilesResult[2],
+            css: uploadFilesResult[3],
           },
         });
         console.log(m("M_FileUploaded"));


### PR DESCRIPTION

## Why

For impact to performance, we want to avoid uploading customize files in parallel.


## What

upload customize files sequentially.


## How to test

```shell
yarn build
bin/cli.js sample/customize-manifest.json
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
