### PR TITLE
test(data-loader): move `jest.setTimeout` to top of the file 

### DIFF
--- a/packages/data-loader/src/__tests__/main.test.ts
+++ b/packages/data-loader/src/__tests__/main.test.ts
@@ -10,9 +10,7 @@ const mainFilePath = path.resolve(
   packageJson.bin["kintone-data-loader"]
 );
 
-beforeEach(() => {
-  jest.setTimeout(10000);
-});
+jest.setTimeout(10000);
 
 const checkRejectArg = ({
   arg,

--- a/packages/data-loader/src/__tests__/main.test.ts
+++ b/packages/data-loader/src/__tests__/main.test.ts
@@ -10,7 +10,7 @@ const mainFilePath = path.resolve(
   packageJson.bin["kintone-data-loader"]
 );
 
-jest.setTimeout(10000);
+jest.setTimeout(30000);
 
 const checkRejectArg = ({
   arg,


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
Fix #1023 .

## What

<!-- What is a solution you want to add? -->
move `jest.setTimeout` to top of the file.

## How to test

<!-- How can we test this pull request? -->
I confirmed that `jest.setTimeout` works in modified code by the following steps:

- Replace `jest.setTimeout(30000)` to `jest.setTimeout(5)` (set very small timeout ms)
- Run `yarn test` under packages/data-loader
- The test fails and the error message says "Exceeded timeout of **5 ms** for a test."

```
 FAIL  src/__tests__/main.test.ts (5.099 s)
  ● main › should throw error when no commands are passed

    thrown: "Exceeded timeout of 5 ms for a test.
    Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."

      26 |
      27 | describe("main", () => {
    > 28 |   it("should throw error when no commands are passed", () => {
         |   ^
      29 |     return checkRejectArg({
      30 |       arg: "",
      31 |       errorMessage: "Not enough non-option arguments: got 0, need at least 1",

      at __tests__/main.test.ts:28:3
      at Object.<anonymous> (__tests__/main.test.ts:27:1)
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
