### PR TITLE
refactor(plugin-uploader): remove `--domain` option and `KINTONE_DOMAIN` (BREAKING CHANGE)

### DIFF
--- a/packages/plugin-uploader/README.md
+++ b/packages/plugin-uploader/README.md
@@ -47,7 +47,6 @@ You can create a project based on `@kintone/plugin-packer` using [@kintone/creat
     $ kintone-plugin-uploader <pluginPath>
   Options
     --base-url Base-url of your kintone
-    --domain Domain of your kintone (This value is deprecated. Please use --base-url.)
     --username Login username
     --password User's password
     --proxy Proxy server
@@ -58,7 +57,6 @@ You can create a project based on `@kintone/plugin-packer` using [@kintone/creat
 
     You can set the values through environment variables
     base-url: KINTONE_BASE_URL
-    domain: KINTONE_DOMAIN (This value is deprecated. Please you KINTONE_BASE_URL.)
     username: KINTONE_USERNAME
     password: KINTONE_PASSWORD
     basic-auth-username: KINTONE_BASIC_AUTH_USERNAME

--- a/packages/plugin-uploader/bin/cli.js
+++ b/packages/plugin-uploader/bin/cli.js
@@ -12,7 +12,6 @@ const { getMessage } = require("../dist/messages");
 const {
   HTTP_PROXY,
   HTTPS_PROXY,
-  KINTONE_DOMAIN,
   KINTONE_BASE_URL,
   KINTONE_USERNAME,
   KINTONE_PASSWORD,
@@ -26,7 +25,6 @@ const cli = meow(
     $ kintone-plugin-uploader <pluginPath>
   Options
     --base-url Base-url of your kintone
-    --domain Domain of your kintone (This value is deprecated. Please use --base-url.)
     --username Login username
     --password User's password
     --proxy Proxy server
@@ -38,7 +36,6 @@ const cli = meow(
 
     You can set the values through environment variables
     base-url: KINTONE_BASE_URL
-    domain: KINTONE_DOMAIN (This value is deprecated. Please you KINTONE_BASE_URL.)
     username: KINTONE_USERNAME
     password: KINTONE_PASSWORD
     basic-auth-username: KINTONE_BASIC_AUTH_USERNAME
@@ -47,10 +44,6 @@ const cli = meow(
 `,
   {
     flags: {
-      domain: {
-        type: "string",
-        default: KINTONE_DOMAIN || "",
-      },
       baseUrl: {
         type: "string",
         default: KINTONE_BASE_URL || "",
@@ -95,7 +88,6 @@ const pluginPath = cli.input[0];
 const {
   username,
   password,
-  domain,
   baseUrl,
   proxy,
   basicAuthUsername,
@@ -124,17 +116,13 @@ if (!pluginPath) {
   cli.showHelp();
 }
 
-if (domain) {
-  console.warn(getMessage(lang, "Warning_Deprecated_domain"));
-}
-
 const wait = (ms) => new Promise((r) => setTimeout(r, ms));
 
 wait(waitingDialogMs)
-  .then(() => inquireParams({ username, password, domain, baseUrl, lang }))
+  .then(() => inquireParams({ username, password, baseUrl, lang }))
   .then((answers) => {
     run(
-      answers.baseUrl || answers.domain,
+      answers.baseUrl,
       answers.username,
       answers.password,
       pluginPath,

--- a/packages/plugin-uploader/src/index.ts
+++ b/packages/plugin-uploader/src/index.ts
@@ -21,7 +21,7 @@ const launchBrowser = (proxy: string | null): Promise<Browser> => {
 
 const readyForUpload = async (
   browser: Browser,
-  domain: string,
+  baseUrl: string,
   userName: string,
   password: string,
   lang: Lang,
@@ -30,10 +30,7 @@ const readyForUpload = async (
   const m = getBoundMessage(lang);
 
   const page = await browser.newPage();
-  const kintoneUrl = domain.match(/^https:\/\//)
-    ? `${domain}`
-    : `https://${domain}`;
-  const loginUrl = `${kintoneUrl}/login?saml=off`;
+  const loginUrl = `${baseUrl}/login?saml=off`;
 
   if (basicAuth) {
     await page.authenticate(basicAuth);
@@ -59,7 +56,7 @@ const readyForUpload = async (
     throw chalk.red(m("Error_failedLogin"));
   }
 
-  const pluginUrl = `${kintoneUrl}/k/admin/system/plugin/`;
+  const pluginUrl = `${baseUrl}/k/admin/system/plugin/`;
   console.log(`Navigate to ${pluginUrl}`);
   await page.goto(pluginUrl);
 
@@ -113,7 +110,7 @@ interface Option {
 }
 
 export const run = async (
-  domain: string,
+  baseUrl: string,
   userName: string,
   password: string,
   pluginPath: string,
@@ -126,7 +123,7 @@ export const run = async (
   try {
     page = await readyForUpload(
       browser,
-      domain,
+      baseUrl,
       userName,
       password,
       lang,
@@ -149,7 +146,7 @@ export const run = async (
           browser = await launchBrowser(options.proxyServer);
           page = await readyForUpload(
             browser,
-            domain,
+            baseUrl,
             userName,
             password,
             lang,

--- a/packages/plugin-uploader/src/messages.ts
+++ b/packages/plugin-uploader/src/messages.ts
@@ -44,10 +44,6 @@ const messages = {
     en: "has been uploaded!",
     ja: "をアップロードしました!",
   },
-  Warning_Deprecated_domain: {
-    en: "The --domain option and KINTONE_DOMAIN are deprecated and will be removed in the next major release. Please use --base-url or KINTONE_BASE_URL instead.",
-    ja: "--domain オプションおよび KINTONE_DOMAIN は非推奨となり、次のメジャーリリースで削除されます。代わりに --base-url や KINTONE_BASE_URL を使用してください",
-  },
 };
 
 /**

--- a/packages/plugin-uploader/src/messages.ts
+++ b/packages/plugin-uploader/src/messages.ts
@@ -30,11 +30,11 @@ const messages = {
   },
   Error_failedLogin: {
     en: "Login failed, please confirm your username and password",
-    ja: "kintoneへのログインに失敗しました。ログイン名とパスワードを確認してください",
+    ja: "kintoneへのログインに失敗しました。ログイン名とパスワードを確認してください。",
   },
   Error_cannotOpenLogin: {
-    en: "Cannot find a login form on the specified page, please confirm the subdomain",
-    ja: "指定されたページにログインフォームが見つかりませんでした。ドメインを確認してください",
+    en: "Login failed, please confirm the base URL",
+    ja: "kintoneへのログインに失敗しました。ベースURLを確認してください。",
   },
   Error_adminPrivilege: {
     en: "Cannot navigate to the plug-ins page, please retry with an account with administrator privileges",

--- a/packages/plugin-uploader/src/params.ts
+++ b/packages/plugin-uploader/src/params.ts
@@ -5,7 +5,6 @@ import { getBoundMessage } from "./messages";
 interface Params {
   username?: string;
   password?: string;
-  domain?: string;
   baseUrl?: string;
   lang: Lang;
 }
@@ -13,7 +12,6 @@ interface Params {
 export const inquireParams = ({
   username,
   password,
-  domain,
   baseUrl,
   lang,
 }: Params) => {
@@ -24,7 +22,7 @@ export const inquireParams = ({
       message: m("Q_BaseUrl"),
       name: "baseUrl",
       default: baseUrl,
-      when: () => !baseUrl && !domain,
+      when: () => !baseUrl,
       validate: (v: string) => !!v,
     },
     {
@@ -47,7 +45,5 @@ export const inquireParams = ({
 
   return inquirer
     .prompt(questions)
-    .then((answers) =>
-      Object.assign({ username, password, domain, baseUrl }, answers)
-    );
+    .then((answers) => Object.assign({ username, password, baseUrl }, answers));
 };


### PR DESCRIPTION

## Why

This is a part of #530
The `--domain` option has been deprecated(https://github.com/kintone/js-sdk/pull/697), in this PR will remove the option.

## What

remove to support `--domain` option and  `KINTONE_DOMAIN`

## How to test

- If execute `bin/cli.js sample.zip` with `--base-url` option or `KINTONE_DOMAIN`, `--base-url` option is required.

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
