### PR TITLE
chore: create release page with release

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "preinitial:release": "yarn prerelease",
     "initial:release": "lerna publish from-package --conventional-commits",
     "prerelease": "npm-run-all -s build -p lint test",
-    "release": "lerna publish --conventional-commits",
+    "release": "lerna publish --conventional-commits --create-release github",
     "pretest": "jest --rootDir __tests__",
     "start": "yarn build --watch",
     "test": "lerna run test --parallel",


### PR DESCRIPTION
## Why

If I will check release notes of js-sdk, should check  CHANGELOG.md under each package.
Famous libraries such as React are often writing a release page in Github.
- https://github.com/facebook/react/releases/tag/v17.0.2
- https://github.com/almin/almin/releases/tag/almin%400.19.0

## What

Use `--create-release` with `lerna publish`, Lerna creates a release page.
https://github.com/lerna/lerna/blob/main/commands/version/README.md#--create-release-type
⚠️ Please add your GitHub authentication token to the `GH_TOKEN` environment variable in your pc.

## How to test

In a test repository, I executed `lerna publish --conventional-commits --create-release github`,  and I confirm created a release page.

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `yarn lint` and `yarn test` on the root directory.
