### PR TITLE
fix(customize-uploader): pass the value of `--proxy`

### DIFF
--- a/packages/customize-uploader/src/KintoneApiClient.ts
+++ b/packages/customize-uploader/src/KintoneApiClient.ts
@@ -1,5 +1,5 @@
 import { KintoneRestAPIClient } from "@kintone/rest-api-client";
-import { isUrlString, wait } from "./util";
+import { isUrlString, parseProxy, wait } from "./util";
 
 export interface Option {
   proxy: string;
@@ -50,6 +50,10 @@ export default class KintoneApiClient {
     if (options.guestSpaceId) {
       guestSpaceId = options.guestSpaceId;
     }
+    let proxy;
+    if (options.proxy) {
+      proxy = parseProxy(options.proxy);
+    }
     this.restApiClient = new KintoneRestAPIClient({
       baseUrl: kintoneUrl,
       auth,
@@ -58,6 +62,7 @@ export default class KintoneApiClient {
         enableAbortSearchError: false,
       },
       guestSpaceId,
+      proxy,
     });
   }
 

--- a/packages/customize-uploader/src/__tests__/util.test.ts
+++ b/packages/customize-uploader/src/__tests__/util.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { isUrlString, wait } from "../util";
+import { isUrlString, parseProxy, wait } from "../util";
 
 describe("util", () => {
   describe("isUrlString", () => {
@@ -18,6 +18,29 @@ describe("util", () => {
       const start = Date.now();
       return wait(100).then(() => {
         assert(Date.now() >= start + 90);
+      });
+    });
+  });
+
+  describe("parseProxy", () => {
+    it("should return proxy object", () => {
+      const host = "localhost";
+      const port = 8080;
+      const result = parseProxy(`http://${host}:${port}`);
+      expect(result).toStrictEqual({ host, port, auth: undefined });
+    });
+    it("should return proxy object with username and password", () => {
+      const host = "localhost";
+      const port = 8080;
+      const username = "USERNAME";
+      const password = "PASSWORD";
+      const result = parseProxy(
+        `http://${username}:${password}@${host}:${port}`
+      );
+      expect(result).toStrictEqual({
+        host,
+        port,
+        auth: { username, password },
       });
     });
   });

--- a/packages/customize-uploader/src/util.ts
+++ b/packages/customize-uploader/src/util.ts
@@ -5,3 +5,23 @@ export function isUrlString(str: string): boolean {
 export async function wait(ms: number): Promise<void> {
   await new Promise((r) => setTimeout(r, ms));
 }
+
+export function parseProxy(proxy: string): {
+  host: string;
+  port: number;
+  auth?: {
+    username: string;
+    password: string;
+  };
+} {
+  const { hostname, port, username, password } = new URL(proxy);
+  let auth;
+  if (username && password) {
+    auth = { username, password };
+  }
+  return {
+    host: hostname,
+    port: Number(port),
+    auth,
+  };
+}


### PR DESCRIPTION
## Why

Fixes #1009.

Even if specify `--proxy` option, customize-uploader is not using the value.
https://github.com/kintone/js-sdk/blob/a6c7ee5eb9ea3a0d647fe8cbec0f16667681295e/packages/customize-uploader/src/KintoneApiClient.ts#L53

## What

pass the specified proxy value to KintoneRestAPIClient

## How to test

1. Setup a proxy server using [Squid](http://www.squid-cache.org/).
  The proxy server is `http://localhost:3128`
2. execute customize-uploader with proxy option
   ```shell
   $ cd packages/customize-uploader
   $ bin/cli.js sample/customize-manifest.json --proxy http://localhost:3128
   ```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
