### PR TITLE
fix(data-loader): fix attachment metadata schema

### DIFF
--- a/packages/data-loader/src/controllers/__tests__/export.test.ts
+++ b/packages/data-loader/src/controllers/__tests__/export.test.ts
@@ -100,7 +100,7 @@ describe("export", () => {
 
     const attachmentMetadataList = [
       {
-        attachment: ["2/test.txt"],
+        attachment: [path.join("2", "test.txt")],
       },
       {},
     ];
@@ -182,7 +182,7 @@ describe("export", () => {
 
     const attachmentMetadataList = [
       {
-        subtable: [{ attachmentInSubtable: ["2/test.txt"] }],
+        subtable: [{ attachmentInSubtable: [path.join("2", "test.txt")] }],
       },
       {},
     ];
@@ -315,12 +315,21 @@ describe("export", () => {
 
     const attachmentMetadataList = [
       {
-        attachment: ["2/test.txt", "2/test-1.txt"],
-        attachment2: ["2/test-2.txt", "2/test-3.txt"],
+        attachment: [path.join("2", "test.txt"), path.join("2", "test-1.txt")],
+        attachment2: [
+          path.join("2", "test-2.txt"),
+          path.join("2", "test-3.txt"),
+        ],
         subtable: [
           {
-            attachmentInSubtable: ["2/test-4.txt", "2/test-5.txt"],
-            attachmentInSubtable2: ["2/test-6.txt", "2/test-7.txt"],
+            attachmentInSubtable: [
+              path.join("2", "test-4.txt"),
+              path.join("2", "test-5.txt"),
+            ],
+            attachmentInSubtable2: [
+              path.join("2", "test-6.txt"),
+              path.join("2", "test-7.txt"),
+            ],
           },
         ],
       },

--- a/packages/data-loader/src/controllers/__tests__/export.test.ts
+++ b/packages/data-loader/src/controllers/__tests__/export.test.ts
@@ -100,7 +100,7 @@ describe("export", () => {
 
     const attachmentMetadataList = [
       {
-        attachment: ["test.txt"],
+        attachment: ["2/test.txt"],
       },
       {},
     ];
@@ -182,7 +182,7 @@ describe("export", () => {
 
     const attachmentMetadataList = [
       {
-        subtable: [{ attachmentInSubtable: ["test.txt"] }],
+        subtable: [{ attachmentInSubtable: ["2/test.txt"] }],
       },
       {},
     ];
@@ -315,12 +315,12 @@ describe("export", () => {
 
     const attachmentMetadataList = [
       {
-        attachment: ["test.txt", "test-1.txt"],
-        attachment2: ["test-2.txt", "test-3.txt"],
+        attachment: ["2/test.txt", "2/test-1.txt"],
+        attachment2: ["2/test-2.txt", "2/test-3.txt"],
         subtable: [
           {
-            attachmentInSubtable: ["test-4.txt", "test-5.txt"],
-            attachmentInSubtable2: ["test-6.txt", "test-7.txt"],
+            attachmentInSubtable: ["2/test-4.txt", "2/test-5.txt"],
+            attachmentInSubtable2: ["2/test-6.txt", "2/test-7.txt"],
           },
         ],
       },

--- a/packages/data-loader/src/controllers/attachments.ts
+++ b/packages/data-loader/src/controllers/attachments.ts
@@ -126,8 +126,8 @@ const downloadFileFieldAttachments = async (params: {
   const metadata: FileFieldMetadata = [];
   for (const { fileKey, name: fileName } of field.value) {
     const filePath = path.join(targetDir, fileName);
-    const file = await apiClient.file.downloadFile({ fileKey });
-    const savedFilePath = await saveFileWithoutOverwrite(filePath, file);
+    const fileBuffer = await apiClient.file.downloadFile({ fileKey });
+    const savedFilePath = await saveFileWithoutOverwrite(filePath, fileBuffer);
     const relativePath = path.relative(metadataBaseDir, savedFilePath);
     metadata.push(relativePath);
   }
@@ -136,11 +136,11 @@ const downloadFileFieldAttachments = async (params: {
 
 const saveFileWithoutOverwrite = async (
   filePath: string,
-  file: any
+  fileBuffer: any
 ): Promise<FileName> => {
   const uniqueFilePath = generateUniqueLocalFilePath(filePath);
   await fs.mkdir(path.dirname(uniqueFilePath), { recursive: true });
-  await fs.writeFile(uniqueFilePath, Buffer.from(file));
+  await fs.writeFile(uniqueFilePath, Buffer.from(fileBuffer));
   return uniqueFilePath;
 };
 

--- a/packages/data-loader/src/controllers/export.ts
+++ b/packages/data-loader/src/controllers/export.ts
@@ -42,7 +42,7 @@ export async function exportRecords(
   // TODO: extract attachment fields first
 
   if (attachmentDir) {
-    await downloadAttachments(apiClient, records, attachmentDir);
+    await downloadAttachments({ apiClient, records, targetDir: attachmentDir });
   }
 
   return records;


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

With the current schema, attachments are stored in `<attachmentDir>/<record ID>/<filename>`,
but there is no record ID information in the metadata.

## What

<!-- What is a solution you want to add? -->
- [x] fix metadata schema
- [x] fix existing tests

### Schema difference between current and new

Refer #887 for the current schema.

In this PR, the leaf node will be changed.
- current: filename of attachment file
- new: relative path of attachment file from `attachments.json`

#### Schema example

<details>

If the following records are exported,

```json
[
  {
    "Attachment_0": {
      "type": "FILE",
      "value": [
        {
          "fileKey": "...",
          "name": "image.png",
          "contentType": "image/png",
          "size": "..."
        },
        {
          "fileKey": "...",
          "name": "image.png",
          "contentType": "image/png",
          "size": "..."
        }
      ]
    },
    "Table_0": {
      "type": "SUBTABLE",
      "value": [
        {
          "id": "...",
          "value": {
            "添付ファイル": {
              "type": "FILE",
              "value": [
                {
                  "fileKey": "...",
                  "name": "image.png",
                  "contentType": "image/png",
                  "size": "..."
                },
                {
                  "fileKey": "...",
                  "name": "image.png",
                  "contentType": "image/png",
                  "size": "..."
                }
              ]
            }
          }
        }
      ]
    },
  }
]

```

attachment files will be saved like following,

```
attachments
├── <record ID>
│   ├── image.png
│   ├── image-1.png
│   ├── image-2.png
│   ├── image-3.png
└── attachments.json
```

and `attachments.json` will be like following.

```json
[
  {
    "Attachment_0": [
      "<record ID>/image.png",
      "<record ID>/image-1.png"
    ],
    "Table_0": [
      {
        "添付ファイル": [
          "<record ID>/image-2.png",
          "<record ID>/image-3.png"
        ]
      }
    ]
  }
]
```

</details>

## How to test

<!-- How can we test this pull request? -->

```sh
$ yarn build
$ yarn test
```

```sh
$ cd packages/data-loader
$ yarn build
$ node cli.js export --app=<APP_ID> --attachment-dir=foo # and username, password, base-url
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
