### PR TITLE
refactor(customize-uploader): remove --domain option and KINTONE_DOMAIN (BREAKING CHANGE) 

### DIFF
--- a/packages/customize-uploader/README.md
+++ b/packages/customize-uploader/README.md
@@ -61,7 +61,6 @@ If you want to upload the customize files automatically when a file is updated, 
     $ kintone-customize-uploader <manifestFile>
   Options
     --base-url Base-url of your kintone
-    --domain Domain of your kintone (This value is deprecated. Please use --base-url.)
     --username Login username
     --password User's password
     --oauth-token OAuth access token (If you set a set of --username and --password, this value is not necessary.)
@@ -82,7 +81,6 @@ If you want to upload the customize files automatically when a file is updated, 
 
     You can set the values through environment variables
     base-url: KINTONE_BASE_URL
-    domain: KINTONE_DOMAIN (This value is deprecated. Please use KINTONE_BASE_URL.)
     username: KINTONE_USERNAME
     password: KINTONE_PASSWORD
     oauth-token: KINTONE_OAUTH_TOKEN (If you set a set of username and password, this value is not necessary.)

--- a/packages/customize-uploader/bin/cli.js
+++ b/packages/customize-uploader/bin/cli.js
@@ -10,7 +10,6 @@ const { getMessage } = require("../dist/messages");
 const {
   HTTP_PROXY,
   HTTPS_PROXY,
-  KINTONE_DOMAIN,
   KINTONE_BASE_URL,
   KINTONE_USERNAME,
   KINTONE_PASSWORD,
@@ -25,7 +24,6 @@ const cli = meow(
     $ kintone-customize-uploader <manifestFile>
   Options
     --base-url Base-url of your kintone
-    --domain Domain of your kintone (This value is deprecated. Please use --base-url.)
     --username Login username
     --password User's password
     --oauth-token OAuth access token (If you set a set of --username and --password, this value is not necessary.)
@@ -46,7 +44,6 @@ const cli = meow(
 
     You can set the values through environment variables
     base-url: KINTONE_BASE_URL
-    domain: KINTONE_DOMAIN (This value is deprecated. Please use KINTONE_BASE_URL.)
     username: KINTONE_USERNAME
     password: KINTONE_PASSWORD
     oauth-token: KINTONE_OAUTH_TOKEN (If you set a set of username and password, this value is not necessary.)
@@ -56,10 +53,6 @@ const cli = meow(
 `,
   {
     flags: {
-      domain: {
-        type: "string",
-        default: KINTONE_DOMAIN || "",
-      },
       baseUrl: {
         type: "string",
         default: KINTONE_BASE_URL || "",
@@ -124,7 +117,6 @@ const {
   basicAuthUsername,
   basicAuthPassword,
   oauthToken,
-  domain,
   baseUrl,
   proxy,
   watch,
@@ -148,10 +140,6 @@ if (!isInitCommand && !manifestFile) {
   process.exit(1);
 }
 
-if (domain) {
-  console.warn(getMessage(lang, "W_Deprecated_domain"));
-}
-
 if (isInitCommand) {
   inquireInitParams(lang)
     .then((initParams) => {
@@ -164,13 +152,12 @@ if (isInitCommand) {
     password,
     oAuthToken: oauthToken,
     baseUrl,
-    domain,
     lang,
   })
     .then((params) => {
       if (isImportCommand) {
         runImport(
-          params.baseUrl || params.domain,
+          params.baseUrl,
           params.username,
           params.password,
           oauthToken,
@@ -181,7 +168,7 @@ if (isInitCommand) {
         );
       } else {
         run(
-          params.baseUrl || params.domain,
+          params.baseUrl,
           params.username,
           params.password,
           oauthToken,

--- a/packages/customize-uploader/src/KintoneApiClient.ts
+++ b/packages/customize-uploader/src/KintoneApiClient.ts
@@ -22,11 +22,9 @@ export default class KintoneApiClient {
     oAuthToken: string | null,
     basicAuthUsername: string | null,
     basicAuthPassword: string | null,
-    domain: string,
+    baseUrl: string,
     public options: Option
   ) {
-    const kintoneUrl =
-      domain.indexOf("https://") > -1 ? domain : `https://${domain}`;
     let auth;
     if (username && password) {
       auth = {
@@ -55,7 +53,7 @@ export default class KintoneApiClient {
       proxy = parseProxy(options.proxy);
     }
     this.restApiClient = new KintoneRestAPIClient({
-      baseUrl: kintoneUrl,
+      baseUrl,
       auth,
       basicAuth,
       featureFlags: {

--- a/packages/customize-uploader/src/commands/import.ts
+++ b/packages/customize-uploader/src/commands/import.ts
@@ -183,7 +183,7 @@ const downloadAndWriteFile = (
 };
 
 export const runImport = async (
-  domain: string,
+  baseUrl: string,
   username: string | null,
   password: string | null,
   oAuthToken: string | null,
@@ -206,7 +206,7 @@ export const runImport = async (
     oAuthToken,
     basicAuthUsername,
     basicAuthPassword,
-    domain,
+    baseUrl,
     options
   );
   await importCustomizeSetting(kintoneApiClient, manifest, status, options);

--- a/packages/customize-uploader/src/commands/index.ts
+++ b/packages/customize-uploader/src/commands/index.ts
@@ -128,7 +128,7 @@ export const upload = async (
 };
 
 export const run = async (
-  domain: string,
+  baseUrl: string,
   username: string | null,
   password: string | null,
   oAuthToken: string | null,
@@ -161,7 +161,7 @@ export const run = async (
     oAuthToken,
     basicAuthUsername,
     basicAuthPassword,
-    domain,
+    baseUrl,
     options
   );
   await upload(kintoneApiClient, manifest, status, options);

--- a/packages/customize-uploader/src/messages.ts
+++ b/packages/customize-uploader/src/messages.ts
@@ -70,8 +70,8 @@ const messages = {
     ja: "運用環境に反映しました!",
   },
   E_Authentication: {
-    en: "Failed to authenticate. Please confirm your username, password, and domain",
-    ja: "認証に失敗しました。ログイン名、パスワード、ドメインを確認してください",
+    en: "Failed to authenticate. Please confirm your username, password, and kintone's base URL",
+    ja: "認証に失敗しました。ログイン名、パスワード、ベース URL を確認してください",
   },
   E_Deployed: {
     en: "Failed to deploy setting",

--- a/packages/customize-uploader/src/messages.ts
+++ b/packages/customize-uploader/src/messages.ts
@@ -93,10 +93,6 @@ const messages = {
     en: "An error occured, exit process. Please check if you passed proper arguments and manifest file",
     ja: "エラーが発生しました。引数の値と、マニフェストファイルに正しい値が入力されているか確認してください",
   },
-  W_Deprecated_domain: {
-    en: "The --domain option and KINTONE_DOMAIN are deprecated and will be removed in the next major release. Please use --base-url or KINTONE_BASE_URL instead.",
-    ja: "--domain オプションおよび KINTONE_DOMAIN は非推奨となり、次のメジャーリリースで削除されます。代わりに --base-url や KINTONE_BASE_URL を使用してください",
-  },
 } as const;
 
 /**

--- a/packages/customize-uploader/src/params/index.ts
+++ b/packages/customize-uploader/src/params/index.ts
@@ -7,14 +7,12 @@ interface Params {
   password?: string;
   oAuthToken?: string;
   baseUrl?: string;
-  domain?: string;
   lang: Lang;
 }
 
 export const inquireParams = ({
   username,
   password,
-  domain,
   baseUrl,
   lang,
   oAuthToken,
@@ -26,7 +24,7 @@ export const inquireParams = ({
       message: m("Q_BaseUrl"),
       name: "baseUrl",
       default: baseUrl,
-      when: () => !baseUrl && !domain,
+      when: () => !baseUrl,
       validate: (v: string) => !!v,
     },
     {
@@ -49,9 +47,7 @@ export const inquireParams = ({
 
   return inquirer
     .prompt(questions)
-    .then((answers) =>
-      Object.assign({ username, password, domain, baseUrl }, answers)
-    );
+    .then((answers) => Object.assign({ username, password, baseUrl }, answers));
 };
 
 export * from "./init";


### PR DESCRIPTION
## Why

This is a part of #530
The `--domain` option has been deprecated(#602), in this PR will remove the option.

## What

remove to support `--domain` option and  `KINTONE_DOMAIN`

## How to test

- If execute `bin/cli.js sample/customize-manifest.json ` with `--base-url` option or `KINTONE_DOMAIN`, `--base-url` option is required.

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
