### PR TITLE
style(dts-gen): remove prettier config

### DIFF
--- a/packages/dts-gen/package.json
+++ b/packages/dts-gen/package.json
@@ -8,7 +8,7 @@
     "build": "tsc --build --force",
     "postbuild": "bin/npm-build.sh && yarn build:integration",
     "clean": "rimraf dist",
-    "lint:fix": "eslint --fix src/**/*.ts",
+    "lint:fix": "yarn lint --fix",
     "lint": "eslint 'src/**/*.ts'",
     "demo": "node dist/index.js --demo --type-name DemoFields -o demo-fields.d.ts",
     "generate": "node dist/index.js --host https://****.cybozu.com --username *** --password *** --app-id ***",

--- a/packages/dts-gen/prettier.config.js
+++ b/packages/dts-gen/prettier.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-    tabWidth: 4,
-    printWidth: 60,
-    trailingComma: "es5",
-};

--- a/packages/dts-gen/src/cli-parser.test.ts
+++ b/packages/dts-gen/src/cli-parser.test.ts
@@ -1,74 +1,65 @@
 import { parse } from "./cli-parser";
 
 describe("parse", () => {
-    describe("with environment variables", () => {
-        beforeEach(() => {
-            process.env.KINTONE_BASE_URL =
-                "https://example.kintone.com";
-            process.env.KINTONE_USERNAME = "admin";
-            process.env.KINTONE_PASSWORD = "password";
-            process.env.KINTONE_BASIC_AUTH_USERNAME =
-                "basic-auth-admin";
-            process.env.KINTONE_BASIC_AUTH_PASSWORD =
-                "basic-auth-password";
-            process.env.KINTONE_API_TOKEN = "api-token";
-            process.env.KINTONE_OAUTH_TOKEN = "oauth-token";
-        });
-        afterEach(() => {
-            delete process.env.KINTONE_BASE_URL;
-            delete process.env.KINTONE_USERNAME;
-            delete process.env.KINTONE_PASSWORD;
-            delete process.env.KINTONE_BASIC_AUTH_USERNAME;
-            delete process.env.KINTONE_BASIC_AUTH_PASSWORD;
-            delete process.env.KINTONE_API_TOKEN;
-            delete process.env.KINTONE_OAUTH_TOKEN;
-        });
-        test("default values", () => {
-            const args = parse(["node", "index.js"]);
-            expect(args.username).toBe("admin");
-            expect(args.password).toBe("password");
-            expect(args.baseUrl).toBe(
-                "https://example.kintone.com"
-            );
-            expect(args.basicAuthUsername).toBe(
-                "basic-auth-admin"
-            );
-            expect(args.basicAuthPassword).toBe(
-                "basic-auth-password"
-            );
-            expect(args.apiToken).toBe("api-token");
-            expect(args.oAuthToken).toBe("oauth-token");
-            expect(args.output).toBe("fields.d.ts");
-        });
+  describe("with environment variables", () => {
+    beforeEach(() => {
+      process.env.KINTONE_BASE_URL = "https://example.kintone.com";
+      process.env.KINTONE_USERNAME = "admin";
+      process.env.KINTONE_PASSWORD = "password";
+      process.env.KINTONE_BASIC_AUTH_USERNAME = "basic-auth-admin";
+      process.env.KINTONE_BASIC_AUTH_PASSWORD = "basic-auth-password";
+      process.env.KINTONE_API_TOKEN = "api-token";
+      process.env.KINTONE_OAUTH_TOKEN = "oauth-token";
     });
-    describe("without environment variables", () => {
-        test("default values", () => {
-            // prettier-ignore
-            const args = parse([
+    afterEach(() => {
+      delete process.env.KINTONE_BASE_URL;
+      delete process.env.KINTONE_USERNAME;
+      delete process.env.KINTONE_PASSWORD;
+      delete process.env.KINTONE_BASIC_AUTH_USERNAME;
+      delete process.env.KINTONE_BASIC_AUTH_PASSWORD;
+      delete process.env.KINTONE_API_TOKEN;
+      delete process.env.KINTONE_OAUTH_TOKEN;
+    });
+    test("default values", () => {
+      const args = parse(["node", "index.js"]);
+      expect(args.username).toBe("admin");
+      expect(args.password).toBe("password");
+      expect(args.baseUrl).toBe("https://example.kintone.com");
+      expect(args.basicAuthUsername).toBe("basic-auth-admin");
+      expect(args.basicAuthPassword).toBe("basic-auth-password");
+      expect(args.apiToken).toBe("api-token");
+      expect(args.oAuthToken).toBe("oauth-token");
+      expect(args.output).toBe("fields.d.ts");
+    });
+  });
+  describe("without environment variables", () => {
+    test("default values", () => {
+      // prettier-ignore
+      const args = parse([
                 "node",
                 "index.js",
                 "--base-url", "https://example2.kintone.com",
             ]);
 
-            expect(args.demo).toBe(false);
-            expect(args.username).toBeNull();
-            expect(args.password).toBeNull();
-            expect(args.apiToken).toBeNull();
-            expect(args.oAuthToken).toBeNull();
-            expect(args.appId).toBeNull();
-            expect(args.guestSpaceId).toBeNull();
-            expect(args.preview).toBe(false);
-            expect(args.namespace).toBe("kintone.types");
-            expect(args.proxyHost).toBeNull();
-            expect(args.proxyPort).toBeNull();
-            expect(args.basicAuthUsername).toBeNull();
-            expect(args.basicAuthPassword).toBeNull();
-            expect(args.output).toBe("fields.d.ts");
-        });
+      expect(args.demo).toBe(false);
+      expect(args.username).toBeNull();
+      expect(args.password).toBeNull();
+      expect(args.apiToken).toBeNull();
+      expect(args.oAuthToken).toBeNull();
+      expect(args.appId).toBeNull();
+      expect(args.guestSpaceId).toBeNull();
+      expect(args.preview).toBe(false);
+      expect(args.namespace).toBe("kintone.types");
+      expect(args.proxyHost).toBeNull();
+      expect(args.proxyPort).toBeNull();
+      expect(args.basicAuthUsername).toBeNull();
+      expect(args.basicAuthPassword).toBeNull();
+      expect(args.output).toBe("fields.d.ts");
+    });
 
-        test("long flag values", () => {
-            // prettier-ignore
-            const args = parse([
+    test("long flag values", () => {
+      // prettier-ignore
+      const args = parse([
                 "node", "index.js",
                 "--base-url", "https://example2.kintone.com",
                 "--demo",
@@ -86,33 +77,25 @@ describe("parse", () => {
                 "--output", "OUTPUT"
             ]);
 
-            expect(args.demo).toBe(true);
-            expect(args.baseUrl).toBe(
-                "https://example2.kintone.com"
-            );
-            expect(args.username).toBe("USERNAME");
-            expect(args.password).toBe("PASSWORD");
-            expect(args.apiToken).toBe("API_TOKEN");
-            expect(args.oAuthToken).toBe("OAUTH_TOKEN");
-            expect(args.appId).toBe("APP_ID");
-            expect(args.guestSpaceId).toBe(
-                "GUEST_SPACE_ID"
-            );
-            expect(args.preview).toBe(true);
-            expect(args.typeName).toBe("TYPE_NAME");
-            expect(args.namespace).toBe("NAMESPACE");
-            expect(args.basicAuthUsername).toBe(
-                "BASIC_AUTH_USERNAME"
-            );
-            expect(args.basicAuthPassword).toBe(
-                "BASIC_AUTH_PASSWORD"
-            );
-            expect(args.output).toBe("OUTPUT");
-        });
+      expect(args.demo).toBe(true);
+      expect(args.baseUrl).toBe("https://example2.kintone.com");
+      expect(args.username).toBe("USERNAME");
+      expect(args.password).toBe("PASSWORD");
+      expect(args.apiToken).toBe("API_TOKEN");
+      expect(args.oAuthToken).toBe("OAUTH_TOKEN");
+      expect(args.appId).toBe("APP_ID");
+      expect(args.guestSpaceId).toBe("GUEST_SPACE_ID");
+      expect(args.preview).toBe(true);
+      expect(args.typeName).toBe("TYPE_NAME");
+      expect(args.namespace).toBe("NAMESPACE");
+      expect(args.basicAuthUsername).toBe("BASIC_AUTH_USERNAME");
+      expect(args.basicAuthPassword).toBe("BASIC_AUTH_PASSWORD");
+      expect(args.output).toBe("OUTPUT");
+    });
 
-        test("short flag values", () => {
-            // prettier-ignore
-            const args = parse([
+    test("short flag values", () => {
+      // prettier-ignore
+      const args = parse([
                 "node", "index.js",
                 "--base-url", "https://example2.kintone.com",
                 "-u", "USERNAME",
@@ -120,72 +103,66 @@ describe("parse", () => {
                 "-o", "OUTPUT"
             ]);
 
-            expect(args.username).toBe("USERNAME");
-            expect(args.password).toBe("PASSWORD");
-            expect(args.output).toBe("OUTPUT");
-        });
+      expect(args.username).toBe("USERNAME");
+      expect(args.password).toBe("PASSWORD");
+      expect(args.output).toBe("OUTPUT");
     });
-    describe("validations", () => {
-        test("unspecified baseUrl", () => {
-            expect(() => {
-                parse(["node", "index.js"]);
-            }).toThrow(
-                "--base-url (KINTONE_BASE_URL) must be specified"
-            );
-        });
+  });
+  describe("validations", () => {
+    test("unspecified baseUrl", () => {
+      expect(() => {
+        parse(["node", "index.js"]);
+      }).toThrow("--base-url (KINTONE_BASE_URL) must be specified");
     });
-    describe("deprecated options", () => {
-        let spy;
-        beforeEach(() => {
-            spy = jest
-                .spyOn(console, "warn")
-                .mockImplementation();
-        });
-        afterEach(() => {
-            spy.mockRestore();
-        });
-        test("should print the deprecating message with --host", () => {
-            const args = parse([
-                "node",
-                "index.js",
-                "--host",
-                "https://example.kintone.com",
-                "--username",
-                "USERNAME",
-                "--password",
-                "PASSWORD",
-                "--app-id",
-                "APP_ID",
-            ]);
-            expect(args.baseUrl).toBe(
-                "https://example.kintone.com"
-            );
-            expect(spy).toHaveBeenCalledWith(
-                "--host option will be deprecated, please use the --base-url option instead."
-            );
-        });
-        test("should print the deprecating message with --proxyHost and --proxyPort", () => {
-            const args = parse([
-                "node",
-                "index.js",
-                "--base-url",
-                "https://example2.kintone.com",
-                "--username",
-                "USERNAME",
-                "--password",
-                "PASSWORD",
-                "--app-id",
-                "APP_ID",
-                "--proxy-host",
-                "PROXY_HOST",
-                "--proxy-port",
-                "PROXY_PORT",
-            ]);
-            expect(args.proxyHost).toBe("PROXY_HOST");
-            expect(args.proxyPort).toBe("PROXY_PORT");
-            expect(spy).toHaveBeenCalledWith(
-                "--proxy-host and --proxy-port options will be deprecated, please use the --proxy option instead"
-            );
-        });
+  });
+  describe("deprecated options", () => {
+    let spy;
+    beforeEach(() => {
+      spy = jest.spyOn(console, "warn").mockImplementation();
     });
+    afterEach(() => {
+      spy.mockRestore();
+    });
+    test("should print the deprecating message with --host", () => {
+      const args = parse([
+        "node",
+        "index.js",
+        "--host",
+        "https://example.kintone.com",
+        "--username",
+        "USERNAME",
+        "--password",
+        "PASSWORD",
+        "--app-id",
+        "APP_ID",
+      ]);
+      expect(args.baseUrl).toBe("https://example.kintone.com");
+      expect(spy).toHaveBeenCalledWith(
+        "--host option will be deprecated, please use the --base-url option instead."
+      );
+    });
+    test("should print the deprecating message with --proxyHost and --proxyPort", () => {
+      const args = parse([
+        "node",
+        "index.js",
+        "--base-url",
+        "https://example2.kintone.com",
+        "--username",
+        "USERNAME",
+        "--password",
+        "PASSWORD",
+        "--app-id",
+        "APP_ID",
+        "--proxy-host",
+        "PROXY_HOST",
+        "--proxy-port",
+        "PROXY_PORT",
+      ]);
+      expect(args.proxyHost).toBe("PROXY_HOST");
+      expect(args.proxyPort).toBe("PROXY_PORT");
+      expect(spy).toHaveBeenCalledWith(
+        "--proxy-host and --proxy-port options will be deprecated, please use the --proxy option instead"
+      );
+    });
+  });
 });

--- a/packages/dts-gen/src/cli-parser.ts
+++ b/packages/dts-gen/src/cli-parser.ts
@@ -1,176 +1,158 @@
 import { Command } from "commander";
 
 interface ParsedArgs {
-    baseUrl: string;
-    username: string | null;
-    password: string | null;
-    oAuthToken: string | null;
-    apiToken: string | null;
-    proxy: string | null;
-    proxyHost: string | null;
-    proxyPort: string | null;
-    basicAuthPassword: string | null;
-    basicAuthUsername: string | null;
-    appId: string | null;
-    preview: boolean;
-    guestSpaceId: string | null;
-    demo: boolean;
-    typeName: string;
-    namespace: string;
-    output: string;
+  baseUrl: string;
+  username: string | null;
+  password: string | null;
+  oAuthToken: string | null;
+  apiToken: string | null;
+  proxy: string | null;
+  proxyHost: string | null;
+  proxyPort: string | null;
+  basicAuthPassword: string | null;
+  basicAuthUsername: string | null;
+  appId: string | null;
+  preview: boolean;
+  guestSpaceId: string | null;
+  demo: boolean;
+  typeName: string;
+  namespace: string;
+  output: string;
 }
 
 export function parse(argv: string[]): ParsedArgs {
-    const program = new Command();
-    program
-        .option(
-            "--demo",
-            "Generate Type definition from demo data.",
-            false
-        )
+  const program = new Command();
+  program
+    .option("--demo", "Generate Type definition from demo data.", false)
 
-        .option(
-            "--host [host]",
-            "A base URL for the Kintone environment. This will be replaced with the --base-url option",
-            null
-        )
-        .option(
-            "--base-url [baseUrl]",
-            "A base URL for the Kintone environment",
-            process.env.KINTONE_BASE_URL || null
-        )
-        .option(
-            "-u, --username [username]",
-            "A username for the Kintone environment",
-            process.env.KINTONE_USERNAME || null
-        )
-        .option(
-            "-p, --password [password]",
-            "A password for the Kintone environment",
-            process.env.KINTONE_PASSWORD || null
-        )
-        .option(
-            "--api-token [apiToken]",
-            "An API token for the Kintone environment",
-            process.env.KINTONE_API_TOKEN || null
-        )
-        .option(
-            "--oauth-token [oAuthToken]",
-            "An OAuth token for the Kintone environment",
-            process.env.KINTONE_OAUTH_TOKEN || null
-        )
-        .option(
-            "--app-id [appId]",
-            "id of kintone app",
-            null
-        )
-        .option(
-            "--guest-space-id [guestSpaceId]",
-            "id of kintone guest space id",
-            null
-        )
-        .option(
-            "--preview",
-            "set this option if kintone app is in preview mode",
-            false
-        )
-        .option(
-            "--type-name [typeName]",
-            "type name to be generated",
-            "Fields"
-        )
-        .option(
-            "--namespace [namespace]",
-            "namespace of type to be generated",
-            "kintone.types"
-        )
-        .option(
-            "--proxy-host [proxyHost]. This will be replaced with the --proxy option",
-            "proxy host",
-            null
-        )
-        .option(
-            "--proxy-port [proxyPort]. This will be replaced with the --proxy option",
-            "proxy port",
-            null
-        )
-        // Axios handles HTTP_PROXY and HTTPS_PROXY natively,
-        // so we don't use the environment variables as the default value
-        .option("--proxy [proxy]", "proxy server", null)
-        .option(
-            "--basic-auth-username [basicAuthUsername]",
-            "A username for basic authentication",
-            process.env.KINTONE_BASIC_AUTH_USERNAME || null
-        )
-        .option(
-            "--basic-auth-password [basicAuthPassword]",
-            "A password for basic authentication",
-            process.env.KINTONE_BASIC_AUTH_PASSWORD || null
-        )
-        .option(
-            "-o, --output [output]",
-            "output file name",
-            "fields.d.ts"
-        )
-        .parse(argv);
+    .option(
+      "--host [host]",
+      "A base URL for the Kintone environment. This will be replaced with the --base-url option",
+      null
+    )
+    .option(
+      "--base-url [baseUrl]",
+      "A base URL for the Kintone environment",
+      process.env.KINTONE_BASE_URL || null
+    )
+    .option(
+      "-u, --username [username]",
+      "A username for the Kintone environment",
+      process.env.KINTONE_USERNAME || null
+    )
+    .option(
+      "-p, --password [password]",
+      "A password for the Kintone environment",
+      process.env.KINTONE_PASSWORD || null
+    )
+    .option(
+      "--api-token [apiToken]",
+      "An API token for the Kintone environment",
+      process.env.KINTONE_API_TOKEN || null
+    )
+    .option(
+      "--oauth-token [oAuthToken]",
+      "An OAuth token for the Kintone environment",
+      process.env.KINTONE_OAUTH_TOKEN || null
+    )
+    .option("--app-id [appId]", "id of kintone app", null)
+    .option(
+      "--guest-space-id [guestSpaceId]",
+      "id of kintone guest space id",
+      null
+    )
+    .option(
+      "--preview",
+      "set this option if kintone app is in preview mode",
+      false
+    )
+    .option("--type-name [typeName]", "type name to be generated", "Fields")
+    .option(
+      "--namespace [namespace]",
+      "namespace of type to be generated",
+      "kintone.types"
+    )
+    .option(
+      "--proxy-host [proxyHost]. This will be replaced with the --proxy option",
+      "proxy host",
+      null
+    )
+    .option(
+      "--proxy-port [proxyPort]. This will be replaced with the --proxy option",
+      "proxy port",
+      null
+    )
+    // Axios handles HTTP_PROXY and HTTPS_PROXY natively,
+    // so we don't use the environment variables as the default value
+    .option("--proxy [proxy]", "proxy server", null)
+    .option(
+      "--basic-auth-username [basicAuthUsername]",
+      "A username for basic authentication",
+      process.env.KINTONE_BASIC_AUTH_USERNAME || null
+    )
+    .option(
+      "--basic-auth-password [basicAuthPassword]",
+      "A password for basic authentication",
+      process.env.KINTONE_BASIC_AUTH_PASSWORD || null
+    )
+    .option("-o, --output [output]", "output file name", "fields.d.ts")
+    .parse(argv);
 
-    const options = program.opts();
-    const {
-        host,
-        username,
-        password,
-        apiToken,
-        oauthToken,
-        proxy,
-        proxyHost,
-        proxyPort,
-        basicAuthPassword,
-        basicAuthUsername,
-        appId,
-        preview,
-        guestSpaceId,
-        demo,
-        typeName,
-        namespace,
-        output,
-    } = options;
+  const options = program.opts();
+  const {
+    host,
+    username,
+    password,
+    apiToken,
+    oauthToken,
+    proxy,
+    proxyHost,
+    proxyPort,
+    basicAuthPassword,
+    basicAuthUsername,
+    appId,
+    preview,
+    guestSpaceId,
+    demo,
+    typeName,
+    namespace,
+    output,
+  } = options;
 
-    // warn deprecated options
-    if (host) {
-        console.warn(
-            "--host option will be deprecated, please use the --base-url option instead."
-        );
-    }
-    if (proxyHost || proxyPort) {
-        console.warn(
-            "--proxy-host and --proxy-port options will be deprecated, please use the --proxy option instead"
-        );
-    }
+  // warn deprecated options
+  if (host) {
+    console.warn(
+      "--host option will be deprecated, please use the --base-url option instead."
+    );
+  }
+  if (proxyHost || proxyPort) {
+    console.warn(
+      "--proxy-host and --proxy-port options will be deprecated, please use the --proxy option instead"
+    );
+  }
 
-    const baseUrl = options.baseUrl || host;
-    if (baseUrl === null) {
-        throw new Error(
-            "--base-url (KINTONE_BASE_URL) must be specified"
-        );
-    }
+  const baseUrl = options.baseUrl || host;
+  if (baseUrl === null) {
+    throw new Error("--base-url (KINTONE_BASE_URL) must be specified");
+  }
 
-    return {
-        baseUrl,
-        username,
-        password,
-        apiToken,
-        oAuthToken: oauthToken,
-        proxy,
-        proxyHost,
-        proxyPort,
-        basicAuthPassword,
-        basicAuthUsername,
-        appId,
-        preview,
-        guestSpaceId,
-        demo,
-        typeName,
-        namespace,
-        output,
-    };
+  return {
+    baseUrl,
+    username,
+    password,
+    apiToken,
+    oAuthToken: oauthToken,
+    proxy,
+    proxyHost,
+    proxyPort,
+    basicAuthPassword,
+    basicAuthUsername,
+    appId,
+    preview,
+    guestSpaceId,
+    demo,
+    typeName,
+    namespace,
+    output,
+  };
 }

--- a/packages/dts-gen/src/converters/fieldtype-converters.test.ts
+++ b/packages/dts-gen/src/converters/fieldtype-converters.test.ts
@@ -3,235 +3,223 @@ import { SubTableFieldType } from "../kintone/clients/forms-client";
 import { objectValues } from "../utils/objectvalues";
 
 describe("FileFieldTypeConverter", () => {
-    const input = {
-        userSelect: {
-            type: "USER_SELECT",
-            code: "userSelect",
-        },
-        userSelect2: {
-            type: "USER_SELECT",
-            code: "userSelect2",
-        },
-        singleLineText: {
-            type: "SINGLE_LINE_TEXT",
-            code: "singleLineText",
-        },
-        multiLineText: {
-            type: "MULTI_LINE_TEXT",
-            code: "multiLineText",
-        },
-        richText: {
-            type: "RICH_TEXT",
-            code: "richText",
-        },
-        date: {
-            type: "DATE",
-            code: "date",
-        },
-        time: {
-            type: "TIME",
-            code: "time",
-        },
-        recordNumber: {
-            type: "RECORD_NUMBER",
-            code: "recordNumber",
-        },
-        createdTime: {
-            type: "CREATED_TIME",
-            code: "createdTime",
-        },
-        updatedTime: {
-            type: "UPDATED_TIME",
-            code: "updatedTime",
-        },
-        dropDown: {
-            type: "DROP_DOWN",
-            code: "dropDown",
-        },
-        link: {
-            type: "LINK",
-            code: "link",
-        },
-        number: {
-            type: "NUMBER",
-            code: "number",
-        },
-        file: {
-            type: "FILE",
-            code: "file",
-        },
-        checkbox: {
-            type: "CHECK_BOX",
-            code: "checkbox",
-        },
-        multiSelect: {
-            type: "MULTI_SELECT",
-            code: "multiSelect",
-        },
-        creator: {
-            type: "CREATOR",
-            code: "creator",
-        },
-        modifier: {
-            type: "MODIFIER",
-            code: "modifier",
-        },
-        // Lookup field and Related App record should be excluded
-        relatedApp: {
-            type: "FILE",
-            code: "relatedApp",
-            relatedApp: "12",
-        },
-        lookupApp: {
-            type: "CHECK_BOX",
-            code: "lookupApp",
-            relatedApp: "13",
-        },
-    };
+  const input = {
+    userSelect: {
+      type: "USER_SELECT",
+      code: "userSelect",
+    },
+    userSelect2: {
+      type: "USER_SELECT",
+      code: "userSelect2",
+    },
+    singleLineText: {
+      type: "SINGLE_LINE_TEXT",
+      code: "singleLineText",
+    },
+    multiLineText: {
+      type: "MULTI_LINE_TEXT",
+      code: "multiLineText",
+    },
+    richText: {
+      type: "RICH_TEXT",
+      code: "richText",
+    },
+    date: {
+      type: "DATE",
+      code: "date",
+    },
+    time: {
+      type: "TIME",
+      code: "time",
+    },
+    recordNumber: {
+      type: "RECORD_NUMBER",
+      code: "recordNumber",
+    },
+    createdTime: {
+      type: "CREATED_TIME",
+      code: "createdTime",
+    },
+    updatedTime: {
+      type: "UPDATED_TIME",
+      code: "updatedTime",
+    },
+    dropDown: {
+      type: "DROP_DOWN",
+      code: "dropDown",
+    },
+    link: {
+      type: "LINK",
+      code: "link",
+    },
+    number: {
+      type: "NUMBER",
+      code: "number",
+    },
+    file: {
+      type: "FILE",
+      code: "file",
+    },
+    checkbox: {
+      type: "CHECK_BOX",
+      code: "checkbox",
+    },
+    multiSelect: {
+      type: "MULTI_SELECT",
+      code: "multiSelect",
+    },
+    creator: {
+      type: "CREATOR",
+      code: "creator",
+    },
+    modifier: {
+      type: "MODIFIER",
+      code: "modifier",
+    },
+    // Lookup field and Related App record should be excluded
+    relatedApp: {
+      type: "FILE",
+      code: "relatedApp",
+      relatedApp: "12",
+    },
+    lookupApp: {
+      type: "CHECK_BOX",
+      code: "lookupApp",
+      relatedApp: "13",
+    },
+  };
 
-    test("selectFieldsTypesEquals returns lists of values which is selected if fieldType is same", () => {
-        const type = VisibleForTesting.constants.FILE_TYPE;
-        const output =
-            VisibleForTesting.selectFieldsTypesEquals(
-                type,
-                objectValues(input)
-            );
-        const expected = [
-            {
-                type: "FILE",
-                code: "file",
-            },
-        ];
-        expect(output).toEqual(expected);
-    });
+  test("selectFieldsTypesEquals returns lists of values which is selected if fieldType is same", () => {
+    const type = VisibleForTesting.constants.FILE_TYPE;
+    const output = VisibleForTesting.selectFieldsTypesEquals(
+      type,
+      objectValues(input)
+    );
+    const expected = [
+      {
+        type: "FILE",
+        code: "file",
+      },
+    ];
+    expect(output).toEqual(expected);
+  });
 
-    test("selectFieldsTypesIn returns list of values which is selected if fieldType was contained in condition.", () => {
-        const types =
-            VisibleForTesting.constants.STRING_LIST_TYPES;
-        const output =
-            VisibleForTesting.selectFieldsTypesIn(
-                types,
-                objectValues(input)
-            );
-        const expected = [
-            {
-                code: "checkbox",
-                type: "CHECK_BOX",
-            },
-            {
-                code: "multiSelect",
-                type: "MULTI_SELECT",
-            },
-        ];
-        expect(output).toEqual(expected);
-    });
+  test("selectFieldsTypesIn returns list of values which is selected if fieldType was contained in condition.", () => {
+    const types = VisibleForTesting.constants.STRING_LIST_TYPES;
+    const output = VisibleForTesting.selectFieldsTypesIn(
+      types,
+      objectValues(input)
+    );
+    const expected = [
+      {
+        code: "checkbox",
+        type: "CHECK_BOX",
+      },
+      {
+        code: "multiSelect",
+        type: "MULTI_SELECT",
+      },
+    ];
+    expect(output).toEqual(expected);
+  });
 
-    test("convertSubTableFields", () => {
-        const subTables = [
-            {
-                type: "SUBTABLE",
-                code: "subTable",
-                fields: input,
-            },
-        ] as SubTableFieldType[];
-        const output =
-            VisibleForTesting.convertSubTableFields(
-                subTables
-            );
-        const expectedSimpleFields = [
-            {
-                code: "singleLineText",
-                type: "SINGLE_LINE_TEXT",
-            },
-            {
-                code: "multiLineText",
-                type: "MULTI_LINE_TEXT",
-            },
-            {
-                code: "richText",
-                type: "RICH_TEXT",
-            },
-            {
-                code: "date",
-                type: "DATE",
-            },
-            {
-                code: "time",
-                type: "TIME",
-            },
-            {
-                code: "dropDown",
-                type: "DROP_DOWN",
-            },
-            {
-                code: "link",
-                type: "LINK",
-            },
-            {
-                code: "number",
-                type: "NUMBER",
-            },
-        ];
-        expect(output[0].fields.stringFields).toEqual(
-            expectedSimpleFields
-        );
+  test("convertSubTableFields", () => {
+    const subTables = [
+      {
+        type: "SUBTABLE",
+        code: "subTable",
+        fields: input,
+      },
+    ] as SubTableFieldType[];
+    const output = VisibleForTesting.convertSubTableFields(subTables);
+    const expectedSimpleFields = [
+      {
+        code: "singleLineText",
+        type: "SINGLE_LINE_TEXT",
+      },
+      {
+        code: "multiLineText",
+        type: "MULTI_LINE_TEXT",
+      },
+      {
+        code: "richText",
+        type: "RICH_TEXT",
+      },
+      {
+        code: "date",
+        type: "DATE",
+      },
+      {
+        code: "time",
+        type: "TIME",
+      },
+      {
+        code: "dropDown",
+        type: "DROP_DOWN",
+      },
+      {
+        code: "link",
+        type: "LINK",
+      },
+      {
+        code: "number",
+        type: "NUMBER",
+      },
+    ];
+    expect(output[0].fields.stringFields).toEqual(expectedSimpleFields);
 
-        const expectedFieldFields = [
-            {
-                code: "file",
-                type: "FILE",
-            },
-        ];
-        expect(output[0].fields.fileTypeFields).toEqual(
-            expectedFieldFields
-        );
+    const expectedFieldFields = [
+      {
+        code: "file",
+        type: "FILE",
+      },
+    ];
+    expect(output[0].fields.fileTypeFields).toEqual(expectedFieldFields);
 
-        const expectedStringListFields = [
-            {
-                code: "checkbox",
-                type: "CHECK_BOX",
-            },
-            {
-                code: "multiSelect",
-                type: "MULTI_SELECT",
-            },
-        ];
-        expect(output[0].fields.stringListFields).toEqual(
-            expectedStringListFields
-        );
+    const expectedStringListFields = [
+      {
+        code: "checkbox",
+        type: "CHECK_BOX",
+      },
+      {
+        code: "multiSelect",
+        type: "MULTI_SELECT",
+      },
+    ];
+    expect(output[0].fields.stringListFields).toEqual(expectedStringListFields);
 
-        const expectedUserFields = [
-            {
-                code: "creator",
-                type: "CREATOR",
-            },
-            {
-                code: "modifier",
-                type: "MODIFIER",
-            },
-        ];
-        expect(
-            output[0].fields.userFieldsInSavedRecord
-        ).toEqual(expectedUserFields);
+    const expectedUserFields = [
+      {
+        code: "creator",
+        type: "CREATOR",
+      },
+      {
+        code: "modifier",
+        type: "MODIFIER",
+      },
+    ];
+    expect(output[0].fields.userFieldsInSavedRecord).toEqual(
+      expectedUserFields
+    );
 
-        const expectedSimpleValueInSavedRecord = [
-            {
-                code: "recordNumber",
-                type: "RECORD_NUMBER",
-            },
-            {
-                code: "createdTime",
-                type: "CREATED_TIME",
-            },
-            {
-                code: "updatedTime",
-                type: "UPDATED_TIME",
-            },
-        ];
-        expect(
-            output[0].fields.stringFieldsInSavedRecord
-        ).toEqual(expectedSimpleValueInSavedRecord);
+    const expectedSimpleValueInSavedRecord = [
+      {
+        code: "recordNumber",
+        type: "RECORD_NUMBER",
+      },
+      {
+        code: "createdTime",
+        type: "CREATED_TIME",
+      },
+      {
+        code: "updatedTime",
+        type: "UPDATED_TIME",
+      },
+    ];
+    expect(output[0].fields.stringFieldsInSavedRecord).toEqual(
+      expectedSimpleValueInSavedRecord
+    );
 
-        expect(output[0].fields.subTableFields).toEqual([]);
-    });
+    expect(output[0].fields.subTableFields).toEqual([]);
+  });
 });

--- a/packages/dts-gen/src/converters/fileldtype-converter.ts
+++ b/packages/dts-gen/src/converters/fileldtype-converter.ts
@@ -1,174 +1,141 @@
-import {
-    FieldType,
-    SubTableFieldType,
-} from "../kintone/clients/forms-client";
+import { FieldType, SubTableFieldType } from "../kintone/clients/forms-client";
 import { objectValues } from "../utils/objectvalues";
 
-type FieldTypesOrSubTableFieldTypes =
-    | FieldType[]
-    | SubTableFieldType[];
+type FieldTypesOrSubTableFieldTypes = FieldType[] | SubTableFieldType[];
 
 const SIMPLE_VALUE_TYPES = [
-    "SINGLE_LINE_TEXT",
-    "MULTI_LINE_TEXT",
-    "RICH_TEXT",
-    "DATE",
-    "NUMBER",
-    "DATETIME",
-    "TIME",
-    "DROP_DOWN",
-    "LINK",
-    "RADIO_BUTTON",
+  "SINGLE_LINE_TEXT",
+  "MULTI_LINE_TEXT",
+  "RICH_TEXT",
+  "DATE",
+  "NUMBER",
+  "DATETIME",
+  "TIME",
+  "DROP_DOWN",
+  "LINK",
+  "RADIO_BUTTON",
 ];
 
 const CALCULATED_VALUE_TYPES = ["CALC"];
 
 const SIMPLE_VALUE_IN_SAVED_RECORD = [
-    "RECORD_NUMBER",
-    "CREATED_TIME",
-    "UPDATED_TIME",
+  "RECORD_NUMBER",
+  "CREATED_TIME",
+  "UPDATED_TIME",
 ];
 
 const USER_TYPES_IN_SAVED_RECORD = ["CREATOR", "MODIFIER"];
 
 const STRING_LIST_TYPES = ["CHECK_BOX", "MULTI_SELECT"];
 
-const ENTITY_LIST_TYPE = [
-    "USER_SELECT",
-    "GROUP_SELECT",
-    "ORGANIZATION_SELECT",
-];
+const ENTITY_LIST_TYPE = ["USER_SELECT", "GROUP_SELECT", "ORGANIZATION_SELECT"];
 
 const FILE_TYPE = "FILE";
 
 const SUB_TABLE_TYPE = "SUBTABLE";
 
 export interface FieldTypeGroups {
-    stringFields: FieldType[];
-    calculatedFields: FieldType[];
-    stringFieldsInSavedRecord: FieldType[];
-    userFieldsInSavedRecord: FieldType[];
-    stringListFields: FieldType[];
-    entityListFields: FieldType[];
-    fileTypeFields: FieldType[];
-    subTableFields: SubTableFieldTypeGroups[];
+  stringFields: FieldType[];
+  calculatedFields: FieldType[];
+  stringFieldsInSavedRecord: FieldType[];
+  userFieldsInSavedRecord: FieldType[];
+  stringListFields: FieldType[];
+  entityListFields: FieldType[];
+  fileTypeFields: FieldType[];
+  subTableFields: SubTableFieldTypeGroups[];
 }
 
 interface SubTableFieldTypeGroups {
-    code: string;
-    type: string;
-    fields: FieldTypeGroups;
+  code: string;
+  type: string;
+  fields: FieldTypeGroups;
 }
 
-function excludeLookupOrRelatedRecord(
-    field: FieldType | SubTableFieldType
-) {
-    return Object.keys(field).indexOf("relatedApp") < 0;
+function excludeLookupOrRelatedRecord(field: FieldType | SubTableFieldType) {
+  return Object.keys(field).indexOf("relatedApp") < 0;
 }
 
 function selectFieldsTypesIn(
-    types: string[],
-    fieldsToBeSelected: FieldTypesOrSubTableFieldTypes
+  types: string[],
+  fieldsToBeSelected: FieldTypesOrSubTableFieldTypes
 ): FieldTypesOrSubTableFieldTypes {
-    const fields = fieldsToBeSelected as Array<
-        FieldType | SubTableFieldType
-    >;
-    const typeIncludes = (fieldToTest) =>
-        types.indexOf(fieldToTest.type) >= 0;
+  const fields = fieldsToBeSelected as Array<FieldType | SubTableFieldType>;
+  const typeIncludes = (fieldToTest) => types.indexOf(fieldToTest.type) >= 0;
 
-    return fields
-        .filter(typeIncludes)
-        .filter(excludeLookupOrRelatedRecord);
+  return fields.filter(typeIncludes).filter(excludeLookupOrRelatedRecord);
 }
 
 function selectFieldsTypesEquals(
-    type: string,
-    fieldsToBeSelected: FieldTypesOrSubTableFieldTypes
+  type: string,
+  fieldsToBeSelected: FieldTypesOrSubTableFieldTypes
 ): FieldTypesOrSubTableFieldTypes {
-    const fields = fieldsToBeSelected as Array<
-        FieldType | SubTableFieldType
-    >;
+  const fields = fieldsToBeSelected as Array<FieldType | SubTableFieldType>;
 
-    return fields
-        .filter((field) => field.type === type)
-        .filter(excludeLookupOrRelatedRecord);
+  return fields
+    .filter((field) => field.type === type)
+    .filter(excludeLookupOrRelatedRecord);
 }
 
 function convertSubTableFields(
-    subTableFields: SubTableFieldType[]
+  subTableFields: SubTableFieldType[]
 ): SubTableFieldTypeGroups[] {
-    return subTableFields.map((subTableField) => {
-        return {
-            code: subTableField.code,
-            type: subTableField.type,
-            fields: convertFieldTypesToFieldTypeGroups(
-                objectValues(subTableField.fields)
-            ),
-        };
-    });
+  return subTableFields.map((subTableField) => {
+    return {
+      code: subTableField.code,
+      type: subTableField.type,
+      fields: convertFieldTypesToFieldTypeGroups(
+        objectValues(subTableField.fields)
+      ),
+    };
+  });
 }
 
 function convertFieldTypesToFieldTypeGroups(
-    properties: FieldTypesOrSubTableFieldTypes
+  properties: FieldTypesOrSubTableFieldTypes
 ): FieldTypeGroups {
-    const fieldTypes = objectValues(properties);
-    const stringFields = selectFieldsTypesIn(
-        SIMPLE_VALUE_TYPES,
-        fieldTypes
-    );
-    const calculatedFields = selectFieldsTypesIn(
-        CALCULATED_VALUE_TYPES,
-        fieldTypes
-    );
-    const stringFieldsInSavedRecord = selectFieldsTypesIn(
-        SIMPLE_VALUE_IN_SAVED_RECORD,
-        fieldTypes
-    );
-    const userFieldsInSavedRecord = selectFieldsTypesIn(
-        USER_TYPES_IN_SAVED_RECORD,
-        fieldTypes
-    );
-    const stringListFields = selectFieldsTypesIn(
-        STRING_LIST_TYPES,
-        fieldTypes
-    );
-    const entityListFields = selectFieldsTypesIn(
-        ENTITY_LIST_TYPE,
-        fieldTypes
-    );
-    const fileTypeFields = selectFieldsTypesEquals(
-        FILE_TYPE,
-        fieldTypes
-    );
-    const subTableFields = convertSubTableFields(
-        selectFieldsTypesEquals(
-            SUB_TABLE_TYPE,
-            fieldTypes
-        ) as SubTableFieldType[]
-    );
+  const fieldTypes = objectValues(properties);
+  const stringFields = selectFieldsTypesIn(SIMPLE_VALUE_TYPES, fieldTypes);
+  const calculatedFields = selectFieldsTypesIn(
+    CALCULATED_VALUE_TYPES,
+    fieldTypes
+  );
+  const stringFieldsInSavedRecord = selectFieldsTypesIn(
+    SIMPLE_VALUE_IN_SAVED_RECORD,
+    fieldTypes
+  );
+  const userFieldsInSavedRecord = selectFieldsTypesIn(
+    USER_TYPES_IN_SAVED_RECORD,
+    fieldTypes
+  );
+  const stringListFields = selectFieldsTypesIn(STRING_LIST_TYPES, fieldTypes);
+  const entityListFields = selectFieldsTypesIn(ENTITY_LIST_TYPE, fieldTypes);
+  const fileTypeFields = selectFieldsTypesEquals(FILE_TYPE, fieldTypes);
+  const subTableFields = convertSubTableFields(
+    selectFieldsTypesEquals(SUB_TABLE_TYPE, fieldTypes) as SubTableFieldType[]
+  );
 
-    return {
-        stringFields,
-        calculatedFields,
-        stringFieldsInSavedRecord,
-        entityListFields,
-        userFieldsInSavedRecord,
-        stringListFields,
-        fileTypeFields,
-        subTableFields,
-    };
+  return {
+    stringFields,
+    calculatedFields,
+    stringFieldsInSavedRecord,
+    entityListFields,
+    userFieldsInSavedRecord,
+    stringListFields,
+    fileTypeFields,
+    subTableFields,
+  };
 }
 
 export const FieldTypeConverter = {
-    convertFieldTypesToFieldTypeGroups,
+  convertFieldTypesToFieldTypeGroups,
 };
 
 export const VisibleForTesting = {
-    selectFieldsTypesIn,
-    selectFieldsTypesEquals,
-    convertSubTableFields,
-    constants: {
-        STRING_LIST_TYPES,
-        FILE_TYPE,
-    },
+  selectFieldsTypesIn,
+  selectFieldsTypesEquals,
+  convertSubTableFields,
+  constants: {
+    STRING_LIST_TYPES,
+    FILE_TYPE,
+  },
 };

--- a/packages/dts-gen/src/index.ts
+++ b/packages/dts-gen/src/index.ts
@@ -6,42 +6,37 @@ import { objectValues } from "./utils//objectvalues";
 import { parse } from "./cli-parser";
 
 process.on("uncaughtException", (e) => {
-    console.error(e.message);
-    // eslint-disable-next-line no-process-exit
-    process.exit(1);
+  console.error(e.message);
+  // eslint-disable-next-line no-process-exit
+  process.exit(1);
 });
 
 const args = parse(process.argv);
 
-const client = args.demo
-    ? new DemoClient()
-    : new FormsClientImpl(args);
+const client = args.demo ? new DemoClient() : new FormsClientImpl(args);
 
 const fetchFormPropertiesInput = {
-    appId: args.appId,
-    guestSpaceId: args.guestSpaceId,
-    preview: args.preview,
+  appId: args.appId,
+  guestSpaceId: args.guestSpaceId,
+  preview: args.preview,
 };
 
 client
-    .fetchFormProperties(fetchFormPropertiesInput)
-    .then((properties) =>
-        FieldTypeConverter.convertFieldTypesToFieldTypeGroups(
-            objectValues(properties)
-        )
+  .fetchFormProperties(fetchFormPropertiesInput)
+  .then((properties) =>
+    FieldTypeConverter.convertFieldTypesToFieldTypeGroups(
+      objectValues(properties)
     )
-    .then((fieldTypeGroups) => {
-        const typeName = args.typeName;
-        const namespace = args.namespace;
-        const input = {
-            typeName,
-            namespace,
-            fieldTypeGroups,
-        };
-        TypeDefinitionTemplate.renderAsFile(
-            args.output,
-            input
-        );
-    })
-    // eslint-disable-next-line no-console
-    .catch((err) => console.error(err));
+  )
+  .then((fieldTypeGroups) => {
+    const typeName = args.typeName;
+    const namespace = args.namespace;
+    const input = {
+      typeName,
+      namespace,
+      fieldTypeGroups,
+    };
+    TypeDefinitionTemplate.renderAsFile(args.output, input);
+  })
+  // eslint-disable-next-line no-console
+  .catch((err) => console.error(err));

--- a/packages/dts-gen/src/integration-tests/dts-gen-api-test.ts
+++ b/packages/dts-gen/src/integration-tests/dts-gen-api-test.ts
@@ -1,150 +1,136 @@
 import * as assert from "assert";
 
 function assertKintoneBuiltinFunctions() {
-    // assert function exists in kintone top-level
-    assertFunction(kintone.getRequestToken);
-    assertFunction(kintone.getLoginUser);
-    assertFunction(kintone.getUiVersion);
+  // assert function exists in kintone top-level
+  assertFunction(kintone.getRequestToken);
+  assertFunction(kintone.getLoginUser);
+  assertFunction(kintone.getUiVersion);
 
-    // assert function exists in kintone.Promise
-    assertFunction(kintone.Promise);
-    assertFunction(kintone.Promise.all);
-    assertFunction(kintone.Promise.resolve);
-    assertFunction(kintone.Promise.reject);
+  // assert function exists in kintone.Promise
+  assertFunction(kintone.Promise);
+  assertFunction(kintone.Promise.all);
+  assertFunction(kintone.Promise.resolve);
+  assertFunction(kintone.Promise.reject);
 
-    // kintone.api.url
-    assert.ok(
-        kintone.api
-            .url("/k/v1/records")
-            .endsWith("/k/v1/records.json")
-    );
-    // only to check to compile success
-    kintone.api.url("/k/v1/records", true);
+  // kintone.api.url
+  assert.ok(kintone.api.url("/k/v1/records").endsWith("/k/v1/records.json"));
+  // only to check to compile success
+  kintone.api.url("/k/v1/records", true);
 
-    const okPromise = new kintone.Promise<number>(
-        (resolve) => resolve(1)
-    );
+  const okPromise = new kintone.Promise<number>((resolve) => resolve(1));
 
-    assert.ok(okPromise);
-    okPromise
-        .then((resolved) => {
-            assert.ok(resolved === 1);
-        })
-        .catch(() => {
-            assert.fail("should not be called");
-        });
-
-    const ngPromise = new kintone.Promise<any>(
-        (_, reject) => reject(1)
-    );
-    ngPromise
-        .then(() => {
-            assert.fail("should not be called");
-        })
-        .catch((rejected) => assert.ok(rejected === 1));
-
-    kintone.Promise.resolve(1)
-        .then((resolved) => assert.ok(resolved === 1))
-        .catch(() => assert.fail("should not be called"));
-
-    kintone.Promise.reject("reject")
-        .then(() => assert.fail("should not be called"))
-        .catch((reject) => assert.ok(reject === "reject"));
-
-    kintone.Promise.all([
-        kintone.Promise.resolve(1),
-        kintone.Promise.resolve(2),
-        kintone.Promise.resolve(3),
-    ]).then((resolved) => {
-        assert.ok(resolved.length === 3);
-        assert.ok(resolved[0] === 1);
-        assert.ok(resolved[1] === 2);
-        assert.ok(resolved[2] === 3);
+  assert.ok(okPromise);
+  okPromise
+    .then((resolved) => {
+      assert.ok(resolved === 1);
+    })
+    .catch(() => {
+      assert.fail("should not be called");
     });
 
-    // assert function exists in kintone.events
-    const e = kintone.events;
-    assertFunction(e.on);
-    assertFunction(e.off);
+  const ngPromise = new kintone.Promise<any>((_, reject) => reject(1));
+  ngPromise
+    .then(() => {
+      assert.fail("should not be called");
+    })
+    .catch((rejected) => assert.ok(rejected === 1));
 
-    // assert function exists in kintone.api
-    const a = kintone.api;
-    assertFunction(a);
-    assertFunction(a.url);
-    assertFunction(a.urlForGet);
-    assertFunction(a.getConcurrencyLimit);
+  kintone.Promise.resolve(1)
+    .then((resolved) => assert.ok(resolved === 1))
+    .catch(() => assert.fail("should not be called"));
 
-    // assert function exists in kintone.proxy
-    const p = kintone.proxy;
-    assertFunction(p);
-    assertFunction(p.upload);
+  kintone.Promise.reject("reject")
+    .then(() => assert.fail("should not be called"))
+    .catch((reject) => assert.ok(reject === "reject"));
 
-    // assert function exists in kintone.app
-    const app = kintone.app;
-    assertFunction(app.getFieldElements);
-    assertFunction(app.getHeaderMenuSpaceElement);
-    assertFunction(app.getHeaderSpaceElement);
-    assertFunction(app.getId);
-    assertFunction(app.getLookupTargetAppId);
-    assertFunction(app.getQuery);
-    assertFunction(app.getQueryCondition);
-    assertFunction(app.getRelatedRecordsTargetAppId);
+  kintone.Promise.all([
+    kintone.Promise.resolve(1),
+    kintone.Promise.resolve(2),
+    kintone.Promise.resolve(3),
+  ]).then((resolved) => {
+    assert.ok(resolved.length === 3);
+    assert.ok(resolved[0] === 1);
+    assert.ok(resolved[1] === 2);
+    assert.ok(resolved[2] === 3);
+  });
 
-    // assert function exists in kintone.app.record
-    const r = kintone.app.record;
-    assertFunction(r.get);
-    assertFunction(r.getHeaderMenuSpaceElement);
-    assertFunction(r.getFieldElement);
-    assertFunction(r.getId);
-    assertFunction(r.getSpaceElement);
-    assertFunction(r.set);
-    assertFunction(r.setFieldShown);
-    assertFunction(r.setGroupFieldOpen);
+  // assert function exists in kintone.events
+  const e = kintone.events;
+  assertFunction(e.on);
+  assertFunction(e.off);
 
-    // assert function exists in kintone.mobile.app
-    const ma = kintone.mobile.app;
-    assertFunction(ma.getFieldElements);
-    assertFunction(ma.getHeaderSpaceElement);
-    assertFunction(ma.getId);
-    assertFunction(ma.getLookupTargetAppId);
-    assertFunction(ma.getQuery);
-    assertFunction(ma.getQueryCondition);
-    assertFunction(ma.getRelatedRecordsTargetAppId);
+  // assert function exists in kintone.api
+  const a = kintone.api;
+  assertFunction(a);
+  assertFunction(a.url);
+  assertFunction(a.urlForGet);
+  assertFunction(a.getConcurrencyLimit);
 
-    // assert function exists in kintone.mobile.app.record
-    const mr = kintone.mobile.app.record;
-    assertFunction(mr.get);
-    assertFunction(mr.getId);
-    assertFunction(mr.getFieldElement);
-    assertFunction(mr.getSpaceElement);
-    assertFunction(mr.set);
-    assertFunction(mr.setFieldShown);
-    assertFunction(mr.setGroupFieldOpen);
+  // assert function exists in kintone.proxy
+  const p = kintone.proxy;
+  assertFunction(p);
+  assertFunction(p.upload);
 
-    // Portal API
-    assertFunction(kintone.portal.getContentSpaceElement);
-    assertFunction(
-        kintone.mobile.portal.getContentSpaceElement
-    );
+  // assert function exists in kintone.app
+  const app = kintone.app;
+  assertFunction(app.getFieldElements);
+  assertFunction(app.getHeaderMenuSpaceElement);
+  assertFunction(app.getHeaderSpaceElement);
+  assertFunction(app.getId);
+  assertFunction(app.getLookupTargetAppId);
+  assertFunction(app.getQuery);
+  assertFunction(app.getQueryCondition);
+  assertFunction(app.getRelatedRecordsTargetAppId);
 
-    // kintone.$PLUGIN_ID
-    assert.ok(kintone.$PLUGIN_ID);
-    assert.ok(typeof kintone.$PLUGIN_ID === "string");
+  // assert function exists in kintone.app.record
+  const r = kintone.app.record;
+  assertFunction(r.get);
+  assertFunction(r.getHeaderMenuSpaceElement);
+  assertFunction(r.getFieldElement);
+  assertFunction(r.getId);
+  assertFunction(r.getSpaceElement);
+  assertFunction(r.set);
+  assertFunction(r.setFieldShown);
+  assertFunction(r.setGroupFieldOpen);
 
-    // Space API
-    assertFunction(
-        kintone.space.portal.getContentSpaceElement
-    );
-    assertFunction(
-        kintone.mobile.space.portal.getContentSpaceElement
-    );
+  // assert function exists in kintone.mobile.app
+  const ma = kintone.mobile.app;
+  assertFunction(ma.getFieldElements);
+  assertFunction(ma.getHeaderSpaceElement);
+  assertFunction(ma.getId);
+  assertFunction(ma.getLookupTargetAppId);
+  assertFunction(ma.getQuery);
+  assertFunction(ma.getQueryCondition);
+  assertFunction(ma.getRelatedRecordsTargetAppId);
+
+  // assert function exists in kintone.mobile.app.record
+  const mr = kintone.mobile.app.record;
+  assertFunction(mr.get);
+  assertFunction(mr.getId);
+  assertFunction(mr.getFieldElement);
+  assertFunction(mr.getSpaceElement);
+  assertFunction(mr.set);
+  assertFunction(mr.setFieldShown);
+  assertFunction(mr.setGroupFieldOpen);
+
+  // Portal API
+  assertFunction(kintone.portal.getContentSpaceElement);
+  assertFunction(kintone.mobile.portal.getContentSpaceElement);
+
+  // kintone.$PLUGIN_ID
+  assert.ok(kintone.$PLUGIN_ID);
+  assert.ok(typeof kintone.$PLUGIN_ID === "string");
+
+  // Space API
+  assertFunction(kintone.space.portal.getContentSpaceElement);
+  assertFunction(kintone.mobile.space.portal.getContentSpaceElement);
 }
 
 function assertFunction(ref) {
-    assert.ok(ref);
-    assert.ok(typeof ref === "function");
+  assert.ok(ref);
+  assert.ok(typeof ref === "function");
 }
 
 export const DTSGenApiTest = {
-    assertKintoneBuiltinFunctions,
+  assertKintoneBuiltinFunctions,
 };

--- a/packages/dts-gen/src/integration-tests/dts-gen-fields-test.ts
+++ b/packages/dts-gen/src/integration-tests/dts-gen-fields-test.ts
@@ -4,275 +4,256 @@ import * as assert from "assert";
 type SavedTestFields = kintone.types.SavedFields;
 
 function assertFieldTypes(record: SavedTestFields) {
-    // Assert simple field types
-    [
-        {
-            ref: record.$id,
-            type: "__ID__",
-        },
-        {
-            ref: record.$revision,
-            type: "__REVISION__",
-        },
-        {
-            ref: record.Record_number,
-            type: "RECORD_NUMBER",
-        },
-        {
-            ref: record.Updated_datetime,
-            type: "UPDATED_TIME",
-        },
-        {
-            ref: record.Created_datetime,
-            type: "CREATED_TIME",
-        },
-        {
-            ref: record.Text,
-            type: "SINGLE_LINE_TEXT",
-        },
-        {
-            ref: record.Rich_text,
-            type: "RICH_TEXT",
-        },
-        {
-            ref: record.Text_area,
-            type: "MULTI_LINE_TEXT",
-        },
-        {
-            ref: record.Number,
-            type: "NUMBER",
-        },
-        {
-            ref: record.Calculated,
-            type: "CALC",
-        },
-        {
-            ref: record.Radio_button,
-            type: "RADIO_BUTTON",
-        },
-        {
-            ref: record.Drop_down,
-            type: "DROP_DOWN",
-        },
-        {
-            ref: record.Date,
-            type: "DATE",
-        },
-        {
-            ref: record.Time,
-            type: "TIME",
-        },
-        {
-            ref: record.Date_and_time,
-            type: "DATETIME",
-        },
-        {
-            ref: record.Link,
-            type: "LINK",
-        },
-    ].forEach(({ ref, type }) =>
-        assertSimpleField(ref, type)
-    );
+  // Assert simple field types
+  [
+    {
+      ref: record.$id,
+      type: "__ID__",
+    },
+    {
+      ref: record.$revision,
+      type: "__REVISION__",
+    },
+    {
+      ref: record.Record_number,
+      type: "RECORD_NUMBER",
+    },
+    {
+      ref: record.Updated_datetime,
+      type: "UPDATED_TIME",
+    },
+    {
+      ref: record.Created_datetime,
+      type: "CREATED_TIME",
+    },
+    {
+      ref: record.Text,
+      type: "SINGLE_LINE_TEXT",
+    },
+    {
+      ref: record.Rich_text,
+      type: "RICH_TEXT",
+    },
+    {
+      ref: record.Text_area,
+      type: "MULTI_LINE_TEXT",
+    },
+    {
+      ref: record.Number,
+      type: "NUMBER",
+    },
+    {
+      ref: record.Calculated,
+      type: "CALC",
+    },
+    {
+      ref: record.Radio_button,
+      type: "RADIO_BUTTON",
+    },
+    {
+      ref: record.Drop_down,
+      type: "DROP_DOWN",
+    },
+    {
+      ref: record.Date,
+      type: "DATE",
+    },
+    {
+      ref: record.Time,
+      type: "TIME",
+    },
+    {
+      ref: record.Date_and_time,
+      type: "DATETIME",
+    },
+    {
+      ref: record.Link,
+      type: "LINK",
+    },
+  ].forEach(({ ref, type }) => assertSimpleField(ref, type));
 
-    // Assert string list field types
-    [
-        {
-            ref: record.Check_box,
-            type: "CHECK_BOX",
-        },
-        {
-            ref: record.Multi_choice,
-            type: "MULTI_SELECT",
-        },
-    ].forEach(({ ref, type }) =>
-        assertStringListField(ref, type)
-    );
-    // assert entity
-    [
-        {
-            ref: record.Updated_by,
-            type: "MODIFIER",
-        },
-        {
-            ref: record.Created_by,
-            type: "CREATOR",
-        },
-    ].forEach(({ ref, type }) => assertEntity(ref, type));
+  // Assert string list field types
+  [
+    {
+      ref: record.Check_box,
+      type: "CHECK_BOX",
+    },
+    {
+      ref: record.Multi_choice,
+      type: "MULTI_SELECT",
+    },
+  ].forEach(({ ref, type }) => assertStringListField(ref, type));
+  // assert entity
+  [
+    {
+      ref: record.Updated_by,
+      type: "MODIFIER",
+    },
+    {
+      ref: record.Created_by,
+      type: "CREATOR",
+    },
+  ].forEach(({ ref, type }) => assertEntity(ref, type));
 
-    // assert entity list field types
-    [
-        {
-            ref: record.User_selection,
-            type: "USER_SELECT",
-        },
-        {
-            ref: record.Department_selection,
-            type: "ORGANIZATION_SELECT",
-        },
-        {
-            ref: record.Group_selection,
-            type: "GROUP_SELECT",
-        },
-    ].forEach(({ ref, type }) => {
-        assertEntityListField(ref, type);
-    });
+  // assert entity list field types
+  [
+    {
+      ref: record.User_selection,
+      type: "USER_SELECT",
+    },
+    {
+      ref: record.Department_selection,
+      type: "ORGANIZATION_SELECT",
+    },
+    {
+      ref: record.Group_selection,
+      type: "GROUP_SELECT",
+    },
+  ].forEach(({ ref, type }) => {
+    assertEntityListField(ref, type);
+  });
 
-    assertType(record.Attachment.type, "FILE");
-    assert.ok(record.Attachment.value.length);
-    assertFileField(record.Attachment);
+  assertType(record.Attachment.type, "FILE");
+  assert.ok(record.Attachment.value.length);
+  assertFileField(record.Attachment);
 
-    [
-        {
-            ref: record.Table,
-        },
-        {
-            ref: record.Table_0,
-        },
-    ].forEach(({ ref }) => assertSubTable(ref));
+  [
+    {
+      ref: record.Table,
+    },
+    {
+      ref: record.Table_0,
+    },
+  ].forEach(({ ref }) => assertSubTable(ref));
 
-    const tv = record.Table.value[0].value;
-    [
-        {
-            ref: tv.Calculated_Table,
-            type: "CALC",
-        },
-        {
-            ref: tv.Number_Table,
-            type: "NUMBER",
-        },
-        {
-            ref: tv.Text_Table,
-            type: "SINGLE_LINE_TEXT",
-        },
-        {
-            ref: tv.Rich_text_Table,
-            type: "RICH_TEXT",
-        },
-        {
-            ref: tv.Text_area_Table,
-            type: "MULTI_LINE_TEXT",
-        },
-    ].forEach(({ ref, type }) =>
-        assertSimpleField(ref, type)
-    );
-    assert.ok(tv.Calculated_Table.value);
-    assert.ok(tv.Number_Table.value);
-    assert.ok(tv.Text_Table.value);
-    assert.ok(tv.Text_area_Table.value);
+  const tv = record.Table.value[0].value;
+  [
+    {
+      ref: tv.Calculated_Table,
+      type: "CALC",
+    },
+    {
+      ref: tv.Number_Table,
+      type: "NUMBER",
+    },
+    {
+      ref: tv.Text_Table,
+      type: "SINGLE_LINE_TEXT",
+    },
+    {
+      ref: tv.Rich_text_Table,
+      type: "RICH_TEXT",
+    },
+    {
+      ref: tv.Text_area_Table,
+      type: "MULTI_LINE_TEXT",
+    },
+  ].forEach(({ ref, type }) => assertSimpleField(ref, type));
+  assert.ok(tv.Calculated_Table.value);
+  assert.ok(tv.Number_Table.value);
+  assert.ok(tv.Text_Table.value);
+  assert.ok(tv.Text_area_Table.value);
 
-    const tv0 = record.Table_0.value[0].value;
-    assertFileField(tv0.Attachment_Table);
-    [
-        {
-            ref: tv0.Check_box_Table,
-            type: "CHECK_BOX",
-        },
-        {
-            ref: tv0.Date_Table,
-            type: "DATE",
-        },
-        {
-            ref: tv0.Date_and_time_Table,
-            type: "DATETIME",
-        },
-        {
-            ref: tv0.Link_Table,
-            type: "LINK",
-        },
-        {
-            ref: tv0.Time_Table,
-            type: "TIME",
-        },
-    ].forEach(({ ref, type }) =>
-        assertSimpleField(ref, type)
-    );
+  const tv0 = record.Table_0.value[0].value;
+  assertFileField(tv0.Attachment_Table);
+  [
+    {
+      ref: tv0.Check_box_Table,
+      type: "CHECK_BOX",
+    },
+    {
+      ref: tv0.Date_Table,
+      type: "DATE",
+    },
+    {
+      ref: tv0.Date_and_time_Table,
+      type: "DATETIME",
+    },
+    {
+      ref: tv0.Link_Table,
+      type: "LINK",
+    },
+    {
+      ref: tv0.Time_Table,
+      type: "TIME",
+    },
+  ].forEach(({ ref, type }) => assertSimpleField(ref, type));
 
-    [
-        {
-            ref: tv0.Check_box_Table,
-            type: "CHECK_BOX",
-        },
-        {
-            ref: tv0.Multi_choice_Table,
-            type: "MULTI_SELECT",
-        },
-    ].forEach(({ ref, type }) =>
-        assertStringListField(ref, type)
-    );
+  [
+    {
+      ref: tv0.Check_box_Table,
+      type: "CHECK_BOX",
+    },
+    {
+      ref: tv0.Multi_choice_Table,
+      type: "MULTI_SELECT",
+    },
+  ].forEach(({ ref, type }) => assertStringListField(ref, type));
 }
 
-function assertSubTable(ref: {
-    type: string;
-    value: any[];
-}) {
-    assertType(ref.type, "SUBTABLE");
-    assertNotUndefined(ref.value.length);
+function assertSubTable(ref: { type: string; value: any[] }) {
+  assertType(ref.type, "SUBTABLE");
+  assertNotUndefined(ref.value.length);
 }
 
 function assertSimpleField(ref: any, expectedType: string) {
-    assertType(ref.type, expectedType);
-    assert.ok(ref.value !== undefined);
+  assertType(ref.type, expectedType);
+  assert.ok(ref.value !== undefined);
 }
 
-function assertStringListField(
-    ref: any,
-    expectedType: string
-) {
-    assertType(ref.type, expectedType);
-    assertNotUndefined(ref.value.length);
+function assertStringListField(ref: any, expectedType: string) {
+  assertType(ref.type, expectedType);
+  assertNotUndefined(ref.value.length);
 }
 
 function assertEntity(
-    ref: {
-        type: string;
-        value: { code: string; name: string };
-    },
-    expectedType: string
+  ref: {
+    type: string;
+    value: { code: string; name: string };
+  },
+  expectedType: string
 ) {
-    assertType(ref.type, expectedType);
-    assertNotUndefined(ref.value);
-    assertNotUndefined(ref.value.code);
-    assertNotUndefined(ref.value.name);
+  assertType(ref.type, expectedType);
+  assertNotUndefined(ref.value);
+  assertNotUndefined(ref.value.code);
+  assertNotUndefined(ref.value.name);
 }
 
-function assertEntityListField(
-    ref: any,
-    expectedType: string
-) {
-    assertType(ref.type, expectedType);
-    assertNotUndefined(ref.value.length);
-    assertNotUndefined(ref.value[0].code);
-    assertNotUndefined(ref.value[0].name);
+function assertEntityListField(ref: any, expectedType: string) {
+  assertType(ref.type, expectedType);
+  assertNotUndefined(ref.value.length);
+  assertNotUndefined(ref.value[0].code);
+  assertNotUndefined(ref.value[0].name);
 }
 
 function assertType(type, expectedType) {
-    assert.strictEqual(
-        type,
-        expectedType,
-        `expected: ${expectedType}, actual:${type}`
-    );
+  assert.strictEqual(
+    type,
+    expectedType,
+    `expected: ${expectedType}, actual:${type}`
+  );
 }
 
 function assertNotUndefined(ref) {
-    assert.ok(ref !== undefined);
+  assert.ok(ref !== undefined);
 }
 
 interface FileFieldValue {
-    type: "FILE";
-    value: Array<{
-        name: string;
-        contentType: string;
-        fileKey: string;
-    }>;
+  type: "FILE";
+  value: Array<{
+    name: string;
+    contentType: string;
+    fileKey: string;
+  }>;
 }
 function assertFileField(ref: FileFieldValue) {
-    assert.ok(ref.type, "FILE");
-    assert.ok(ref.value.length);
-    assert.ok(ref.value[0].name);
-    assert.ok(ref.value[0].contentType);
-    assert.ok(ref.value[0].fileKey);
+  assert.ok(ref.type, "FILE");
+  assert.ok(ref.value.length);
+  assert.ok(ref.value[0].name);
+  assert.ok(ref.value[0].contentType);
+  assert.ok(ref.value[0].fileKey);
 }
 
 export const DTSGenFieldsTest = {
-    assertFieldTypes,
+  assertFieldTypes,
 };

--- a/packages/dts-gen/src/integration-tests/dts-gen-integration-test.ts
+++ b/packages/dts-gen/src/integration-tests/dts-gen-integration-test.ts
@@ -8,35 +8,30 @@ import { DTSGenApiTest } from "./dts-gen-api-test";
 import { DTSGenFieldsTest } from "./dts-gen-fields-test";
 
 interface Event {
-    appId: number;
-    viewId: number;
-    viewType: string;
-    viewName: string;
-    offset: number;
-    size: number;
-    date: string;
-    records: kintone.types.SavedFields[];
+  appId: number;
+  viewId: number;
+  viewType: string;
+  viewName: string;
+  offset: number;
+  size: number;
+  date: string;
+  records: kintone.types.SavedFields[];
 }
 (() => {
-    kintone.events.on(
-        "app.record.index.show",
-        (ev: Event) => {
-            DTSGenApiTest.assertKintoneBuiltinFunctions();
-            DTSGenFieldsTest.assertFieldTypes(
-                ev.records[0]
-            );
+  kintone.events.on("app.record.index.show", (ev: Event) => {
+    DTSGenApiTest.assertKintoneBuiltinFunctions();
+    DTSGenFieldsTest.assertFieldTypes(ev.records[0]);
 
-            assertNotUndefined(ev.appId);
-            assertNotUndefined(ev.viewType);
-            assertNotUndefined(ev.viewId);
-            assertNotUndefined(ev.viewName);
-            assertNotUndefined(ev.offset);
-            assertNotUndefined(ev.size);
-            assertNotUndefined(ev.date);
-        }
-    );
+    assertNotUndefined(ev.appId);
+    assertNotUndefined(ev.viewType);
+    assertNotUndefined(ev.viewId);
+    assertNotUndefined(ev.viewName);
+    assertNotUndefined(ev.offset);
+    assertNotUndefined(ev.size);
+    assertNotUndefined(ev.date);
+  });
 
-    function assertNotUndefined(ref) {
-        assert.ok(ref !== undefined);
-    }
+  function assertNotUndefined(ref) {
+    assert.ok(ref !== undefined);
+  }
 })();

--- a/packages/dts-gen/src/integration-tests/setup-test-app.ts
+++ b/packages/dts-gen/src/integration-tests/setup-test-app.ts
@@ -6,75 +6,61 @@ import { SetupTestApp } from "./setup-test-utils";
 import { log } from "../utils/logger";
 
 program
-    .version("0.0.1")
-    .option("--host <host>")
-    .option("-u, --username <username>")
-    .option("-p, --password <password>")
-    .option("--proxy-host [proxyHost]", "proxy host", null)
-    .option("--proxy-port [proxyPort]", "proxy port", null)
-    .option("--proxy [proxy]", "proxy server", null)
-    .option(
-        "--basic-auth-username [basicAuthUsername]",
-        "username for basic authentication",
-        null
-    )
-    .option(
-        "--basic-auth-password [basicAuthPassword]",
-        "password for basic authentication",
-        null
-    )
-    .option(
-        "--integration-test-js-file <integrationTestJsFile>",
-        "path to integration js file which will be uploaded to test kintone app"
-    )
-    .parse(process.argv);
+  .version("0.0.1")
+  .option("--host <host>")
+  .option("-u, --username <username>")
+  .option("-p, --password <password>")
+  .option("--proxy-host [proxyHost]", "proxy host", null)
+  .option("--proxy-port [proxyPort]", "proxy port", null)
+  .option("--proxy [proxy]", "proxy server", null)
+  .option(
+    "--basic-auth-username [basicAuthUsername]",
+    "username for basic authentication",
+    null
+  )
+  .option(
+    "--basic-auth-password [basicAuthPassword]",
+    "password for basic authentication",
+    null
+  )
+  .option(
+    "--integration-test-js-file <integrationTestJsFile>",
+    "path to integration js file which will be uploaded to test kintone app"
+  )
+  .parse(process.argv);
 
 (async () => {
-    await handleSetupApp(program);
+  await handleSetupApp(program);
 })();
 
 async function handleSetupApp(command) {
-    const newClientInput = {
-        baseUrl: command.host,
-        username: command.username,
-        password: command.password,
-        apiToken: command.apiToken,
-        oAuthToken: command.oAuthToken,
-        proxyHost: command.proxyHost,
-        proxyPort: command.proxyPort,
-        proxy: command.proxy,
-        basicAuthUsername: command.basicAuthUsername,
-        basicAuthPassword: command.basicAuthPassword,
-    };
+  const newClientInput = {
+    baseUrl: command.host,
+    username: command.username,
+    password: command.password,
+    apiToken: command.apiToken,
+    oAuthToken: command.oAuthToken,
+    proxyHost: command.proxyHost,
+    proxyPort: command.proxyPort,
+    proxy: command.proxy,
+    basicAuthUsername: command.basicAuthUsername,
+    basicAuthPassword: command.basicAuthPassword,
+  };
 
-    const client = new SetUpTestAppClient(newClientInput);
-    const app = await SetupTestApp.createKintoneApp(
-        client,
-        "dts-gen-integration-test"
-    );
-    await SetupTestApp.addDemoField(client, app);
+  const client = new SetUpTestAppClient(newClientInput);
+  const app = await SetupTestApp.createKintoneApp(
+    client,
+    "dts-gen-integration-test"
+  );
+  await SetupTestApp.addDemoField(client, app);
 
-    const data = fs.createReadStream(
-        command.integrationTestJsFile
-    );
-    const fileKey = await SetupTestApp.uploadFile(
-        client,
-        data,
-        {
-            name: "dts-gen-integration-test.js",
-            contentType: "text/javascript",
-        }
-    );
-    await SetupTestApp.updateJsCustomize(
-        client,
-        app,
-        fileKey
-    );
-    await SetupTestApp.deployApp(client, app);
-    log("Adding Demo Record");
-    await SetupTestApp.addDemoRecord(
-        client,
-        app,
-        command.integrationTestJsFile
-    );
+  const data = fs.createReadStream(command.integrationTestJsFile);
+  const fileKey = await SetupTestApp.uploadFile(client, data, {
+    name: "dts-gen-integration-test.js",
+    contentType: "text/javascript",
+  });
+  await SetupTestApp.updateJsCustomize(client, app, fileKey);
+  await SetupTestApp.deployApp(client, app);
+  log("Adding Demo Record");
+  await SetupTestApp.addDemoRecord(client, app, command.integrationTestJsFile);
 }

--- a/packages/dts-gen/src/integration-tests/setup-test-utils.ts
+++ b/packages/dts-gen/src/integration-tests/setup-test-utils.ts
@@ -1,9 +1,9 @@
 import * as fs from "fs";
 import {
-    SetUpTestAppClient,
-    AddFormFieldOutput,
-    JsCustomizeOutput,
-    AddRecordOutput,
+  SetUpTestAppClient,
+  AddFormFieldOutput,
+  JsCustomizeOutput,
+  AddRecordOutput,
 } from "../kintone/clients/setup-test-app-client";
 import { DemoDatas } from "../kintone/clients/demo-datas";
 import { log } from "../utils/logger";
@@ -12,149 +12,136 @@ type Client = SetUpTestAppClient;
 
 const rethrow = (err) => Promise.reject(err);
 
-async function createKintoneApp(
-    client: Client,
-    name: string
-): Promise<string> {
-    return client
-        .requestCreateNewApp({ name })
-        .then((resp) => {
-            log(`Preparing for App(ID:${resp.app})`);
-            return resp.app;
-        })
-        .catch(rethrow);
+async function createKintoneApp(client: Client, name: string): Promise<string> {
+  return client
+    .requestCreateNewApp({ name })
+    .then((resp) => {
+      log(`Preparing for App(ID:${resp.app})`);
+      return resp.app;
+    })
+    .catch(rethrow);
 }
 
 async function addDemoField(
-    client: Client,
-    app: string
+  client: Client,
+  app: string
 ): Promise<AddFormFieldOutput> {
-    log(`Preparing for field settings(ID:${app})`);
-    const properties = DemoDatas.DemoDataFields;
-    return client
-        .requestAddFormField({
-            app,
-            properties,
-        })
-        .catch(rethrow);
+  log(`Preparing for field settings(ID:${app})`);
+  const properties = DemoDatas.DemoDataFields;
+  return client
+    .requestAddFormField({
+      app,
+      properties,
+    })
+    .catch(rethrow);
 }
 
 async function uploadFile(
-    client: Client,
-    data: fs.ReadStream,
-    metadata: {
-        name: string;
-        contentType: string;
-    }
+  client: Client,
+  data: fs.ReadStream,
+  metadata: {
+    name: string;
+    contentType: string;
+  }
 ) {
-    log(`Uploading ${metadata.name}`);
-    return client
-        .requestUploadFile({
-            data,
-            fileName: metadata.name,
-            contentType: metadata.contentType,
-        })
-        .then((resp) => {
-            log(
-                `Finish Uploading ${metadata.name}(${resp.fileKey})`
-            );
-            return resp.fileKey;
-        })
-        .catch(rethrow);
+  log(`Uploading ${metadata.name}`);
+  return client
+    .requestUploadFile({
+      data,
+      fileName: metadata.name,
+      contentType: metadata.contentType,
+    })
+    .then((resp) => {
+      log(`Finish Uploading ${metadata.name}(${resp.fileKey})`);
+      return resp.fileKey;
+    })
+    .catch(rethrow);
 }
 
 async function sleep(msec) {
-    return new Promise((resolve) =>
-        setTimeout(resolve, msec)
-    );
+  return new Promise((resolve) => setTimeout(resolve, msec));
 }
 
 async function updateJsCustomize(
-    client: Client,
-    app: string,
-    fileKey: string
+  client: Client,
+  app: string,
+  fileKey: string
 ): Promise<JsCustomizeOutput> {
-    const scope = "ALL";
-    const desktop = {
-        js: [
-            {
-                type: "FILE",
-                file: {
-                    fileKey,
-                },
-            },
-        ],
-    };
-    return client
-        .requestJsCustomizeUpdate({
-            app,
-            scope,
-            desktop,
-        })
-        .catch(rethrow);
+  const scope = "ALL";
+  const desktop = {
+    js: [
+      {
+        type: "FILE",
+        file: {
+          fileKey,
+        },
+      },
+    ],
+  };
+  return client
+    .requestJsCustomizeUpdate({
+      app,
+      scope,
+      desktop,
+    })
+    .catch(rethrow);
 }
 
 async function deployApp(client: Client, app: string) {
-    const apps = [{ app }];
-    await client.requestDepoy({ apps });
-    for (const i of [1, 2, 3, 4, 5]) {
-        const successApps = await client
-            .requestGetDeployStatus({ apps: [app] })
-            .then((resp) => {
-                return resp.apps.filter(
-                    (a) => a.status === "SUCCESS"
-                );
-            })
-            .catch(rethrow);
-        if (successApps.length !== 1) {
-            log(
-                `Waiting for Deploy complete... ${i} times`
-            );
-            await sleep(3000);
-        }
+  const apps = [{ app }];
+  await client.requestDepoy({ apps });
+  for (const i of [1, 2, 3, 4, 5]) {
+    const successApps = await client
+      .requestGetDeployStatus({ apps: [app] })
+      .then((resp) => {
+        return resp.apps.filter((a) => a.status === "SUCCESS");
+      })
+      .catch(rethrow);
+    if (successApps.length !== 1) {
+      log(`Waiting for Deploy complete... ${i} times`);
+      await sleep(3000);
     }
+  }
 }
 
 async function addDemoRecord(
-    client: Client,
-    app: string,
-    fileName: string
+  client: Client,
+  app: string,
+  fileName: string
 ): Promise<AddRecordOutput> {
-    const DemoRecord = DemoDatas.DemoRecord;
-    const record = Object.assign(DemoRecord);
+  const DemoRecord = DemoDatas.DemoRecord;
+  const record = Object.assign(DemoRecord);
 
-    const upload1 = await client.requestUploadFile({
-        data: fs.createReadStream(fileName),
-        fileName: "sampleText",
-        contentType: "plain/text",
-    });
-    record.Attachment.value.push({
-        contentType: "plain/text",
-        fileKey: upload1.fileKey,
-        name: "text1",
-    });
+  const upload1 = await client.requestUploadFile({
+    data: fs.createReadStream(fileName),
+    fileName: "sampleText",
+    contentType: "plain/text",
+  });
+  record.Attachment.value.push({
+    contentType: "plain/text",
+    fileKey: upload1.fileKey,
+    name: "text1",
+  });
 
-    const upload2 = await client.requestUploadFile({
-        data: fs.createReadStream(fileName),
-        fileName: "sampleText",
-        contentType: "plain/text",
-    });
-    record.Table_0.value[0].value.Attachment_Table.value.push(
-        {
-            contentType: "plain/text",
-            fileKey: upload2.fileKey,
-            name: "text2",
-        }
-    );
+  const upload2 = await client.requestUploadFile({
+    data: fs.createReadStream(fileName),
+    fileName: "sampleText",
+    contentType: "plain/text",
+  });
+  record.Table_0.value[0].value.Attachment_Table.value.push({
+    contentType: "plain/text",
+    fileKey: upload2.fileKey,
+    name: "text2",
+  });
 
-    return client.requestAddRecord({ app, record });
+  return client.requestAddRecord({ app, record });
 }
 
 export const SetupTestApp = {
-    createKintoneApp,
-    addDemoField,
-    uploadFile,
-    updateJsCustomize,
-    deployApp,
-    addDemoRecord,
+  createKintoneApp,
+  addDemoField,
+  uploadFile,
+  updateJsCustomize,
+  deployApp,
+  addDemoRecord,
 };

--- a/packages/dts-gen/src/integration-tests/testfields.d.ts
+++ b/packages/dts-gen/src/integration-tests/testfields.d.ts
@@ -1,62 +1,62 @@
 declare namespace kintone.types {
-    interface Fields {
-        Text: kintone.fieldTypes.SingleLineText;
-        Rich_text: kintone.fieldTypes.RichText;
-        Text_area: kintone.fieldTypes.MultiLineText;
-        Number: kintone.fieldTypes.Number;
-        Radio_button: kintone.fieldTypes.RadioButton;
-        Drop_down: kintone.fieldTypes.DropDown;
-        Date: kintone.fieldTypes.Date;
-        Time: kintone.fieldTypes.Time;
-        Date_and_time: kintone.fieldTypes.DateTime;
-        Link: kintone.fieldTypes.Link;
-        Calculated: kintone.fieldTypes.Calc;
-        Check_box: kintone.fieldTypes.CheckBox;
-        Multi_choice: kintone.fieldTypes.MultiSelect;
-        User_selection: kintone.fieldTypes.UserSelect;
-        Department_selection: kintone.fieldTypes.OrganizationSelect;
-        Group_selection: kintone.fieldTypes.GroupSelect;
-        Attachment: kintone.fieldTypes.File;
-        Table: {
-            type: "SUBTABLE";
-            value: Array<{
-                id: string;
-                value: {
-                    Text_Table: kintone.fieldTypes.SingleLineText;
-                    Rich_text_Table: kintone.fieldTypes.RichText;
-                    Text_area_Table: kintone.fieldTypes.MultiLineText;
-                    Number_Table: kintone.fieldTypes.Number;
-                    Calculated_Table: kintone.fieldTypes.Calc;
-                };
-            }>;
+  interface Fields {
+    Text: kintone.fieldTypes.SingleLineText;
+    Rich_text: kintone.fieldTypes.RichText;
+    Text_area: kintone.fieldTypes.MultiLineText;
+    Number: kintone.fieldTypes.Number;
+    Radio_button: kintone.fieldTypes.RadioButton;
+    Drop_down: kintone.fieldTypes.DropDown;
+    Date: kintone.fieldTypes.Date;
+    Time: kintone.fieldTypes.Time;
+    Date_and_time: kintone.fieldTypes.DateTime;
+    Link: kintone.fieldTypes.Link;
+    Calculated: kintone.fieldTypes.Calc;
+    Check_box: kintone.fieldTypes.CheckBox;
+    Multi_choice: kintone.fieldTypes.MultiSelect;
+    User_selection: kintone.fieldTypes.UserSelect;
+    Department_selection: kintone.fieldTypes.OrganizationSelect;
+    Group_selection: kintone.fieldTypes.GroupSelect;
+    Attachment: kintone.fieldTypes.File;
+    Table: {
+      type: "SUBTABLE";
+      value: Array<{
+        id: string;
+        value: {
+          Text_Table: kintone.fieldTypes.SingleLineText;
+          Rich_text_Table: kintone.fieldTypes.RichText;
+          Text_area_Table: kintone.fieldTypes.MultiLineText;
+          Number_Table: kintone.fieldTypes.Number;
+          Calculated_Table: kintone.fieldTypes.Calc;
         };
-        Table_0: {
-            type: "SUBTABLE";
-            value: Array<{
-                id: string;
-                value: {
-                    Radio_button_Table: kintone.fieldTypes.RadioButton;
-                    Drop_down_Table: kintone.fieldTypes.DropDown;
-                    Date_Table: kintone.fieldTypes.Date;
-                    Time_Table: kintone.fieldTypes.Time;
-                    Date_and_time_Table: kintone.fieldTypes.DateTime;
-                    Link_Table: kintone.fieldTypes.Link;
+      }>;
+    };
+    Table_0: {
+      type: "SUBTABLE";
+      value: Array<{
+        id: string;
+        value: {
+          Radio_button_Table: kintone.fieldTypes.RadioButton;
+          Drop_down_Table: kintone.fieldTypes.DropDown;
+          Date_Table: kintone.fieldTypes.Date;
+          Time_Table: kintone.fieldTypes.Time;
+          Date_and_time_Table: kintone.fieldTypes.DateTime;
+          Link_Table: kintone.fieldTypes.Link;
 
-                    Check_box_Table: kintone.fieldTypes.CheckBox;
-                    Multi_choice_Table: kintone.fieldTypes.MultiSelect;
+          Check_box_Table: kintone.fieldTypes.CheckBox;
+          Multi_choice_Table: kintone.fieldTypes.MultiSelect;
 
-                    Attachment_Table: kintone.fieldTypes.File;
-                };
-            }>;
+          Attachment_Table: kintone.fieldTypes.File;
         };
-    }
-    interface SavedFields extends Fields {
-        $id: kintone.fieldTypes.Id;
-        $revision: kintone.fieldTypes.Revision;
-        Updated_by: kintone.fieldTypes.Modifier;
-        Created_by: kintone.fieldTypes.Creator;
-        Record_number: kintone.fieldTypes.RecordNumber;
-        Updated_datetime: kintone.fieldTypes.UpdatedTime;
-        Created_datetime: kintone.fieldTypes.CreatedTime;
-    }
+      }>;
+    };
+  }
+  interface SavedFields extends Fields {
+    $id: kintone.fieldTypes.Id;
+    $revision: kintone.fieldTypes.Revision;
+    Updated_by: kintone.fieldTypes.Modifier;
+    Created_by: kintone.fieldTypes.Creator;
+    Record_number: kintone.fieldTypes.RecordNumber;
+    Updated_datetime: kintone.fieldTypes.UpdatedTime;
+    Created_datetime: kintone.fieldTypes.CreatedTime;
+  }
 }

--- a/packages/dts-gen/src/kintone/clients/axios-utils.test.ts
+++ b/packages/dts-gen/src/kintone/clients/axios-utils.test.ts
@@ -1,140 +1,118 @@
-import {
-    AxiosUtils,
-    VisibleForTesting,
-} from "./axios-utils";
+import { AxiosUtils, VisibleForTesting } from "./axios-utils";
 import { AxiosRequestConfig } from "axios";
 
 describe("FormsClientImpl#constructor", () => {
-    const baseUrl = "https://kintone.com";
-    const authToken = Buffer.from(
-        "username:password"
-    ).toString("base64");
+  const baseUrl = "https://kintone.com";
+  const authToken = Buffer.from("username:password").toString("base64");
 
-    function assertConstructorWithArgs(
-        input,
-        expectedInput: AxiosRequestConfig
-    ) {
-        VisibleForTesting.newAxiosInstanceInternal =
-            jest.fn();
-        AxiosUtils.newAxiosInstance(input);
-        expect(
-            VisibleForTesting.newAxiosInstanceInternal
-        ).toBeCalledWith(expectedInput);
-    }
+  function assertConstructorWithArgs(input, expectedInput: AxiosRequestConfig) {
+    VisibleForTesting.newAxiosInstanceInternal = jest.fn();
+    AxiosUtils.newAxiosInstance(input);
+    expect(VisibleForTesting.newAxiosInstanceInternal).toBeCalledWith(
+      expectedInput
+    );
+  }
 
-    test("with plain settings", () => {
-        const input = {
-            baseUrl,
-            username: "username",
-            password: "password",
-            proxy: null,
-            proxyHost: null,
-            proxyPort: null,
-            basicAuthPassword: null,
-            basicAuthUsername: null,
-        };
+  test("with plain settings", () => {
+    const input = {
+      baseUrl,
+      username: "username",
+      password: "password",
+      proxy: null,
+      proxyHost: null,
+      proxyPort: null,
+      basicAuthPassword: null,
+      basicAuthUsername: null,
+    };
 
-        const headers = {
-            "X-Cybozu-Authorization": authToken,
-        };
-        const expectedCalledWith = {
-            headers,
-            baseURL: baseUrl,
-            proxy: undefined,
-        } as AxiosRequestConfig;
-        assertConstructorWithArgs(
-            input,
-            expectedCalledWith
-        );
-    });
+    const headers = {
+      "X-Cybozu-Authorization": authToken,
+    };
+    const expectedCalledWith = {
+      headers,
+      baseURL: baseUrl,
+      proxy: undefined,
+    } as AxiosRequestConfig;
+    assertConstructorWithArgs(input, expectedCalledWith);
+  });
 
-    test("with proxyHost and proxyPort option", () => {
-        const input = {
-            baseUrl,
-            username: "username",
-            password: "password",
-            proxy: null,
-            proxyHost: "proxyHost",
-            proxyPort: "1234",
-            basicAuthPassword: null,
-            basicAuthUsername: null,
-        };
+  test("with proxyHost and proxyPort option", () => {
+    const input = {
+      baseUrl,
+      username: "username",
+      password: "password",
+      proxy: null,
+      proxyHost: "proxyHost",
+      proxyPort: "1234",
+      basicAuthPassword: null,
+      basicAuthUsername: null,
+    };
 
-        const headers = {
-            "X-Cybozu-Authorization": authToken,
-        };
-        const expectedCalledWith = {
-            headers,
-            baseURL: baseUrl,
-            proxy: {
-                host: "proxyHost",
-                port: 1234,
-            },
-        };
-        assertConstructorWithArgs(
-            input,
-            expectedCalledWith
-        );
-    });
+    const headers = {
+      "X-Cybozu-Authorization": authToken,
+    };
+    const expectedCalledWith = {
+      headers,
+      baseURL: baseUrl,
+      proxy: {
+        host: "proxyHost",
+        port: 1234,
+      },
+    };
+    assertConstructorWithArgs(input, expectedCalledWith);
+  });
 
-    test("with proxy option", () => {
-        const input = {
-            baseUrl,
-            username: "username",
-            password: "password",
-            proxy: "http://admin:password@localhost:1234",
-            proxyHost: null,
-            proxyPort: null,
-            basicAuthPassword: null,
-            basicAuthUsername: null,
-        };
+  test("with proxy option", () => {
+    const input = {
+      baseUrl,
+      username: "username",
+      password: "password",
+      proxy: "http://admin:password@localhost:1234",
+      proxyHost: null,
+      proxyPort: null,
+      basicAuthPassword: null,
+      basicAuthUsername: null,
+    };
 
-        const headers = {
-            "X-Cybozu-Authorization": authToken,
-        };
-        const expectedCalledWith = {
-            headers,
-            baseURL: baseUrl,
-            proxy: {
-                host: "localhost",
-                port: 1234,
-                auth: {
-                    username: "admin",
-                    password: "password",
-                },
-            },
-        };
-        assertConstructorWithArgs(
-            input,
-            expectedCalledWith
-        );
-    });
+    const headers = {
+      "X-Cybozu-Authorization": authToken,
+    };
+    const expectedCalledWith = {
+      headers,
+      baseURL: baseUrl,
+      proxy: {
+        host: "localhost",
+        port: 1234,
+        auth: {
+          username: "admin",
+          password: "password",
+        },
+      },
+    };
+    assertConstructorWithArgs(input, expectedCalledWith);
+  });
 
-    test("with basic auth", () => {
-        const input = {
-            baseUrl,
-            username: "username",
-            password: "password",
-            proxy: null,
-            proxyHost: null,
-            proxyPort: null,
-            basicAuthPassword: "basicUsername",
-            basicAuthUsername: "basicPassword",
-        };
+  test("with basic auth", () => {
+    const input = {
+      baseUrl,
+      username: "username",
+      password: "password",
+      proxy: null,
+      proxyHost: null,
+      proxyPort: null,
+      basicAuthPassword: "basicUsername",
+      basicAuthUsername: "basicPassword",
+    };
 
-        const headers = {
-            "X-Cybozu-Authorization": authToken,
-            Authorization:
-                "Basic YmFzaWNQYXNzd29yZDpiYXNpY1VzZXJuYW1l",
-        };
-        const expectedCalledWith = {
-            headers,
-            baseURL: baseUrl,
-            proxy: undefined,
-        } as AxiosRequestConfig;
-        assertConstructorWithArgs(
-            input,
-            expectedCalledWith
-        );
-    });
+    const headers = {
+      "X-Cybozu-Authorization": authToken,
+      Authorization: "Basic YmFzaWNQYXNzd29yZDpiYXNpY1VzZXJuYW1l",
+    };
+    const expectedCalledWith = {
+      headers,
+      baseURL: baseUrl,
+      proxy: undefined,
+    } as AxiosRequestConfig;
+    assertConstructorWithArgs(input, expectedCalledWith);
+  });
 });

--- a/packages/dts-gen/src/kintone/clients/axios-utils.ts
+++ b/packages/dts-gen/src/kintone/clients/axios-utils.ts
@@ -1,96 +1,84 @@
 import axios, {
-    AxiosInstance,
-    AxiosProxyConfig,
-    AxiosRequestConfig,
+  AxiosInstance,
+  AxiosProxyConfig,
+  AxiosRequestConfig,
 } from "axios";
 import { IncomingHttpHeaders } from "http";
 
 export interface NewInstanceInput {
-    baseUrl: string;
-    username: string | null;
-    password: string | null;
-    oAuthToken: string | null;
-    apiToken: string | null;
-    proxy: string | null;
-    proxyHost: string | null;
-    proxyPort: string | null;
-    basicAuthPassword: string | null;
-    basicAuthUsername: string | null;
+  baseUrl: string;
+  username: string | null;
+  password: string | null;
+  oAuthToken: string | null;
+  apiToken: string | null;
+  proxy: string | null;
+  proxyHost: string | null;
+  proxyPort: string | null;
+  basicAuthPassword: string | null;
+  basicAuthUsername: string | null;
 }
 
-function newAxiosInstance(
-    input: NewInstanceInput
-): AxiosInstance {
-    let proxy: AxiosProxyConfig | undefined;
-    // parse the proxy URL like http://admin:pass@localhost:8000
-    if (input.proxy) {
-        const proxyUrl = new URL(input.proxy);
-        proxy = {
-            host: proxyUrl.hostname,
-            port: parseInt(proxyUrl.port, 10),
-            auth: {
-                username: proxyUrl.username,
-                password: proxyUrl.password,
-            },
-        };
-    } else if (
-        input.proxyHost !== null &&
-        input.proxyPort !== null
-    ) {
-        proxy = {
-            host: input.proxyHost,
-            port: parseInt(input.proxyPort, 10),
-        };
-    }
+function newAxiosInstance(input: NewInstanceInput): AxiosInstance {
+  let proxy: AxiosProxyConfig | undefined;
+  // parse the proxy URL like http://admin:pass@localhost:8000
+  if (input.proxy) {
+    const proxyUrl = new URL(input.proxy);
+    proxy = {
+      host: proxyUrl.hostname,
+      port: parseInt(proxyUrl.port, 10),
+      auth: {
+        username: proxyUrl.username,
+        password: proxyUrl.password,
+      },
+    };
+  } else if (input.proxyHost !== null && input.proxyPort !== null) {
+    proxy = {
+      host: input.proxyHost,
+      port: parseInt(input.proxyPort, 10),
+    };
+  }
 
-    let headers: IncomingHttpHeaders;
-    if (input.username && input.password) {
-        headers = {
-            "X-Cybozu-Authorization": Buffer.from(
-                `${input.username}:${input.password}`
-            ).toString("base64"),
-        };
-    } else if (input.apiToken) {
-        headers = {
-            "X-Cybozu-API-Token": input.apiToken,
-        };
-    } else if (input.oAuthToken) {
-        headers = {
-            Authorization: `Bearer ${input.oAuthToken}`,
-        };
-    } else {
-        throw new Error(
-            "cannot get an authentication input"
-        );
-    }
+  let headers: IncomingHttpHeaders;
+  if (input.username && input.password) {
+    headers = {
+      "X-Cybozu-Authorization": Buffer.from(
+        `${input.username}:${input.password}`
+      ).toString("base64"),
+    };
+  } else if (input.apiToken) {
+    headers = {
+      "X-Cybozu-API-Token": input.apiToken,
+    };
+  } else if (input.oAuthToken) {
+    headers = {
+      Authorization: `Bearer ${input.oAuthToken}`,
+    };
+  } else {
+    throw new Error("cannot get an authentication input");
+  }
 
-    if (
-        input.basicAuthPassword &&
-        input.basicAuthPassword
-    ) {
-        headers.Authorization =
-            "Basic " +
-            Buffer.from(
-                `${input.basicAuthUsername}:${input.basicAuthPassword}`
-            ).toString("base64");
-    }
-    return VisibleForTesting.newAxiosInstanceInternal({
-        baseURL: input.baseUrl,
-        headers,
-        proxy,
-    });
+  if (input.basicAuthPassword && input.basicAuthPassword) {
+    headers.Authorization =
+      "Basic " +
+      Buffer.from(
+        `${input.basicAuthUsername}:${input.basicAuthPassword}`
+      ).toString("base64");
+  }
+  return VisibleForTesting.newAxiosInstanceInternal({
+    baseURL: input.baseUrl,
+    headers,
+    proxy,
+  });
 }
 
-function newAxiosInstanceInternal(
-    config: AxiosRequestConfig
-) {
-    return axios.create(config);
+function newAxiosInstanceInternal(config: AxiosRequestConfig) {
+  return axios.create(config);
 }
 
 export const AxiosUtils = {
-    newAxiosInstance,
+  newAxiosInstance,
 };
 
 export const VisibleForTesting = {
-    newAxiosInstanceInternal,
+  newAxiosInstanceInternal,
 };

--- a/packages/dts-gen/src/kintone/clients/demo-client.ts
+++ b/packages/dts-gen/src/kintone/clients/demo-client.ts
@@ -1,20 +1,19 @@
 import {
-    FetchFormPropertiesInput,
-    FormsClient,
-    FieldNameAndFieldOrSubTableField,
+  FetchFormPropertiesInput,
+  FormsClient,
+  FieldNameAndFieldOrSubTableField,
 } from "./forms-client";
 import { DemoDatas } from "./demo-datas";
 
 export class DemoClient implements FormsClient {
-    fetchFormProperties(
-        _: FetchFormPropertiesInput
-    ): Promise<FieldNameAndFieldOrSubTableField> {
-        const demoResp = {
-            properties:
-                DemoDatas.DemoDataIncludingBuiltinFields,
-        };
-        return Promise.resolve(
-            demoResp.properties as FieldNameAndFieldOrSubTableField
-        );
-    }
+  fetchFormProperties(
+    _: FetchFormPropertiesInput
+  ): Promise<FieldNameAndFieldOrSubTableField> {
+    const demoResp = {
+      properties: DemoDatas.DemoDataIncludingBuiltinFields,
+    };
+    return Promise.resolve(
+      demoResp.properties as FieldNameAndFieldOrSubTableField
+    );
+  }
 }

--- a/packages/dts-gen/src/kintone/clients/demo-datas.ts
+++ b/packages/dts-gen/src/kintone/clients/demo-datas.ts
@@ -1,9 +1,225 @@
 const DemoDataFields: any = {
-    Text: {
+  Text: {
+    type: "SINGLE_LINE_TEXT",
+    label: "Text",
+    noLabel: "false",
+    code: "Text",
+    required: "false",
+    minLength: null,
+    maxLength: null,
+    expression: "",
+    hideExpression: "false",
+    unique: "false",
+    defaultValue: "",
+  },
+
+  Rich_text: {
+    type: "RICH_TEXT",
+    label: "Rich text",
+    noLabel: "false",
+    code: "Rich_text",
+    required: "false",
+    defaultValue: "",
+  },
+
+  Text_area: {
+    type: "MULTI_LINE_TEXT",
+    label: "Text area",
+    noLabel: "false",
+    code: "Text_area",
+    required: "false",
+    defaultValue: "",
+  },
+
+  Number: {
+    type: "NUMBER",
+    label: "Number",
+    noLabel: "false",
+    code: "Number",
+    required: "false",
+    minValue: null,
+    maxValue: null,
+    digit: "false",
+    unique: "false",
+    defaultValue: null,
+    displayScale: null,
+    unit: null,
+    unitPosition: "BEFORE",
+  },
+
+  Calculated: {
+    type: "CALC",
+    label: "Calculated",
+    noLabel: "false",
+    code: "Calculated",
+    required: "false",
+    expression: "100 + 100",
+    format: "NUMBER",
+    displayScale: null,
+    hideExpression: "false",
+    unit: null,
+    unitPosition: "BEFORE",
+  },
+
+  Radio_button: {
+    type: "RADIO_BUTTON",
+    code: "Radio_button",
+    label: "Radio button",
+    noLabel: false,
+    required: true,
+    options: {
+      sample1: {
+        label: "sample1",
+        index: "0",
+      },
+      sample2: {
+        label: "sample2",
+        index: "1",
+      },
+    },
+    defaultValue: "sample1",
+    align: "HORIZONTAL",
+  },
+  Check_box: {
+    type: "CHECK_BOX",
+    code: "Check_box",
+    label: "Check box",
+    noLabel: false,
+    required: false,
+    options: {
+      sample1: {
+        label: "sample1",
+        index: "0",
+      },
+      sample2: {
+        label: "sample2",
+        index: "1",
+      },
+    },
+    defaultValue: [],
+    align: "HORIZONTAL",
+  },
+
+  Multi_choice: {
+    type: "MULTI_SELECT",
+    code: "Multi_choice",
+    label: "Multi choice",
+    noLabel: false,
+    required: false,
+    options: {
+      sample1: {
+        label: "sample1",
+        index: "0",
+      },
+      sample2: {
+        label: "sample2",
+        index: "1",
+      },
+    },
+    defaultValue: [],
+  },
+
+  Drop_down: {
+    type: "DROP_DOWN",
+    code: "Drop_down",
+    label: "Drop down",
+    noLabel: false,
+    required: false,
+    options: {
+      sample1: {
+        label: "sample1",
+        index: "0",
+      },
+      sample2: {
+        label: "sample2",
+        index: "1",
+      },
+    },
+    defaultValue: "",
+  },
+
+  Date: {
+    type: "DATE",
+    label: "Date",
+    noLabel: "false",
+    code: "Date",
+    required: "false",
+    unique: "false",
+    defaultValue: null,
+    defaultExpression: "NOW",
+  },
+
+  Time: {
+    type: "TIME",
+    label: "Time",
+    noLabel: "false",
+    code: "Time",
+    required: "false",
+    defaultValue: null,
+    defaultExpression: "NOW",
+  },
+  Date_and_time: {
+    type: "DATETIME",
+    label: "Date and time",
+    noLabel: "false",
+    code: "Date_and_time",
+    required: "false",
+    unique: "false",
+    defaultValue: null,
+    defaultExpression: "NOW",
+  },
+
+  Attachment: {
+    type: "FILE",
+    label: "Attachment",
+    noLabel: "false",
+    code: "Attachment",
+    required: "false",
+  },
+  Link: {
+    type: "LINK",
+    label: "Link",
+    noLabel: "false",
+    code: "Link",
+    required: "false",
+    protocol: "MAIL",
+    minLength: null,
+    maxLength: null,
+    unique: "false",
+    defaultValue: "",
+  },
+
+  User_selection: {
+    type: "USER_SELECT",
+    label: "User selection",
+    noLabel: "false",
+    code: "User_selection",
+    required: "false",
+  },
+  Department_selection: {
+    type: "ORGANIZATION_SELECT",
+    label: "Department selection",
+    noLabel: "false",
+    code: "Department_selection",
+    required: "false",
+  },
+  Group_selection: {
+    type: "GROUP_SELECT",
+    label: "Group selection",
+    noLabel: "false",
+    code: "Group_selection",
+    required: "false",
+  },
+
+  Table: {
+    type: "SUBTABLE",
+    code: "Table",
+    fields: {
+      Text_Table: {
         type: "SINGLE_LINE_TEXT",
         label: "Text",
         noLabel: "false",
-        code: "Text",
+        code: "Text_Table",
         required: "false",
         minLength: null,
         maxLength: null,
@@ -11,31 +227,28 @@ const DemoDataFields: any = {
         hideExpression: "false",
         unique: "false",
         defaultValue: "",
-    },
-
-    Rich_text: {
+      },
+      Rich_text_Table: {
         type: "RICH_TEXT",
         label: "Rich text",
         noLabel: "false",
-        code: "Rich_text",
+        code: "Rich_text_Table",
         required: "false",
         defaultValue: "",
-    },
-
-    Text_area: {
+      },
+      Text_area_Table: {
         type: "MULTI_LINE_TEXT",
         label: "Text area",
         noLabel: "false",
-        code: "Text_area",
+        code: "Text_area_Table",
         required: "false",
         defaultValue: "",
-    },
-
-    Number: {
+      },
+      Number_Table: {
         type: "NUMBER",
         label: "Number",
         noLabel: "false",
-        code: "Number",
+        code: "Number_Table",
         required: "false",
         minValue: null,
         maxValue: null,
@@ -45,563 +258,350 @@ const DemoDataFields: any = {
         displayScale: null,
         unit: null,
         unitPosition: "BEFORE",
-    },
-
-    Calculated: {
+      },
+      Calculated_Table: {
         type: "CALC",
         label: "Calculated",
         noLabel: "false",
-        code: "Calculated",
+        code: "Calculated_Table",
         required: "false",
-        expression: "100 + 100",
+        expression: "1 + 1",
         format: "NUMBER",
         displayScale: null,
         hideExpression: "false",
         unit: null,
         unitPosition: "BEFORE",
+      },
     },
+  },
 
-    Radio_button: {
+  Table_0: {
+    type: "SUBTABLE",
+    code: "Table_0",
+    fields: {
+      Radio_button_Table: {
         type: "RADIO_BUTTON",
-        code: "Radio_button",
         label: "Radio button",
-        noLabel: false,
-        required: true,
+        noLabel: "false",
+        code: "Radio_button_Table",
+        required: "true",
         options: {
-            sample1: {
-                label: "sample1",
-                index: "0",
-            },
-            sample2: {
-                label: "sample2",
-                index: "1",
-            },
+          sample1: {
+            label: "sample1",
+            index: "0",
+          },
+          sample2: {
+            label: "sample2",
+            index: "1",
+          },
         },
         defaultValue: "sample1",
-        align: "HORIZONTAL",
-    },
-    Check_box: {
+      },
+      Check_box_Table: {
         type: "CHECK_BOX",
-        code: "Check_box",
         label: "Check box",
-        noLabel: false,
-        required: false,
+        noLabel: "false",
+        code: "Check_box_Table",
+        required: "false",
         options: {
-            sample1: {
-                label: "sample1",
-                index: "0",
-            },
-            sample2: {
-                label: "sample2",
-                index: "1",
-            },
+          sample1: {
+            label: "sample1",
+            index: "0",
+          },
+          sample2: {
+            label: "sample2",
+            index: "1",
+          },
         },
         defaultValue: [],
-        align: "HORIZONTAL",
-    },
-
-    Multi_choice: {
+      },
+      Multi_choice_Table: {
         type: "MULTI_SELECT",
-        code: "Multi_choice",
-        label: "Multi choice",
-        noLabel: false,
-        required: false,
+        label: "Multi-choice",
+        noLabel: "false",
+        code: "Multi_choice_Table",
+        required: "false",
         options: {
-            sample1: {
-                label: "sample1",
-                index: "0",
-            },
-            sample2: {
-                label: "sample2",
-                index: "1",
-            },
+          sample1: {
+            label: "sample1",
+            index: "0",
+          },
+          sample2: {
+            label: "sample2",
+            index: "1",
+          },
         },
         defaultValue: [],
-    },
-
-    Drop_down: {
+      },
+      Drop_down_Table: {
         type: "DROP_DOWN",
-        code: "Drop_down",
-        label: "Drop down",
-        noLabel: false,
-        required: false,
+        label: "Drop-down",
+        noLabel: "false",
+        code: "Drop_down_Table",
+        required: "false",
         options: {
-            sample1: {
-                label: "sample1",
-                index: "0",
-            },
-            sample2: {
-                label: "sample2",
-                index: "1",
-            },
+          sample1: {
+            label: "sample1",
+            index: "0",
+          },
+          sample2: {
+            label: "sample2",
+            index: "1",
+          },
         },
-        defaultValue: "",
-    },
-
-    Date: {
+        defaultValue: null,
+      },
+      Date_Table: {
         type: "DATE",
         label: "Date",
         noLabel: "false",
-        code: "Date",
+        code: "Date_Table",
         required: "false",
         unique: "false",
         defaultValue: null,
         defaultExpression: "NOW",
-    },
-
-    Time: {
+      },
+      Time_Table: {
         type: "TIME",
         label: "Time",
         noLabel: "false",
-        code: "Time",
+        code: "Time_Table",
         required: "false",
         defaultValue: null,
         defaultExpression: "NOW",
-    },
-    Date_and_time: {
+      },
+      Date_and_time_Table: {
         type: "DATETIME",
         label: "Date and time",
         noLabel: "false",
-        code: "Date_and_time",
+        code: "Date_and_time_Table",
         required: "false",
         unique: "false",
         defaultValue: null,
         defaultExpression: "NOW",
-    },
-
-    Attachment: {
+      },
+      Attachment_Table: {
         type: "FILE",
         label: "Attachment",
         noLabel: "false",
-        code: "Attachment",
+        code: "Attachment_Table",
         required: "false",
-    },
-    Link: {
+      },
+      Link_Table: {
         type: "LINK",
         label: "Link",
         noLabel: "false",
-        code: "Link",
+        code: "Link_Table",
         required: "false",
-        protocol: "MAIL",
+        protocol: "WEB",
         minLength: null,
         maxLength: null,
         unique: "false",
         defaultValue: "",
+      },
     },
-
-    User_selection: {
-        type: "USER_SELECT",
-        label: "User selection",
-        noLabel: "false",
-        code: "User_selection",
-        required: "false",
-    },
-    Department_selection: {
-        type: "ORGANIZATION_SELECT",
-        label: "Department selection",
-        noLabel: "false",
-        code: "Department_selection",
-        required: "false",
-    },
-    Group_selection: {
-        type: "GROUP_SELECT",
-        label: "Group selection",
-        noLabel: "false",
-        code: "Group_selection",
-        required: "false",
-    },
-
-    Table: {
-        type: "SUBTABLE",
-        code: "Table",
-        fields: {
-            Text_Table: {
-                type: "SINGLE_LINE_TEXT",
-                label: "Text",
-                noLabel: "false",
-                code: "Text_Table",
-                required: "false",
-                minLength: null,
-                maxLength: null,
-                expression: "",
-                hideExpression: "false",
-                unique: "false",
-                defaultValue: "",
-            },
-            Rich_text_Table: {
-                type: "RICH_TEXT",
-                label: "Rich text",
-                noLabel: "false",
-                code: "Rich_text_Table",
-                required: "false",
-                defaultValue: "",
-            },
-            Text_area_Table: {
-                type: "MULTI_LINE_TEXT",
-                label: "Text area",
-                noLabel: "false",
-                code: "Text_area_Table",
-                required: "false",
-                defaultValue: "",
-            },
-            Number_Table: {
-                type: "NUMBER",
-                label: "Number",
-                noLabel: "false",
-                code: "Number_Table",
-                required: "false",
-                minValue: null,
-                maxValue: null,
-                digit: "false",
-                unique: "false",
-                defaultValue: null,
-                displayScale: null,
-                unit: null,
-                unitPosition: "BEFORE",
-            },
-            Calculated_Table: {
-                type: "CALC",
-                label: "Calculated",
-                noLabel: "false",
-                code: "Calculated_Table",
-                required: "false",
-                expression: "1 + 1",
-                format: "NUMBER",
-                displayScale: null,
-                hideExpression: "false",
-                unit: null,
-                unitPosition: "BEFORE",
-            },
-        },
-    },
-
-    Table_0: {
-        type: "SUBTABLE",
-        code: "Table_0",
-        fields: {
-            Radio_button_Table: {
-                type: "RADIO_BUTTON",
-                label: "Radio button",
-                noLabel: "false",
-                code: "Radio_button_Table",
-                required: "true",
-                options: {
-                    sample1: {
-                        label: "sample1",
-                        index: "0",
-                    },
-                    sample2: {
-                        label: "sample2",
-                        index: "1",
-                    },
-                },
-                defaultValue: "sample1",
-            },
-            Check_box_Table: {
-                type: "CHECK_BOX",
-                label: "Check box",
-                noLabel: "false",
-                code: "Check_box_Table",
-                required: "false",
-                options: {
-                    sample1: {
-                        label: "sample1",
-                        index: "0",
-                    },
-                    sample2: {
-                        label: "sample2",
-                        index: "1",
-                    },
-                },
-                defaultValue: [],
-            },
-            Multi_choice_Table: {
-                type: "MULTI_SELECT",
-                label: "Multi-choice",
-                noLabel: "false",
-                code: "Multi_choice_Table",
-                required: "false",
-                options: {
-                    sample1: {
-                        label: "sample1",
-                        index: "0",
-                    },
-                    sample2: {
-                        label: "sample2",
-                        index: "1",
-                    },
-                },
-                defaultValue: [],
-            },
-            Drop_down_Table: {
-                type: "DROP_DOWN",
-                label: "Drop-down",
-                noLabel: "false",
-                code: "Drop_down_Table",
-                required: "false",
-                options: {
-                    sample1: {
-                        label: "sample1",
-                        index: "0",
-                    },
-                    sample2: {
-                        label: "sample2",
-                        index: "1",
-                    },
-                },
-                defaultValue: null,
-            },
-            Date_Table: {
-                type: "DATE",
-                label: "Date",
-                noLabel: "false",
-                code: "Date_Table",
-                required: "false",
-                unique: "false",
-                defaultValue: null,
-                defaultExpression: "NOW",
-            },
-            Time_Table: {
-                type: "TIME",
-                label: "Time",
-                noLabel: "false",
-                code: "Time_Table",
-                required: "false",
-                defaultValue: null,
-                defaultExpression: "NOW",
-            },
-            Date_and_time_Table: {
-                type: "DATETIME",
-                label: "Date and time",
-                noLabel: "false",
-                code: "Date_and_time_Table",
-                required: "false",
-                unique: "false",
-                defaultValue: null,
-                defaultExpression: "NOW",
-            },
-            Attachment_Table: {
-                type: "FILE",
-                label: "Attachment",
-                noLabel: "false",
-                code: "Attachment_Table",
-                required: "false",
-            },
-            Link_Table: {
-                type: "LINK",
-                label: "Link",
-                noLabel: "false",
-                code: "Link_Table",
-                required: "false",
-                protocol: "WEB",
-                minLength: null,
-                maxLength: null,
-                unique: "false",
-                defaultValue: "",
-            },
-        },
-    },
+  },
 };
 
 const DemoRecord: any = {
-    Text: {
-        type: "SINGLE_LINE_TEXT",
-        value: "Sample Sample",
-    },
+  Text: {
+    type: "SINGLE_LINE_TEXT",
+    value: "Sample Sample",
+  },
 
-    Rich_text: {
-        type: "RICH_TEXT",
-        value: "<span>Sample Sample</span>",
-    },
+  Rich_text: {
+    type: "RICH_TEXT",
+    value: "<span>Sample Sample</span>",
+  },
 
-    Text_area: {
-        type: "MULTI_LINE_TEXT",
-        value: "Sample\nSample",
-    },
+  Text_area: {
+    type: "MULTI_LINE_TEXT",
+    value: "Sample\nSample",
+  },
 
-    Number: {
-        type: "NUMBER",
-        value: "1",
-    },
+  Number: {
+    type: "NUMBER",
+    value: "1",
+  },
 
-    Calculated: {
-        type: "CALC",
-        value: "",
-    },
-    Radio_button: {
-        type: "RADIO_BUTTON",
-        value: "sample1",
-    },
-    Check_box: {
-        type: "CHECK_BOX",
-        value: ["sample1", "sample2"],
-    },
+  Calculated: {
+    type: "CALC",
+    value: "",
+  },
+  Radio_button: {
+    type: "RADIO_BUTTON",
+    value: "sample1",
+  },
+  Check_box: {
+    type: "CHECK_BOX",
+    value: ["sample1", "sample2"],
+  },
 
-    Multi_choice: {
-        type: "MULTI_SELECT",
-        code: "Multi_choice",
-        value: ["sample1", "sample2"],
-    },
+  Multi_choice: {
+    type: "MULTI_SELECT",
+    code: "Multi_choice",
+    value: ["sample1", "sample2"],
+  },
 
-    Drop_down: {
-        type: "DROP_DOWN",
-        value: "sample1",
-    },
+  Drop_down: {
+    type: "DROP_DOWN",
+    value: "sample1",
+  },
 
-    Date: {
-        type: "DATE",
-        value: "2019-01-31",
-    },
+  Date: {
+    type: "DATE",
+    value: "2019-01-31",
+  },
 
-    Time: {
-        type: "TIME",
-        value: "12:31",
-    },
-    Date_and_time: {
-        type: "DATETIME",
-        value: "2012-01-11T11:30:00Z",
-    },
+  Time: {
+    type: "TIME",
+    value: "12:31",
+  },
+  Date_and_time: {
+    type: "DATETIME",
+    value: "2012-01-11T11:30:00Z",
+  },
 
-    Attachment: {
-        type: "FILE",
-        value: [],
-    },
-    Link: {
-        type: "LINK",
-        value: "exmale@example.com",
-    },
+  Attachment: {
+    type: "FILE",
+    value: [],
+  },
+  Link: {
+    type: "LINK",
+    value: "exmale@example.com",
+  },
 
-    User_selection: {
-        type: "USER_SELECT",
-        value: [],
-    },
-    Department_selection: {
-        type: "ORGANIZATION_SELECT",
-        value: [],
-    },
-    Group_selection: {
-        type: "GROUP_SELECT",
-        value: [],
-    },
+  User_selection: {
+    type: "USER_SELECT",
+    value: [],
+  },
+  Department_selection: {
+    type: "ORGANIZATION_SELECT",
+    value: [],
+  },
+  Group_selection: {
+    type: "GROUP_SELECT",
+    value: [],
+  },
 
-    Table: {
-        type: "SUBTABLE",
-        code: "Table",
+  Table: {
+    type: "SUBTABLE",
+    code: "Table",
 
-        value: [
-            {
-                value: {
-                    Text_Table: {
-                        type: "SINGLE_LINE_TEXT",
-                        value: "Table Text",
-                    },
-                    Rich_text_Table: {
-                        type: "RICH_TEXT",
-                        value: "<div> Table Text</div>",
-                    },
-                    Text_area_Table: {
-                        type: "MULTI_LINE_TEXT",
-                        value: "Table\nText",
-                    },
-                    Number_Table: {
-                        type: "NUMBER",
-                        value: "1",
-                    },
-                    Calculated_Table: {
-                        type: "CALC",
-                        value: null,
-                    },
-                },
-            },
-        ],
-    },
+    value: [
+      {
+        value: {
+          Text_Table: {
+            type: "SINGLE_LINE_TEXT",
+            value: "Table Text",
+          },
+          Rich_text_Table: {
+            type: "RICH_TEXT",
+            value: "<div> Table Text</div>",
+          },
+          Text_area_Table: {
+            type: "MULTI_LINE_TEXT",
+            value: "Table\nText",
+          },
+          Number_Table: {
+            type: "NUMBER",
+            value: "1",
+          },
+          Calculated_Table: {
+            type: "CALC",
+            value: null,
+          },
+        },
+      },
+    ],
+  },
 
-    Table_0: {
-        type: "SUBTABLE",
-        code: "Table_0",
-        value: [
-            {
-                value: {
-                    Radio_button_Table: {
-                        type: "RADIO_BUTTON",
-                        value: "sample1",
-                    },
-                    Check_box_Table: {
-                        type: "CHECK_BOX",
-                        value: ["sample1", "sample2"],
-                    },
-                    Multi_choice_Table: {
-                        type: "MULTI_SELECT",
-                        value: ["sample1", "sample2"],
-                    },
-                    Drop_down_Table: {
-                        type: "DROP_DOWN",
-                        value: "sample1",
-                    },
-                    Date_Table: {
-                        type: "DATE",
-                        value: "2018-12-01",
-                    },
-                    Time_Table: {
-                        type: "TIME",
-                        value: "12:00",
-                    },
-                    Date_and_time_Table: {
-                        type: "DATETIME",
-                        value: "2012-01-11T11:30:00Z",
-                    },
-                    Attachment_Table: {
-                        type: "FILE",
-                        value: [],
-                    },
-                    Link_Table: {
-                        type: "LINK",
-                        value: "https://example.com",
-                    },
-                },
-            },
-        ],
-    },
+  Table_0: {
+    type: "SUBTABLE",
+    code: "Table_0",
+    value: [
+      {
+        value: {
+          Radio_button_Table: {
+            type: "RADIO_BUTTON",
+            value: "sample1",
+          },
+          Check_box_Table: {
+            type: "CHECK_BOX",
+            value: ["sample1", "sample2"],
+          },
+          Multi_choice_Table: {
+            type: "MULTI_SELECT",
+            value: ["sample1", "sample2"],
+          },
+          Drop_down_Table: {
+            type: "DROP_DOWN",
+            value: "sample1",
+          },
+          Date_Table: {
+            type: "DATE",
+            value: "2018-12-01",
+          },
+          Time_Table: {
+            type: "TIME",
+            value: "12:00",
+          },
+          Date_and_time_Table: {
+            type: "DATETIME",
+            value: "2012-01-11T11:30:00Z",
+          },
+          Attachment_Table: {
+            type: "FILE",
+            value: [],
+          },
+          Link_Table: {
+            type: "LINK",
+            value: "https://example.com",
+          },
+        },
+      },
+    ],
+  },
 };
 
 const DemoDataBuiltinFields: any = {
-    Record_number: {
-        type: "RECORD_NUMBER",
-        label: "Record number",
-        noLabel: "false",
-        code: "Record_number",
-    },
-    Updated_by: {
-        type: "MODIFIER",
-        label: "Updated by",
-        noLabel: "false",
-        code: "Updated_by",
-    },
-    Created_by: {
-        type: "CREATOR",
-        label: "Created by",
-        noLabel: "false",
-        code: "Created_by",
-    },
-    Updated_datetime: {
-        type: "UPDATED_TIME",
-        label: "Updated datetime",
-        noLabel: "false",
-        code: "Updated_datetime",
-    },
-    Created_datetime: {
-        type: "CREATED_TIME",
-        label: "Created datetime",
-        noLabel: "false",
-        code: "Created_datetime",
-    },
+  Record_number: {
+    type: "RECORD_NUMBER",
+    label: "Record number",
+    noLabel: "false",
+    code: "Record_number",
+  },
+  Updated_by: {
+    type: "MODIFIER",
+    label: "Updated by",
+    noLabel: "false",
+    code: "Updated_by",
+  },
+  Created_by: {
+    type: "CREATOR",
+    label: "Created by",
+    noLabel: "false",
+    code: "Created_by",
+  },
+  Updated_datetime: {
+    type: "UPDATED_TIME",
+    label: "Updated datetime",
+    noLabel: "false",
+    code: "Updated_datetime",
+  },
+  Created_datetime: {
+    type: "CREATED_TIME",
+    label: "Created datetime",
+    noLabel: "false",
+    code: "Created_datetime",
+  },
 };
 
 export const DemoDatas = {
-    DemoDataFields,
-    DemoDataIncludingBuiltinFields: Object.assign(
-        DemoDataBuiltinFields,
-        DemoDataFields
-    ),
-    DemoRecord,
+  DemoDataFields,
+  DemoDataIncludingBuiltinFields: Object.assign(
+    DemoDataBuiltinFields,
+    DemoDataFields
+  ),
+  DemoRecord,
 };

--- a/packages/dts-gen/src/kintone/clients/demo-fullwidth-symbol-client.ts
+++ b/packages/dts-gen/src/kintone/clients/demo-fullwidth-symbol-client.ts
@@ -1,22 +1,19 @@
 import {
-    FetchFormPropertiesInput,
-    FormsClient,
-    FieldNameAndFieldOrSubTableField,
+  FetchFormPropertiesInput,
+  FormsClient,
+  FieldNameAndFieldOrSubTableField,
 } from "./forms-client";
 import { DemoDatas } from "./demo-fullwidth-symbols-datas";
 
-export class DemoFullWidthSymbolClient
-    implements FormsClient
-{
-    fetchFormProperties(
-        _: FetchFormPropertiesInput
-    ): Promise<FieldNameAndFieldOrSubTableField> {
-        const demoResp = {
-            properties:
-                DemoDatas.DemoDataIncludingBuiltinFields,
-        };
-        return Promise.resolve(
-            demoResp.properties as FieldNameAndFieldOrSubTableField
-        );
-    }
+export class DemoFullWidthSymbolClient implements FormsClient {
+  fetchFormProperties(
+    _: FetchFormPropertiesInput
+  ): Promise<FieldNameAndFieldOrSubTableField> {
+    const demoResp = {
+      properties: DemoDatas.DemoDataIncludingBuiltinFields,
+    };
+    return Promise.resolve(
+      demoResp.properties as FieldNameAndFieldOrSubTableField
+    );
+  }
 }

--- a/packages/dts-gen/src/kintone/clients/demo-fullwidth-symbols-datas.ts
+++ b/packages/dts-gen/src/kintone/clients/demo-fullwidth-symbols-datas.ts
@@ -1,104 +1,104 @@
 const DemoFullWidthSymbolDataFields: any = {
-    Nakaguro: {
-        type: "SINGLE_LINE_TEXT",
-        label: "・",
-        noLabel: "false",
-        code: "・",
-        required: "false",
-        expression: "",
-        hideExpression: "false",
-        unique: "false",
-        defaultValue: "",
-    },
+  Nakaguro: {
+    type: "SINGLE_LINE_TEXT",
+    label: "・",
+    noLabel: "false",
+    code: "・",
+    required: "false",
+    expression: "",
+    hideExpression: "false",
+    unique: "false",
+    defaultValue: "",
+  },
 
-    FullWidthDollar: {
-        type: "SINGLE_LINE_TEXT",
-        label: "＄",
-        noLabel: "false",
-        code: "＄",
-        required: "false",
-        defaultValue: "",
-    },
+  FullWidthDollar: {
+    type: "SINGLE_LINE_TEXT",
+    label: "＄",
+    noLabel: "false",
+    code: "＄",
+    required: "false",
+    defaultValue: "",
+  },
 
-    FullWidthYen: {
-        type: "SINGLE_LINE_TEXT",
-        label: "￥",
-        noLabel: "false",
-        code: "￥",
-        required: "false",
-        defaultValue: "",
-    },
+  FullWidthYen: {
+    type: "SINGLE_LINE_TEXT",
+    label: "￥",
+    noLabel: "false",
+    code: "￥",
+    required: "false",
+    defaultValue: "",
+  },
 
-    FullWidthUnderBar: {
-        type: "SINGLE_LINE_TEXT",
-        label: "＿",
-        noLabel: "false",
-        code: "＿",
-        required: "false",
-        defaultValue: "",
-    },
+  FullWidthUnderBar: {
+    type: "SINGLE_LINE_TEXT",
+    label: "＿",
+    noLabel: "false",
+    code: "＿",
+    required: "false",
+    defaultValue: "",
+  },
 };
 
 const DemoFullWidthSymbolRecord: any = {
-    Nakaguro: {
-        type: "SINGLE_LINE_TEXT",
-        value: "・",
-    },
+  Nakaguro: {
+    type: "SINGLE_LINE_TEXT",
+    value: "・",
+  },
 
-    FullWidthDollar: {
-        type: "SINGLE_LINE_TEXT",
-        value: "＄",
-    },
+  FullWidthDollar: {
+    type: "SINGLE_LINE_TEXT",
+    value: "＄",
+  },
 
-    FullWidthYen: {
-        type: "SINGLE_LINE_TEXT",
-        value: "￥",
-    },
+  FullWidthYen: {
+    type: "SINGLE_LINE_TEXT",
+    value: "￥",
+  },
 
-    FullWidthUnderBar: {
-        type: "SINGLE_LINE_TEXT",
-        value: "＿",
-    },
+  FullWidthUnderBar: {
+    type: "SINGLE_LINE_TEXT",
+    value: "＿",
+  },
 };
 
 const DemoDataBuiltinFields: any = {
-    Record_number: {
-        type: "RECORD_NUMBER",
-        label: "Record number",
-        noLabel: "false",
-        code: "Record_number",
-    },
-    Updated_by: {
-        type: "MODIFIER",
-        label: "Updated by",
-        noLabel: "false",
-        code: "Updated_by",
-    },
-    Created_by: {
-        type: "CREATOR",
-        label: "Created by",
-        noLabel: "false",
-        code: "Created_by",
-    },
-    Updated_datetime: {
-        type: "UPDATED_TIME",
-        label: "Updated datetime",
-        noLabel: "false",
-        code: "Updated_datetime",
-    },
-    Created_datetime: {
-        type: "CREATED_TIME",
-        label: "Created datetime",
-        noLabel: "false",
-        code: "Created_datetime",
-    },
+  Record_number: {
+    type: "RECORD_NUMBER",
+    label: "Record number",
+    noLabel: "false",
+    code: "Record_number",
+  },
+  Updated_by: {
+    type: "MODIFIER",
+    label: "Updated by",
+    noLabel: "false",
+    code: "Updated_by",
+  },
+  Created_by: {
+    type: "CREATOR",
+    label: "Created by",
+    noLabel: "false",
+    code: "Created_by",
+  },
+  Updated_datetime: {
+    type: "UPDATED_TIME",
+    label: "Updated datetime",
+    noLabel: "false",
+    code: "Updated_datetime",
+  },
+  Created_datetime: {
+    type: "CREATED_TIME",
+    label: "Created datetime",
+    noLabel: "false",
+    code: "Created_datetime",
+  },
 };
 
 export const DemoDatas = {
-    DemoFullWidthSymbolDataFields,
-    DemoDataIncludingBuiltinFields: Object.assign(
-        DemoDataBuiltinFields,
-        DemoFullWidthSymbolDataFields
-    ),
-    DemoFullWidthSymbolRecord,
+  DemoFullWidthSymbolDataFields,
+  DemoDataIncludingBuiltinFields: Object.assign(
+    DemoDataBuiltinFields,
+    DemoFullWidthSymbolDataFields
+  ),
+  DemoFullWidthSymbolRecord,
 };

--- a/packages/dts-gen/src/kintone/clients/forms-client-impl.test.ts
+++ b/packages/dts-gen/src/kintone/clients/forms-client-impl.test.ts
@@ -1,101 +1,89 @@
-import {
-    FormsClientImpl,
-    VisibleForTesting,
-} from "./forms-client-impl";
+import { FormsClientImpl, VisibleForTesting } from "./forms-client-impl";
 import { AxiosUtils } from "./axios-utils";
 
 describe("VisibleForTesting.constructUrl", () => {
-    const testCases = [
-        {
-            preview: false,
-            guestSpaceId: "1",
-            expected: "/k/guest/1/v1/app/form/fields.json",
-        },
-        {
-            preview: false,
-            guestSpaceId: null,
-            expected: "/k/v1/app/form/fields.json",
-        },
-        {
-            preview: true,
-            guestSpaceId: "1",
-            expected:
-                "/k/guest/1/v1/preview/app/form/fields.json",
-        },
-        {
-            preview: true,
-            guestSpaceId: null,
-            expected: "/k/v1/preview/app/form/fields.json",
-        },
-    ];
-    test.each(testCases)(
-        "constructUrl with %p",
-        ({ preview, guestSpaceId, expected }) => {
-            const input = {
-                appId: "123",
-                preview,
-                guestSpaceId,
-            };
-            expect(
-                VisibleForTesting.constructUrl(input)
-            ).toEqual(expected);
-        }
-    );
+  const testCases = [
+    {
+      preview: false,
+      guestSpaceId: "1",
+      expected: "/k/guest/1/v1/app/form/fields.json",
+    },
+    {
+      preview: false,
+      guestSpaceId: null,
+      expected: "/k/v1/app/form/fields.json",
+    },
+    {
+      preview: true,
+      guestSpaceId: "1",
+      expected: "/k/guest/1/v1/preview/app/form/fields.json",
+    },
+    {
+      preview: true,
+      guestSpaceId: null,
+      expected: "/k/v1/preview/app/form/fields.json",
+    },
+  ];
+  test.each(testCases)(
+    "constructUrl with %p",
+    ({ preview, guestSpaceId, expected }) => {
+      const input = {
+        appId: "123",
+        preview,
+        guestSpaceId,
+      };
+      expect(VisibleForTesting.constructUrl(input)).toEqual(expected);
+    }
+  );
 });
 
 describe("FormsClientImpl#fetchFormProperties", () => {
-    test("#fertchFormProperties calls AxoisInstance#request", () => {
-        const mockConstructUrl = jest.fn();
-        mockConstructUrl.mockReturnValue(
-            "/k/v1/app/form/fields.json"
-        );
-        VisibleForTesting.constructUrl = mockConstructUrl;
+  test("#fertchFormProperties calls AxoisInstance#request", () => {
+    const mockConstructUrl = jest.fn();
+    mockConstructUrl.mockReturnValue("/k/v1/app/form/fields.json");
+    VisibleForTesting.constructUrl = mockConstructUrl;
 
-        const mockRequest = jest.fn();
-        mockRequest.mockReturnValue(
-            Promise.resolve({
-                data: {
-                    properties: {},
-                },
-            })
-        );
+    const mockRequest = jest.fn();
+    mockRequest.mockReturnValue(
+      Promise.resolve({
+        data: {
+          properties: {},
+        },
+      })
+    );
 
-        const mockNewAxiosInstance = jest.fn();
-        mockNewAxiosInstance.mockReturnValue({
-            request: mockRequest,
-        });
-        AxiosUtils.newAxiosInstance = mockNewAxiosInstance;
-
-        const input = {
-            baseUrl: "https://kintone.com",
-            username: "username",
-            password: "password",
-            apiToken: null,
-            oAuthToken: null,
-            proxyHost: null,
-            proxyPort: null,
-            proxy: null,
-            basicAuthPassword: null,
-            basicAuthUsername: null,
-        };
-        const fetchInput = {
-            appId: "1",
-            preview: false,
-            guestSpaceId: null,
-        };
-        new FormsClientImpl(input).fetchFormProperties(
-            fetchInput
-        );
-
-        const expectedRequestConfig = {
-            method: "GET",
-            url: "/k/v1/app/form/fields.json",
-            params: {
-                app: "1",
-            },
-        };
-        expect(mockRequest).toBeCalledWith(
-            expectedRequestConfig
-        );
+    const mockNewAxiosInstance = jest.fn();
+    mockNewAxiosInstance.mockReturnValue({
+      request: mockRequest,
     });
+    AxiosUtils.newAxiosInstance = mockNewAxiosInstance;
+
+    const input = {
+      baseUrl: "https://kintone.com",
+      username: "username",
+      password: "password",
+      apiToken: null,
+      oAuthToken: null,
+      proxyHost: null,
+      proxyPort: null,
+      proxy: null,
+      basicAuthPassword: null,
+      basicAuthUsername: null,
+    };
+    const fetchInput = {
+      appId: "1",
+      preview: false,
+      guestSpaceId: null,
+    };
+    new FormsClientImpl(input).fetchFormProperties(fetchInput);
+
+    const expectedRequestConfig = {
+      method: "GET",
+      url: "/k/v1/app/form/fields.json",
+      params: {
+        app: "1",
+      },
+    };
+    expect(mockRequest).toBeCalledWith(expectedRequestConfig);
+  });
 });

--- a/packages/dts-gen/src/kintone/clients/forms-client-impl.ts
+++ b/packages/dts-gen/src/kintone/clients/forms-client-impl.ts
@@ -1,55 +1,50 @@
 import {
-    FormsClient,
-    FetchFormPropertiesInput,
-    FieldNameAndFieldOrSubTableField,
+  FormsClient,
+  FetchFormPropertiesInput,
+  FieldNameAndFieldOrSubTableField,
 } from "./forms-client";
 
-import {
-    AxiosUtils,
-    NewInstanceInput,
-} from "./axios-utils";
+import { AxiosUtils, NewInstanceInput } from "./axios-utils";
 import { AxiosInstance, AxiosRequestConfig } from "axios";
 
 export class FormsClientImpl implements FormsClient {
-    readonly client: AxiosInstance;
+  readonly client: AxiosInstance;
 
-    constructor(input: NewInstanceInput) {
-        this.client = AxiosUtils.newAxiosInstance(input);
-    }
+  constructor(input: NewInstanceInput) {
+    this.client = AxiosUtils.newAxiosInstance(input);
+  }
 
-    fetchFormProperties(
-        input: FetchFormPropertiesInput
-    ): Promise<FieldNameAndFieldOrSubTableField> {
-        const config: AxiosRequestConfig = {
-            method: "GET",
-            url: constructUrl(input),
-            params: {
-                app: input.appId,
-            },
-        };
+  fetchFormProperties(
+    input: FetchFormPropertiesInput
+  ): Promise<FieldNameAndFieldOrSubTableField> {
+    const config: AxiosRequestConfig = {
+      method: "GET",
+      url: constructUrl(input),
+      params: {
+        app: input.appId,
+      },
+    };
 
-        return this.client
-            .request(config)
-            .then(
-                (resp) => resp.data.properties
-            ) as Promise<FieldNameAndFieldOrSubTableField>;
-    }
+    return this.client
+      .request(config)
+      .then(
+        (resp) => resp.data.properties
+      ) as Promise<FieldNameAndFieldOrSubTableField>;
+  }
 }
 
-function constructUrl(
-    input: FetchFormPropertiesInput
-): string {
-    const guest = input.guestSpaceId;
-    if (guest !== null && input.preview) {
-        return `/k/guest/${guest}/v1/preview/app/form/fields.json`;
-    } else if (input.guestSpaceId !== null) {
-        return `/k/guest/${guest}/v1/app/form/fields.json`;
-    } else if (input.preview) {
-        return "/k/v1/preview/app/form/fields.json";
-    }
-    return "/k/v1/app/form/fields.json";
+function constructUrl(input: FetchFormPropertiesInput): string {
+  const guest = input.guestSpaceId;
+  if (guest !== null && input.preview) {
+    return `/k/guest/${guest}/v1/preview/app/form/fields.json`;
+  } else if (input.guestSpaceId !== null) {
+    return `/k/guest/${guest}/v1/app/form/fields.json`;
+  } else if (input.preview) {
+    return "/k/v1/preview/app/form/fields.json";
+  }
+  return "/k/v1/app/form/fields.json";
 }
 
 export const VisibleForTesting = {
-    constructUrl,
+  constructUrl,
 };

--- a/packages/dts-gen/src/kintone/clients/forms-client.ts
+++ b/packages/dts-gen/src/kintone/clients/forms-client.ts
@@ -1,31 +1,29 @@
 export interface FetchFormPropertiesInput {
-    appId: string;
-    preview: boolean | false;
-    guestSpaceId: string | null;
+  appId: string;
+  preview: boolean | false;
+  guestSpaceId: string | null;
 }
 
 export interface FieldType {
-    type: string;
-    code: string;
-    relatedApp?: string;
+  type: string;
+  code: string;
+  relatedApp?: string;
 }
 
 export interface SubTableFieldType {
-    code: string;
-    type: string;
-    fields: FieldNameAndFieldOrSubTableField;
+  code: string;
+  type: string;
+  fields: FieldNameAndFieldOrSubTableField;
 }
 
-export type FieldTypeOrSubTableFieldType =
-    | FieldType
-    | SubTableFieldType;
+export type FieldTypeOrSubTableFieldType = FieldType | SubTableFieldType;
 
 export type FieldNameAndFieldOrSubTableField = {
-    [key: string]: FieldTypeOrSubTableFieldType;
+  [key: string]: FieldTypeOrSubTableFieldType;
 };
 
 export interface FormsClient {
-    fetchFormProperties(
-        input: FetchFormPropertiesInput
-    ): Promise<FieldNameAndFieldOrSubTableField>;
+  fetchFormProperties(
+    input: FetchFormPropertiesInput
+  ): Promise<FieldNameAndFieldOrSubTableField>;
 }

--- a/packages/dts-gen/src/kintone/clients/setup-test-app-client.ts
+++ b/packages/dts-gen/src/kintone/clients/setup-test-app-client.ts
@@ -2,183 +2,166 @@ import { AxiosInstance, AxiosRequestConfig } from "axios";
 import FormData from "form-data";
 import fs from "fs";
 
-import {
-    NewInstanceInput,
-    AxiosUtils,
-} from "./axios-utils";
+import { NewInstanceInput, AxiosUtils } from "./axios-utils";
 
 interface CreateAppInput {
-    name: string;
+  name: string;
 }
 
 interface CreateAppOutput {
-    app: string;
-    revision: string;
+  app: string;
+  revision: string;
 }
 
 interface AddFormFieldInput {
-    app: string;
-    properties: any[];
+  app: string;
+  properties: any[];
 }
 
 export interface AddFormFieldOutput {}
 
 interface DeployInput {
-    apps: Array<{
-        app: string;
-    }>;
+  apps: Array<{
+    app: string;
+  }>;
 }
 
 interface DeployStatusInput {
-    apps: string[];
+  apps: string[];
 }
 
 interface DeployStatusOutput {
-    apps: Array<{
-        app: string;
-        status:
-            | "PROCESSING"
-            | "SUCCESS"
-            | "FAIL"
-            | "CANCEL";
-    }>;
+  apps: Array<{
+    app: string;
+    status: "PROCESSING" | "SUCCESS" | "FAIL" | "CANCEL";
+  }>;
 }
 
 interface UploadFileInput {
-    data: fs.ReadStream;
-    fileName: string;
-    contentType: string;
+  data: fs.ReadStream;
+  fileName: string;
+  contentType: string;
 }
 
 interface UploadFileOutput {
-    fileKey: string;
+  fileKey: string;
 }
 
 interface JsCustomizeInput {
-    app: string;
-    scope: string;
-    desktop: {
-        js: Array<{
-            type: string;
-            file: { fileKey: string };
-        }>;
-    };
+  app: string;
+  scope: string;
+  desktop: {
+    js: Array<{
+      type: string;
+      file: { fileKey: string };
+    }>;
+  };
 }
 
 export interface JsCustomizeOutput {
-    revision: string;
+  revision: string;
 }
 
 interface AddRecordInput {
-    app: string;
-    record: any;
+  app: string;
+  record: any;
 }
 
 export interface AddRecordOutput {
-    id: string;
-    revision: string;
+  id: string;
+  revision: string;
 }
 export class SetUpTestAppClient {
-    readonly client: AxiosInstance;
+  readonly client: AxiosInstance;
 
-    constructor(input: NewInstanceInput) {
-        this.client = AxiosUtils.newAxiosInstance(input);
-    }
+  constructor(input: NewInstanceInput) {
+    this.client = AxiosUtils.newAxiosInstance(input);
+  }
 
-    requestCreateNewApp(
-        input: CreateAppInput
-    ): Promise<CreateAppOutput> {
-        const config: AxiosRequestConfig = {
-            url: "/k/v1/preview/app.json",
-            method: "POST",
-            data: input,
-        };
-        return this.client
-            .request(config)
-            .then((resp) => resp.data as CreateAppOutput);
-    }
+  requestCreateNewApp(input: CreateAppInput): Promise<CreateAppOutput> {
+    const config: AxiosRequestConfig = {
+      url: "/k/v1/preview/app.json",
+      method: "POST",
+      data: input,
+    };
+    return this.client
+      .request(config)
+      .then((resp) => resp.data as CreateAppOutput);
+  }
 
-    requestAddFormField(
-        input: AddFormFieldInput
-    ): Promise<AddFormFieldOutput> {
-        const config: AxiosRequestConfig = {
-            url: "/k/v1/preview/app/form/fields.json",
-            method: "POST",
-            data: input,
-        };
-        return this.client.request(config).then((resp) => {
-            return resp.data as AddFormFieldOutput;
-        });
-    }
+  requestAddFormField(input: AddFormFieldInput): Promise<AddFormFieldOutput> {
+    const config: AxiosRequestConfig = {
+      url: "/k/v1/preview/app/form/fields.json",
+      method: "POST",
+      data: input,
+    };
+    return this.client.request(config).then((resp) => {
+      return resp.data as AddFormFieldOutput;
+    });
+  }
 
-    requestUploadFile(
-        input: UploadFileInput
-    ): Promise<UploadFileOutput> {
-        const data = new FormData();
+  requestUploadFile(input: UploadFileInput): Promise<UploadFileOutput> {
+    const data = new FormData();
 
-        data.append("file", input.data, {
-            filename: input.fileName,
-            contentType: input.contentType,
-        });
-        const headers = data.getHeaders();
-        const config: AxiosRequestConfig = {
-            url: "/k/v1/file.json",
-            headers,
-            method: "POST",
-            data,
-        };
-        return this.client.request(config).then((resp) => {
-            return resp.data as UploadFileOutput;
-        });
-    }
+    data.append("file", input.data, {
+      filename: input.fileName,
+      contentType: input.contentType,
+    });
+    const headers = data.getHeaders();
+    const config: AxiosRequestConfig = {
+      url: "/k/v1/file.json",
+      headers,
+      method: "POST",
+      data,
+    };
+    return this.client.request(config).then((resp) => {
+      return resp.data as UploadFileOutput;
+    });
+  }
 
-    requestJsCustomizeUpdate(
-        input: JsCustomizeInput
-    ): Promise<JsCustomizeOutput> {
-        const config: AxiosRequestConfig = {
-            url: "/k/v1/preview/app/customize.json",
-            method: "PUT",
-            data: input,
-        };
-        return this.client.request(config).then((resp) => {
-            return resp.data as JsCustomizeOutput;
-        });
-    }
+  requestJsCustomizeUpdate(
+    input: JsCustomizeInput
+  ): Promise<JsCustomizeOutput> {
+    const config: AxiosRequestConfig = {
+      url: "/k/v1/preview/app/customize.json",
+      method: "PUT",
+      data: input,
+    };
+    return this.client.request(config).then((resp) => {
+      return resp.data as JsCustomizeOutput;
+    });
+  }
 
-    requestDepoy(input: DeployInput): Promise<any> {
-        const config: AxiosRequestConfig = {
-            url: "/k/v1/preview/app/deploy.json",
-            method: "POST",
-            data: input,
-        };
-        return this.client
-            .request(config)
-            .then((resp) => resp.data);
-    }
+  requestDepoy(input: DeployInput): Promise<any> {
+    const config: AxiosRequestConfig = {
+      url: "/k/v1/preview/app/deploy.json",
+      method: "POST",
+      data: input,
+    };
+    return this.client.request(config).then((resp) => resp.data);
+  }
 
-    requestGetDeployStatus(
-        input: DeployStatusInput
-    ): Promise<DeployStatusOutput> {
-        const config: AxiosRequestConfig = {
-            url: "/k/v1/preview/app/deploy.json",
-            method: "GET",
-            data: input,
-        };
-        return this.client.request(config).then((resp) => {
-            return resp.data as DeployStatusOutput;
-        });
-    }
+  requestGetDeployStatus(
+    input: DeployStatusInput
+  ): Promise<DeployStatusOutput> {
+    const config: AxiosRequestConfig = {
+      url: "/k/v1/preview/app/deploy.json",
+      method: "GET",
+      data: input,
+    };
+    return this.client.request(config).then((resp) => {
+      return resp.data as DeployStatusOutput;
+    });
+  }
 
-    requestAddRecord(
-        input: AddRecordInput
-    ): Promise<AddRecordOutput> {
-        const config: AxiosRequestConfig = {
-            url: "/k/v1/record.json",
-            method: "POST",
-            data: input,
-        };
-        return this.client.request(config).then((resp) => {
-            return resp.data as AddRecordOutput;
-        });
-    }
+  requestAddRecord(input: AddRecordInput): Promise<AddRecordOutput> {
+    const config: AxiosRequestConfig = {
+      url: "/k/v1/record.json",
+      method: "POST",
+      data: input,
+    };
+    return this.client.request(config).then((resp) => {
+      return resp.data as AddRecordOutput;
+    });
+  }
 }

--- a/packages/dts-gen/src/templates/converter.ts
+++ b/packages/dts-gen/src/templates/converter.ts
@@ -2,96 +2,83 @@ import { FieldTypeGroups } from "../converters/fileldtype-converter";
 import * as F from "./expressions/fields";
 import { Namespace } from "./expressions/namespace";
 import {
-    TypeDefinition,
-    SavedTypeDefinition,
+  TypeDefinition,
+  SavedTypeDefinition,
 } from "./expressions/typedefinitions";
 import { FieldType } from "../kintone/clients/forms-client";
 
 export function convertToTsExpression({
-    namespace,
-    typeName,
-    fieldTypeGroups,
+  namespace,
+  typeName,
+  fieldTypeGroups,
 }: {
-    namespace: string;
-    typeName: string;
-    fieldTypeGroups: FieldTypeGroups;
+  namespace: string;
+  typeName: string;
+  fieldTypeGroups: FieldTypeGroups;
 }): Namespace {
-    const fieldGroup = convertToFieldGroup(fieldTypeGroups);
-    const subTableFields =
-        fieldTypeGroups.subTableFields.map(
-            (f) =>
-                new F.SubTableField(
-                    f.code,
-                    f.type,
-                    convertToFieldGroup(f.fields)
-                )
-        );
+  const fieldGroup = convertToFieldGroup(fieldTypeGroups);
+  const subTableFields = fieldTypeGroups.subTableFields.map(
+    (f) => new F.SubTableField(f.code, f.type, convertToFieldGroup(f.fields))
+  );
 
-    const typeDefenition = new TypeDefinition(
-        typeName,
-        fieldGroup,
-        subTableFields
+  const typeDefenition = new TypeDefinition(
+    typeName,
+    fieldGroup,
+    subTableFields
+  );
+
+  const userFields = fieldTypeGroups.userFieldsInSavedRecord.map(
+    (f) => new F.TsDefinedField(f.code, f.type)
+  );
+
+  const stringFieldsInSavedRecord =
+    fieldTypeGroups.stringFieldsInSavedRecord.map(
+      (f) => new F.TsDefinedField(f.code, f.type)
     );
 
-    const userFields =
-        fieldTypeGroups.userFieldsInSavedRecord.map(
-            (f) => new F.TsDefinedField(f.code, f.type)
-        );
+  const savedTypeDefenition = new SavedTypeDefinition(
+    typeName,
+    userFields,
+    stringFieldsInSavedRecord
+  );
 
-    const stringFieldsInSavedRecord =
-        fieldTypeGroups.stringFieldsInSavedRecord.map(
-            (f) => new F.TsDefinedField(f.code, f.type)
-        );
-
-    const savedTypeDefenition = new SavedTypeDefinition(
-        typeName,
-        userFields,
-        stringFieldsInSavedRecord
-    );
-
-    return new Namespace(
-        namespace,
-        typeDefenition,
-        savedTypeDefenition
-    );
+  return new Namespace(namespace, typeDefenition, savedTypeDefenition);
 }
 
 interface ConvertToFieldGroupInput {
-    stringFields: FieldType[];
-    calculatedFields: FieldType[];
-    stringFieldsInSavedRecord: FieldType[];
-    stringListFields: FieldType[];
-    entityListFields: FieldType[];
-    fileTypeFields: FieldType[];
+  stringFields: FieldType[];
+  calculatedFields: FieldType[];
+  stringFieldsInSavedRecord: FieldType[];
+  stringListFields: FieldType[];
+  entityListFields: FieldType[];
+  fileTypeFields: FieldType[];
 }
-function convertToFieldGroup(
-    input: ConvertToFieldGroupInput
-): F.FieldGroup {
-    const stringFields = input.stringFields.map(
-        (f) => new F.TsDefinedField(f.code, f.type)
-    );
+function convertToFieldGroup(input: ConvertToFieldGroupInput): F.FieldGroup {
+  const stringFields = input.stringFields.map(
+    (f) => new F.TsDefinedField(f.code, f.type)
+  );
 
-    const calculatedFields = input.calculatedFields.map(
-        (f) => new F.TsDefinedField(f.code, f.type)
-    );
+  const calculatedFields = input.calculatedFields.map(
+    (f) => new F.TsDefinedField(f.code, f.type)
+  );
 
-    const stringListFields = input.stringListFields.map(
-        (f) => new F.TsDefinedField(f.code, f.type)
-    );
+  const stringListFields = input.stringListFields.map(
+    (f) => new F.TsDefinedField(f.code, f.type)
+  );
 
-    const entityFields = input.entityListFields.map(
-        (f) => new F.TsDefinedField(f.code, f.type)
-    );
+  const entityFields = input.entityListFields.map(
+    (f) => new F.TsDefinedField(f.code, f.type)
+  );
 
-    const fileFields = input.fileTypeFields.map(
-        (f) => new F.TsDefinedField(f.code, f.type)
-    );
+  const fileFields = input.fileTypeFields.map(
+    (f) => new F.TsDefinedField(f.code, f.type)
+  );
 
-    return new F.FieldGroup(
-        stringFields,
-        calculatedFields,
-        stringListFields,
-        entityFields,
-        fileFields
-    );
+  return new F.FieldGroup(
+    stringFields,
+    calculatedFields,
+    stringListFields,
+    entityFields,
+    fileFields
+  );
 }

--- a/packages/dts-gen/src/templates/expressions/expression.test.ts
+++ b/packages/dts-gen/src/templates/expressions/expression.test.ts
@@ -1,28 +1,25 @@
-import {
-    TsExpression,
-    toTsExpressions,
-} from "./expression";
+import { TsExpression, toTsExpressions } from "./expression";
 
 describe("toTsExpressions", () => {
-    class TestExpression implements TsExpression {
-        constructor(private expression: string) {}
-        tsExpression(): string {
-            return this.expression;
-        }
+  class TestExpression implements TsExpression {
+    constructor(private expression: string) {}
+    tsExpression(): string {
+      return this.expression;
     }
-    test("join all TsExpression after call tsExpression()", () => {
-        expect(
-            toTsExpressions([
-                new TestExpression("1"),
-                new TestExpression("2"),
-                new TestExpression("3"),
-            ])
-        ).toEqual(
-            `
+  }
+  test("join all TsExpression after call tsExpression()", () => {
+    expect(
+      toTsExpressions([
+        new TestExpression("1"),
+        new TestExpression("2"),
+        new TestExpression("3"),
+      ])
+    ).toEqual(
+      `
 1
 2
 3
 `.trim()
-        );
-    });
+    );
+  });
 });

--- a/packages/dts-gen/src/templates/expressions/expression.ts
+++ b/packages/dts-gen/src/templates/expressions/expression.ts
@@ -1,11 +1,7 @@
 export interface TsExpression {
-    tsExpression(): string;
+  tsExpression(): string;
 }
 
-export function toTsExpressions(
-    expressions: TsExpression[]
-): string {
-    return expressions
-        .map((e) => e.tsExpression())
-        .join("\n");
+export function toTsExpressions(expressions: TsExpression[]): string {
+  return expressions.map((e) => e.tsExpression()).join("\n");
 }

--- a/packages/dts-gen/src/templates/expressions/fields.test.ts
+++ b/packages/dts-gen/src/templates/expressions/fields.test.ts
@@ -1,106 +1,61 @@
-import {
-    TsDefinedField,
-    SubTableField,
-    FieldGroup,
-} from "./fields";
+import { TsDefinedField, SubTableField, FieldGroup } from "./fields";
 
 describe("TsDefinedField with SINGLE_LINE_TEXT", () => {
-    test("toTsExpression()", () => {
-        expect(
-            new TsDefinedField(
-                "fieldName",
-                "SINGLE_LINE_TEXT"
-            )
-                .tsExpression()
-                .trim()
-        ).toEqual(
-            `"fieldName" : kintone.fieldTypes.SingleLineText;`.trim()
-        );
-    });
+  test("toTsExpression()", () => {
+    expect(
+      new TsDefinedField("fieldName", "SINGLE_LINE_TEXT").tsExpression().trim()
+    ).toEqual(`"fieldName" : kintone.fieldTypes.SingleLineText;`.trim());
+  });
 });
 
 describe("TsDefinedField with Full Width Symbol FieldCode", () => {
-    test("toTsExpression() with ・", () => {
-        expect(
-            new TsDefinedField("・", "SINGLE_LINE_TEXT")
-                .tsExpression()
-                .trim()
-        ).toEqual(
-            `"・" : kintone.fieldTypes.SingleLineText;`.trim()
-        );
-    });
-    test("toTsExpression() with ￥", () => {
-        expect(
-            new TsDefinedField("￥", "SINGLE_LINE_TEXT")
-                .tsExpression()
-                .trim()
-        ).toEqual(
-            `"￥" : kintone.fieldTypes.SingleLineText;`.trim()
-        );
-    });
-    test("toTsExpression() with ＿", () => {
-        expect(
-            new TsDefinedField("＿", "SINGLE_LINE_TEXT")
-                .tsExpression()
-                .trim()
-        ).toEqual(
-            `"＿" : kintone.fieldTypes.SingleLineText;`.trim()
-        );
-    });
-    test("toTsExpression() with ＄", () => {
-        expect(
-            new TsDefinedField("＄", "SINGLE_LINE_TEXT")
-                .tsExpression()
-                .trim()
-        ).toEqual(
-            `"＄" : kintone.fieldTypes.SingleLineText;`.trim()
-        );
-    });
+  test("toTsExpression() with ・", () => {
+    expect(
+      new TsDefinedField("・", "SINGLE_LINE_TEXT").tsExpression().trim()
+    ).toEqual(`"・" : kintone.fieldTypes.SingleLineText;`.trim());
+  });
+  test("toTsExpression() with ￥", () => {
+    expect(
+      new TsDefinedField("￥", "SINGLE_LINE_TEXT").tsExpression().trim()
+    ).toEqual(`"￥" : kintone.fieldTypes.SingleLineText;`.trim());
+  });
+  test("toTsExpression() with ＿", () => {
+    expect(
+      new TsDefinedField("＿", "SINGLE_LINE_TEXT").tsExpression().trim()
+    ).toEqual(`"＿" : kintone.fieldTypes.SingleLineText;`.trim());
+  });
+  test("toTsExpression() with ＄", () => {
+    expect(
+      new TsDefinedField("＄", "SINGLE_LINE_TEXT").tsExpression().trim()
+    ).toEqual(`"＄" : kintone.fieldTypes.SingleLineText;`.trim());
+  });
 });
 
 describe("TsDefinedField with CHECK_BOX", () => {
-    test("toTsExpression()", () => {
-        expect(
-            new TsDefinedField("fieldName", "CHECK_BOX")
-                .tsExpression()
-                .trim()
-        ).toEqual(
-            `"fieldName" : kintone.fieldTypes.CheckBox;`.trim()
-        );
-    });
+  test("toTsExpression()", () => {
+    expect(
+      new TsDefinedField("fieldName", "CHECK_BOX").tsExpression().trim()
+    ).toEqual(`"fieldName" : kintone.fieldTypes.CheckBox;`.trim());
+  });
 });
 
 describe("TsDefinedField with USER_SELECT", () => {
-    test("toTsExpression()", () => {
-        expect(
-            new TsDefinedField("fieldName", "USER_SELECT")
-                .tsExpression()
-                .trim()
-        ).toEqual(
-            `"fieldName" : kintone.fieldTypes.UserSelect;`.trim()
-        );
-    });
+  test("toTsExpression()", () => {
+    expect(
+      new TsDefinedField("fieldName", "USER_SELECT").tsExpression().trim()
+    ).toEqual(`"fieldName" : kintone.fieldTypes.UserSelect;`.trim());
+  });
 });
 
 describe("SubTableField", () => {
-    test("toTsExpression()", () => {
-        const fieldGroup = new FieldGroup(
-            [],
-            [],
-            [],
-            [],
-            []
-        );
-        expect(
-            new SubTableField(
-                "fieldName",
-                "SUBTABLE",
-                fieldGroup
-            )
-                .tsExpression()
-                .trim()
-        ).toEqual(
-            `
+  test("toTsExpression()", () => {
+    const fieldGroup = new FieldGroup([], [], [], [], []);
+    expect(
+      new SubTableField("fieldName", "SUBTABLE", fieldGroup)
+        .tsExpression()
+        .trim()
+    ).toEqual(
+      `
 "fieldName" : {
     type: "SUBTABLE";
     value: {
@@ -110,61 +65,41 @@ describe("SubTableField", () => {
         }
     }[];
 };`.trim()
-        );
-    });
+    );
+  });
 });
 
 describe("FileField", () => {
-    test("toTsExpression()", () => {
-        expect(
-            new TsDefinedField("fieldName", "FILE")
-                .tsExpression()
-                .trim()
-        ).toEqual(
-            `"fieldName" : kintone.fieldTypes.File;`.trim()
-        );
-    });
+  test("toTsExpression()", () => {
+    expect(
+      new TsDefinedField("fieldName", "FILE").tsExpression().trim()
+    ).toEqual(`"fieldName" : kintone.fieldTypes.File;`.trim());
+  });
 });
 
 describe("FieldGroup", () => {
-    test("toTsExpression()", () => {
-        expect(
-            new FieldGroup(
-                [
-                    new TsDefinedField(
-                        "fieldName1",
-                        "SINGLE_LINE_TEXT"
-                    ),
-                    new TsDefinedField(
-                        "fieldName2",
-                        "SINGLE_LINE_TEXT"
-                    ),
-                ],
-                [new TsDefinedField("fieldName3", "CALC")],
-                [
-                    new TsDefinedField(
-                        "fieldName4",
-                        "MULTI_SELECT"
-                    ),
-                ],
-                [
-                    new TsDefinedField(
-                        "fieldName5",
-                        "USER_SELECT"
-                    ),
-                ],
-                [new TsDefinedField("fieldName6", "FILE")]
-            )
-                .tsExpression()
-                .trim()
-        ).toEqual(
-            `
+  test("toTsExpression()", () => {
+    expect(
+      new FieldGroup(
+        [
+          new TsDefinedField("fieldName1", "SINGLE_LINE_TEXT"),
+          new TsDefinedField("fieldName2", "SINGLE_LINE_TEXT"),
+        ],
+        [new TsDefinedField("fieldName3", "CALC")],
+        [new TsDefinedField("fieldName4", "MULTI_SELECT")],
+        [new TsDefinedField("fieldName5", "USER_SELECT")],
+        [new TsDefinedField("fieldName6", "FILE")]
+      )
+        .tsExpression()
+        .trim()
+    ).toEqual(
+      `
 "fieldName1" : kintone.fieldTypes.SingleLineText;
 "fieldName2" : kintone.fieldTypes.SingleLineText;
 "fieldName3" : kintone.fieldTypes.Calc;
 "fieldName4" : kintone.fieldTypes.MultiSelect;
 "fieldName5" : kintone.fieldTypes.UserSelect;
 "fieldName6" : kintone.fieldTypes.File;`.trim()
-        );
-    });
+    );
+  });
 });

--- a/packages/dts-gen/src/templates/expressions/fields.ts
+++ b/packages/dts-gen/src/templates/expressions/fields.ts
@@ -1,55 +1,50 @@
-import {
-    TsExpression,
-    toTsExpressions,
-} from "./expression";
+import { TsExpression, toTsExpressions } from "./expression";
 import { Converter as FieldTypeConverter } from "./typescriptfieldtypeconverter";
 
 export class FieldGroup implements TsExpression {
-    constructor(
-        private stringFields: TsDefinedField[],
-        private calculatedFields: TsDefinedField[],
-        private stringListFields: TsDefinedField[],
-        private entityListFields: TsDefinedField[],
-        private fileFields: TsDefinedField[]
-    ) {}
+  constructor(
+    private stringFields: TsDefinedField[],
+    private calculatedFields: TsDefinedField[],
+    private stringListFields: TsDefinedField[],
+    private entityListFields: TsDefinedField[],
+    private fileFields: TsDefinedField[]
+  ) {}
 
-    tsExpression(): string {
-        return `
+  tsExpression(): string {
+    return `
 ${toTsExpressions(this.stringFields)}
 ${toTsExpressions(this.calculatedFields)}
 ${toTsExpressions(this.stringListFields)}
 ${toTsExpressions(this.entityListFields)}
 ${toTsExpressions(this.fileFields)}
 `.trim();
-    }
+  }
 }
 
 export class TsDefinedField implements TsExpression {
-    private readonly fieldName: string;
-    private readonly fieldType: string;
+  private readonly fieldName: string;
+  private readonly fieldType: string;
 
-    constructor(fieldName: string, fieldType: string) {
-        this.fieldName = fieldName;
-        this.fieldType = fieldType;
-    }
+  constructor(fieldName: string, fieldType: string) {
+    this.fieldName = fieldName;
+    this.fieldType = fieldType;
+  }
 
-    tsExpression(): string {
-        return `"${
-            this.fieldName
-        }" : ${FieldTypeConverter.convert(
-            this.fieldType
-        )};`.trim();
-    }
+  tsExpression(): string {
+    return `"${this.fieldName}" : ${FieldTypeConverter.convert(
+      this.fieldType
+    )};`.trim();
+  }
 }
 
 export class SubTableField implements TsExpression {
-    constructor(
-        private fieldName: string,
-        private fieldType: string,
-        private fieldGroup: FieldGroup
-    ) {}
-    tsExpression(): string {
-        return `
+  constructor(
+    private fieldName: string,
+    private fieldType: string,
+    private fieldGroup: FieldGroup
+  ) {}
+  tsExpression(): string {
+    return `
 "${this.fieldName}" : {
     type: "${this.fieldType}";
     value: {
@@ -59,5 +54,5 @@ export class SubTableField implements TsExpression {
         }
     }[];
 };`.trim();
-    }
+  }
 }

--- a/packages/dts-gen/src/templates/expressions/namespace.test.ts
+++ b/packages/dts-gen/src/templates/expressions/namespace.test.ts
@@ -1,43 +1,40 @@
 import { Namespace } from "./namespace";
-import {
-    TypeDefinition,
-    SavedTypeDefinition,
-} from "./typedefinitions";
+import { TypeDefinition, SavedTypeDefinition } from "./typedefinitions";
 
 describe("Namespace", () => {
-    class TestTypeDefinition extends TypeDefinition {
-        constructor() {
-            super(null, null, []);
-        }
-        tsExpression(): string {
-            return "interface TestType {}";
-        }
+  class TestTypeDefinition extends TypeDefinition {
+    constructor() {
+      super(null, null, []);
     }
+    tsExpression(): string {
+      return "interface TestType {}";
+    }
+  }
 
-    class TestSavedTypeDefinition extends SavedTypeDefinition {
-        constructor() {
-            super(null, [], []);
-        }
-        tsExpression(): string {
-            return "interface SavedTestType extends TestType {}";
-        }
+  class TestSavedTypeDefinition extends SavedTypeDefinition {
+    constructor() {
+      super(null, [], []);
     }
-    test("tsExpression()", () => {
-        const typeName = "TestField";
-        expect(
-            new Namespace(
-                "test.types",
-                new TestTypeDefinition(),
-                new TestSavedTypeDefinition()
-            )
-                .tsExpression()
-                .trim()
-        ).toEqual(
-            `
+    tsExpression(): string {
+      return "interface SavedTestType extends TestType {}";
+    }
+  }
+  test("tsExpression()", () => {
+    const typeName = "TestField";
+    expect(
+      new Namespace(
+        "test.types",
+        new TestTypeDefinition(),
+        new TestSavedTypeDefinition()
+      )
+        .tsExpression()
+        .trim()
+    ).toEqual(
+      `
 declare namespace test.types {
     interface TestType {}
     interface SavedTestType extends TestType {}
 }`.trim()
-        );
-    });
+    );
+  });
 });

--- a/packages/dts-gen/src/templates/expressions/namespace.ts
+++ b/packages/dts-gen/src/templates/expressions/namespace.ts
@@ -1,20 +1,17 @@
-import {
-    TypeDefinition,
-    SavedTypeDefinition,
-} from "./typedefinitions";
+import { TypeDefinition, SavedTypeDefinition } from "./typedefinitions";
 import { TsExpression } from "./expression";
 
 export class Namespace implements TsExpression {
-    constructor(
-        private namespace: string,
-        private typeDefenition: TypeDefinition,
-        private savedTypeDefenition: SavedTypeDefinition
-    ) {}
-    tsExpression(): string {
-        return `
+  constructor(
+    private namespace: string,
+    private typeDefenition: TypeDefinition,
+    private savedTypeDefenition: SavedTypeDefinition
+  ) {}
+  tsExpression(): string {
+    return `
 declare namespace ${this.namespace} {
     ${this.typeDefenition.tsExpression()}
     ${this.savedTypeDefenition.tsExpression()}
 }`.trim();
-    }
+  }
 }

--- a/packages/dts-gen/src/templates/expressions/typedefinitions.test.ts
+++ b/packages/dts-gen/src/templates/expressions/typedefinitions.test.ts
@@ -1,89 +1,78 @@
-import {
-    TypeDefinition,
-    SavedTypeDefinition,
-} from "./typedefinitions";
-import {
-    FieldGroup,
-    SubTableField,
-    TsDefinedField,
-} from "./fields";
+import { TypeDefinition, SavedTypeDefinition } from "./typedefinitions";
+import { FieldGroup, SubTableField, TsDefinedField } from "./fields";
 
 describe("TypeDefinition", () => {
-    class TestFieldGroup extends FieldGroup {
-        constructor() {
-            super(null, null, null, null, null);
-        }
-        tsExpression(): string {
-            return "// FieldGroup";
-        }
+  class TestFieldGroup extends FieldGroup {
+    constructor() {
+      super(null, null, null, null, null);
     }
-
-    class TestSubTableField extends SubTableField {
-        constructor() {
-            super(null, null, null);
-        }
-        tsExpression(): string {
-            return "// SubTableField";
-        }
+    tsExpression(): string {
+      return "// FieldGroup";
     }
+  }
 
-    test("tsExpression()", () => {
-        expect(
-            new TypeDefinition(
-                "TestType",
-                new TestFieldGroup(),
-                [
-                    new TestSubTableField(),
-                    new TestSubTableField(),
-                ]
-            )
-                .tsExpression()
-                .trim()
-        ).toEqual(
-            `
+  class TestSubTableField extends SubTableField {
+    constructor() {
+      super(null, null, null);
+    }
+    tsExpression(): string {
+      return "// SubTableField";
+    }
+  }
+
+  test("tsExpression()", () => {
+    expect(
+      new TypeDefinition("TestType", new TestFieldGroup(), [
+        new TestSubTableField(),
+        new TestSubTableField(),
+      ])
+        .tsExpression()
+        .trim()
+    ).toEqual(
+      `
 interface TestType {
     // FieldGroup
     // SubTableField
 // SubTableField
 }`.trim()
-        );
-    });
+    );
+  });
 });
 
 describe("SavedTypeDefinition", () => {
-    class TestStringFieldInSavedRecord extends TsDefinedField {
-        constructor() {
-            super(null, null);
-        }
-        tsExpression(): string {
-            return "// StringFieldInSavedRecord";
-        }
+  class TestStringFieldInSavedRecord extends TsDefinedField {
+    constructor() {
+      super(null, null);
     }
-    class TestUserField extends TsDefinedField {
-        constructor() {
-            super(null, null);
-        }
-        tsExpression(): string {
-            return "// UserField";
-        }
+    tsExpression(): string {
+      return "// StringFieldInSavedRecord";
     }
-    test("tsExpression()", () => {
-        expect(
-            new SavedTypeDefinition(
-                "TestType",
-                [new TestUserField()],
-                [new TestStringFieldInSavedRecord()]
-            )
-                .tsExpression()
-                .trim()
-        ).toEqual(
-            `
+  }
+  class TestUserField extends TsDefinedField {
+    constructor() {
+      super(null, null);
+    }
+    tsExpression(): string {
+      return "// UserField";
+    }
+  }
+  test("tsExpression()", () => {
+    expect(
+      new SavedTypeDefinition(
+        "TestType",
+        [new TestUserField()],
+        [new TestStringFieldInSavedRecord()]
+      )
+        .tsExpression()
+        .trim()
+    ).toEqual(
+      `
 interface SavedTestType extends TestType {
     $id : kintone.fieldTypes.Id;
     $revision: kintone.fieldTypes.Revision;
     // UserField
     // StringFieldInSavedRecord
 }`.trim()
-        );
-    });
+    );
+  });
 });

--- a/packages/dts-gen/src/templates/expressions/typedefinitions.ts
+++ b/packages/dts-gen/src/templates/expressions/typedefinitions.ts
@@ -1,42 +1,35 @@
-import {
-    FieldGroup,
-    SubTableField,
-    TsDefinedField,
-} from "./fields";
-import {
-    TsExpression,
-    toTsExpressions,
-} from "./expression";
+import { FieldGroup, SubTableField, TsDefinedField } from "./fields";
+import { TsExpression, toTsExpressions } from "./expression";
 
 export class TypeDefinition implements TsExpression {
-    constructor(
-        private typeName: string,
-        private fieldGroup: FieldGroup,
-        private subtableFields: SubTableField[]
-    ) {}
-    tsExpression(): string {
-        return `
+  constructor(
+    private typeName: string,
+    private fieldGroup: FieldGroup,
+    private subtableFields: SubTableField[]
+  ) {}
+  tsExpression(): string {
+    return `
 interface ${this.typeName} {
     ${this.fieldGroup.tsExpression()}
     ${toTsExpressions(this.subtableFields)}
 }`.trim();
-    }
+  }
 }
 
 export class SavedTypeDefinition implements TsExpression {
-    constructor(
-        private typeName: string,
-        private userFields: TsDefinedField[],
-        private stringFieldsInSavedRecord: TsDefinedField[]
-    ) {}
+  constructor(
+    private typeName: string,
+    private userFields: TsDefinedField[],
+    private stringFieldsInSavedRecord: TsDefinedField[]
+  ) {}
 
-    tsExpression(): string {
-        return `
+  tsExpression(): string {
+    return `
 interface Saved${this.typeName} extends ${this.typeName} {
     $id : kintone.fieldTypes.Id;
     $revision: kintone.fieldTypes.Revision;
     ${toTsExpressions(this.userFields)}
     ${toTsExpressions(this.stringFieldsInSavedRecord)}
 }`.trim();
-    }
+  }
 }

--- a/packages/dts-gen/src/templates/expressions/typescriptfieldtypeconverter.ts
+++ b/packages/dts-gen/src/templates/expressions/typescriptfieldtypeconverter.ts
@@ -1,42 +1,39 @@
 const KintoneFieldTypeAndTypeScriptFieldTypeName = {
-    SINGLE_LINE_TEXT: "kintone.fieldTypes.SingleLineText",
-    MULTI_LINE_TEXT: "kintone.fieldTypes.MultiLineText",
-    RICH_TEXT: "kintone.fieldTypes.RichText",
-    DATE: "kintone.fieldTypes.Date",
-    CALC: "kintone.fieldTypes.Calc",
-    FILE: "kintone.fieldTypes.File",
-    NUMBER: "kintone.fieldTypes.Number",
-    DATETIME: "kintone.fieldTypes.DateTime",
-    TIME: "kintone.fieldTypes.Time",
-    DROP_DOWN: "kintone.fieldTypes.DropDown",
-    LINK: "kintone.fieldTypes.Link",
-    RADIO_BUTTON: "kintone.fieldTypes.RadioButton",
-    CHECK_BOX: "kintone.fieldTypes.CheckBox",
-    MULTI_SELECT: "kintone.fieldTypes.MultiSelect",
-    RECORD_NUMBER: "kintone.fieldTypes.RecordNumber",
-    CREATED_TIME: "kintone.fieldTypes.CreatedTime",
-    UPDATED_TIME: "kintone.fieldTypes.UpdatedTime",
-    MODIFIER: "kintone.fieldTypes.Modifier",
-    CREATOR: "kintone.fieldTypes.Creator",
-    USER_SELECT: "kintone.fieldTypes.UserSelect",
-    GROUP_SELECT: "kintone.fieldTypes.GroupSelect",
-    ORGANIZATION_SELECT:
-        "kintone.fieldTypes.OrganizationSelect",
+  SINGLE_LINE_TEXT: "kintone.fieldTypes.SingleLineText",
+  MULTI_LINE_TEXT: "kintone.fieldTypes.MultiLineText",
+  RICH_TEXT: "kintone.fieldTypes.RichText",
+  DATE: "kintone.fieldTypes.Date",
+  CALC: "kintone.fieldTypes.Calc",
+  FILE: "kintone.fieldTypes.File",
+  NUMBER: "kintone.fieldTypes.Number",
+  DATETIME: "kintone.fieldTypes.DateTime",
+  TIME: "kintone.fieldTypes.Time",
+  DROP_DOWN: "kintone.fieldTypes.DropDown",
+  LINK: "kintone.fieldTypes.Link",
+  RADIO_BUTTON: "kintone.fieldTypes.RadioButton",
+  CHECK_BOX: "kintone.fieldTypes.CheckBox",
+  MULTI_SELECT: "kintone.fieldTypes.MultiSelect",
+  RECORD_NUMBER: "kintone.fieldTypes.RecordNumber",
+  CREATED_TIME: "kintone.fieldTypes.CreatedTime",
+  UPDATED_TIME: "kintone.fieldTypes.UpdatedTime",
+  MODIFIER: "kintone.fieldTypes.Modifier",
+  CREATOR: "kintone.fieldTypes.Creator",
+  USER_SELECT: "kintone.fieldTypes.UserSelect",
+  GROUP_SELECT: "kintone.fieldTypes.GroupSelect",
+  ORGANIZATION_SELECT: "kintone.fieldTypes.OrganizationSelect",
 };
 
 function convert(typeName: string) {
-    const typeScriptFieldType =
-        KintoneFieldTypeAndTypeScriptFieldTypeName[
-            typeName
-        ];
-    if (!typeScriptFieldType) {
-        throw new Error(
-            `${typeName} is not mapped to kintone.fieldTypes[TypeName]`
-        );
-    }
-    return typeScriptFieldType;
+  const typeScriptFieldType =
+    KintoneFieldTypeAndTypeScriptFieldTypeName[typeName];
+  if (!typeScriptFieldType) {
+    throw new Error(
+      `${typeName} is not mapped to kintone.fieldTypes[TypeName]`
+    );
+  }
+  return typeScriptFieldType;
 }
 
 export const Converter = {
-    convert,
+  convert,
 };

--- a/packages/dts-gen/src/templates/template.test.ts
+++ b/packages/dts-gen/src/templates/template.test.ts
@@ -5,99 +5,93 @@ import { FieldTypeConverter } from "../converters/fileldtype-converter";
 import { objectValues } from "../utils/objectvalues";
 import * as fs from "fs";
 describe("renderAsFile", () => {
-    const TEMP_TEST_TYPEDEF = "tmp.testfields.d.ts";
-    test("generate typedefinition file", async () => {
-        const client = new DemoClient();
-        const fieldTypeGroups = await client
-            .fetchFormProperties({
-                appId: "",
-                preview: false,
-                guestSpaceId: null,
-            })
-            .then((properties) =>
-                FieldTypeConverter.convertFieldTypesToFieldTypeGroups(
-                    objectValues(properties)
-                )
-            );
-        const input = {
-            typeName: "TestFields",
-            namespace: "kintone.types",
-            fieldTypeGroups,
-        };
-        t.renderAsFile(TEMP_TEST_TYPEDEF, input);
+  const TEMP_TEST_TYPEDEF = "tmp.testfields.d.ts";
+  test("generate typedefinition file", async () => {
+    const client = new DemoClient();
+    const fieldTypeGroups = await client
+      .fetchFormProperties({
+        appId: "",
+        preview: false,
+        guestSpaceId: null,
+      })
+      .then((properties) =>
+        FieldTypeConverter.convertFieldTypesToFieldTypeGroups(
+          objectValues(properties)
+        )
+      );
+    const input = {
+      typeName: "TestFields",
+      namespace: "kintone.types",
+      fieldTypeGroups,
+    };
+    t.renderAsFile(TEMP_TEST_TYPEDEF, input);
 
-        const expected = fs
-            .readFileSync("./resources/testfields.d.ts")
-            .toString()
-            .trim()
-            .replace(/\r?\n/g, "");
+    const expected = fs
+      .readFileSync("./resources/testfields.d.ts")
+      .toString()
+      .trim()
+      .replace(/\r?\n/g, "");
 
-        const actual = fs
-            .readFileSync(TEMP_TEST_TYPEDEF)
-            .toString()
-            .trim()
-            .replace(/\r?\n/g, "");
+    const actual = fs
+      .readFileSync(TEMP_TEST_TYPEDEF)
+      .toString()
+      .trim()
+      .replace(/\r?\n/g, "");
 
-        expect(actual.toString().trim()).toEqual(
-            expected.toString().trim()
-        );
+    expect(actual.toString().trim()).toEqual(expected.toString().trim());
+  });
+
+  afterEach(() => {
+    fs.unlink(TEMP_TEST_TYPEDEF, (err) => {
+      if (err) {
+        throw err;
+      }
     });
-
-    afterEach(() => {
-        fs.unlink(TEMP_TEST_TYPEDEF, (err) => {
-            if (err) {
-                throw err;
-            }
-        });
-    });
+  });
 });
 
 describe("fullWidthSymbol Test", () => {
-    const TEMP_TEST_TYPEDEF = "tmp.testfields.d.ts";
-    test("generate type definition file", async () => {
-        const client = new DemoFullWidthSymbolClient();
-        const fieldTypeGroups = await client
-            .fetchFormProperties({
-                appId: "",
-                preview: false,
-                guestSpaceId: null,
-            })
-            .then((properties) =>
-                FieldTypeConverter.convertFieldTypesToFieldTypeGroups(
-                    objectValues(properties)
-                )
-            );
-        const input = {
-            typeName: "TestFields",
-            namespace: "kintone.types",
-            fieldTypeGroups,
-        };
-        t.renderAsFile(TEMP_TEST_TYPEDEF, input);
+  const TEMP_TEST_TYPEDEF = "tmp.testfields.d.ts";
+  test("generate type definition file", async () => {
+    const client = new DemoFullWidthSymbolClient();
+    const fieldTypeGroups = await client
+      .fetchFormProperties({
+        appId: "",
+        preview: false,
+        guestSpaceId: null,
+      })
+      .then((properties) =>
+        FieldTypeConverter.convertFieldTypesToFieldTypeGroups(
+          objectValues(properties)
+        )
+      );
+    const input = {
+      typeName: "TestFields",
+      namespace: "kintone.types",
+      fieldTypeGroups,
+    };
+    t.renderAsFile(TEMP_TEST_TYPEDEF, input);
 
-        const expected = fs
-            .readFileSync(
-                "./resources/test-fullwidth-symbol-field.d.ts"
-            )
-            .toString()
-            .trim()
-            .replace(/\r?\n/g, "");
+    const expected = fs
+      .readFileSync("./resources/test-fullwidth-symbol-field.d.ts")
+      .toString()
+      .trim()
+      .replace(/\r?\n/g, "");
 
-        const actual = fs
-            .readFileSync(TEMP_TEST_TYPEDEF)
-            .toString()
-            .trim()
-            .replace(/\r?\n/g, "");
+    const actual = fs
+      .readFileSync(TEMP_TEST_TYPEDEF)
+      .toString()
+      .trim()
+      .replace(/\r?\n/g, "");
 
-        expect(actual.toString().trim()).toEqual(
-            expected.toString().trim()
-        );
+    expect(actual.toString().trim()).toEqual(expected.toString().trim());
+  });
+
+  afterEach(() => {
+    fs.unlink(TEMP_TEST_TYPEDEF, (err) => {
+      if (err) {
+        throw err;
+      }
     });
-
-    afterEach(() => {
-        fs.unlink(TEMP_TEST_TYPEDEF, (err) => {
-            if (err) {
-                throw err;
-            }
-        });
-    });
+  });
 });

--- a/packages/dts-gen/src/templates/template.ts
+++ b/packages/dts-gen/src/templates/template.ts
@@ -6,32 +6,25 @@ import { FieldTypeGroups } from "../converters/fileldtype-converter";
 import { convertToTsExpression } from "./converter";
 
 interface RenderInput {
-    typeName: string;
-    namespace: string;
-    fieldTypeGroups: FieldTypeGroups;
+  typeName: string;
+  namespace: string;
+  fieldTypeGroups: FieldTypeGroups;
 }
 
-function renderAsFile(
-    output: string,
-    renderInput: RenderInput
-) {
-    const tsExpression = convertToTsExpression(renderInput);
-    const prettySource = prettier.format(
-        tsExpression.tsExpression(),
-        { parser: "typescript" }
-    );
-    const outputPath = path.join(process.cwd(), output);
+function renderAsFile(output: string, renderInput: RenderInput) {
+  const tsExpression = convertToTsExpression(renderInput);
+  const prettySource = prettier.format(tsExpression.tsExpression(), {
+    parser: "typescript",
+  });
+  const outputPath = path.join(process.cwd(), output);
 
-    if (!fs.existsSync(path.dirname(outputPath))) {
-        fs.mkdirSync(path.dirname(outputPath));
-    }
+  if (!fs.existsSync(path.dirname(outputPath))) {
+    fs.mkdirSync(path.dirname(outputPath));
+  }
 
-    fs.writeFileSync(
-        path.join(process.cwd(), output),
-        prettySource
-    );
+  fs.writeFileSync(path.join(process.cwd(), output), prettySource);
 }
 // definition
 export const TypeDefinitionTemplate = {
-    renderAsFile,
+  renderAsFile,
 };

--- a/packages/dts-gen/src/utils/logger.ts
+++ b/packages/dts-gen/src/utils/logger.ts
@@ -1,4 +1,4 @@
 export function log(message: string) {
-    // eslint-disable-next-line no-console
-    console.log(message);
+  // eslint-disable-next-line no-console
+  console.log(message);
 }

--- a/packages/dts-gen/src/utils/objectvalues.ts
+++ b/packages/dts-gen/src/utils/objectvalues.ts
@@ -1,7 +1,5 @@
 import { toPairs } from "lodash";
 
-export function objectValues<T extends Record<string, any>>(
-    object: T
-) {
-    return toPairs(object).map((entry) => entry[1]);
+export function objectValues<T extends Record<string, any>>(object: T) {
+  return toPairs(object).map((entry) => entry[1]);
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

dts-gen has own `prettier.config.js`, but we want to use same config for all js-sdk packages.

## What

<!-- What is a solution you want to add? -->

- [x] remove `prettier.config.js` from dts-gen package
- [x] fix `lint:fix` command of dts-gen package
- [x] reformat code

In this PR, there is no change in the generated type definition file.

## How to test

<!-- How can we test this pull request? -->

```sh
$ yarn lint & yarn test
```

check the generated type definition file.
```sh
$ cd ./packages/dts-gen
$ yarn demo
$ cat ./demo-fields.d.ts
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
