### PR TITLE
refactor(dts-gen): remove --host, --proxyHost and --proxyPort options (BREAKING CHANGE) 

### DIFF
--- a/packages/dts-gen/docs/maintenance-guide.md
+++ b/packages/dts-gen/docs/maintenance-guide.md
@@ -59,7 +59,7 @@ You can execute these tools like below:
 $ node ./dist/integration-tests/setup-test-app.js \
     -u *** \
     -p *** \
-    --host https://****.cybozu.com \
+    --base-url https://****.cybozu.com \
     --integration-test-js-file ./dist/dts-gen-integration-test.js
 ```
 
@@ -68,6 +68,6 @@ $ node ./dist/integration-tests/setup-test-app.js \
 path of integration test which will be uploaded as kintone js customize file.
 You can run the test code as a kintone customize js customize code.
 
-`-u, --p, --host`:
+`-u, --p, --base-url`:
 
-username, password, host of kintone.
+username, password, base URL of kintone.

--- a/packages/dts-gen/package.json
+++ b/packages/dts-gen/package.json
@@ -11,7 +11,6 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint 'src/**/*.ts'",
     "demo": "node dist/index.js --demo --type-name DemoFields -o demo-fields.d.ts",
-    "generate": "node dist/index.js --host https://****.cybozu.com --username *** --password *** --app-id ***",
     "help": "node dist/index.js --help",
     "test": "jest",
     "test:ci": "jest --runInBand",

--- a/packages/dts-gen/src/cli-parser.test.ts
+++ b/packages/dts-gen/src/cli-parser.test.ts
@@ -123,24 +123,6 @@ describe("parse", () => {
     afterEach(() => {
       spy.mockRestore();
     });
-    test("should print the deprecating message with --host", () => {
-      const args = parse([
-        "node",
-        "index.js",
-        "--host",
-        "https://example.kintone.com",
-        "--username",
-        "USERNAME",
-        "--password",
-        "PASSWORD",
-        "--app-id",
-        "APP_ID",
-      ]);
-      expect(args.baseUrl).toBe("https://example.kintone.com");
-      expect(spy).toHaveBeenCalledWith(
-        "--host option will be deprecated, please use the --base-url option instead."
-      );
-    });
     test("should print the deprecating message with --proxyHost and --proxyPort", () => {
       const args = parse([
         "node",

--- a/packages/dts-gen/src/cli-parser.test.ts
+++ b/packages/dts-gen/src/cli-parser.test.ts
@@ -50,8 +50,6 @@ describe("parse", () => {
       expect(args.guestSpaceId).toBeNull();
       expect(args.preview).toBe(false);
       expect(args.namespace).toBe("kintone.types");
-      expect(args.proxyHost).toBeNull();
-      expect(args.proxyPort).toBeNull();
       expect(args.basicAuthUsername).toBeNull();
       expect(args.basicAuthPassword).toBeNull();
       expect(args.output).toBe("fields.d.ts");
@@ -113,38 +111,6 @@ describe("parse", () => {
       expect(() => {
         parse(["node", "index.js"]);
       }).toThrow("--base-url (KINTONE_BASE_URL) must be specified");
-    });
-  });
-  describe("deprecated options", () => {
-    let spy;
-    beforeEach(() => {
-      spy = jest.spyOn(console, "warn").mockImplementation();
-    });
-    afterEach(() => {
-      spy.mockRestore();
-    });
-    test("should print the deprecating message with --proxyHost and --proxyPort", () => {
-      const args = parse([
-        "node",
-        "index.js",
-        "--base-url",
-        "https://example2.kintone.com",
-        "--username",
-        "USERNAME",
-        "--password",
-        "PASSWORD",
-        "--app-id",
-        "APP_ID",
-        "--proxy-host",
-        "PROXY_HOST",
-        "--proxy-port",
-        "PROXY_PORT",
-      ]);
-      expect(args.proxyHost).toBe("PROXY_HOST");
-      expect(args.proxyPort).toBe("PROXY_PORT");
-      expect(spy).toHaveBeenCalledWith(
-        "--proxy-host and --proxy-port options will be deprecated, please use the --proxy option instead"
-      );
     });
   });
 });

--- a/packages/dts-gen/src/cli-parser.ts
+++ b/packages/dts-gen/src/cli-parser.ts
@@ -7,8 +7,6 @@ interface ParsedArgs {
   oAuthToken: string | null;
   apiToken: string | null;
   proxy: string | null;
-  proxyHost: string | null;
-  proxyPort: string | null;
   basicAuthPassword: string | null;
   basicAuthUsername: string | null;
   appId: string | null;
@@ -66,16 +64,6 @@ export const parse = (argv: string[]): ParsedArgs => {
       "namespace of type to be generated",
       "kintone.types"
     )
-    .option(
-      "--proxy-host [proxyHost]. This will be replaced with the --proxy option",
-      "proxy host",
-      null
-    )
-    .option(
-      "--proxy-port [proxyPort]. This will be replaced with the --proxy option",
-      "proxy port",
-      null
-    )
     // Axios handles HTTP_PROXY and HTTPS_PROXY natively,
     // so we don't use the environment variables as the default value
     .option("--proxy [proxy]", "proxy server", null)
@@ -99,8 +87,6 @@ export const parse = (argv: string[]): ParsedArgs => {
     apiToken,
     oauthToken,
     proxy,
-    proxyHost,
-    proxyPort,
     basicAuthPassword,
     basicAuthUsername,
     appId,
@@ -111,13 +97,6 @@ export const parse = (argv: string[]): ParsedArgs => {
     namespace,
     output,
   } = options;
-
-  // warn deprecated options
-  if (proxyHost || proxyPort) {
-    console.warn(
-      "--proxy-host and --proxy-port options will be deprecated, please use the --proxy option instead"
-    );
-  }
 
   const baseUrl = options.baseUrl;
   if (baseUrl === null) {
@@ -131,8 +110,6 @@ export const parse = (argv: string[]): ParsedArgs => {
     apiToken,
     oAuthToken: oauthToken,
     proxy,
-    proxyHost,
-    proxyPort,
     basicAuthPassword,
     basicAuthUsername,
     appId,

--- a/packages/dts-gen/src/cli-parser.ts
+++ b/packages/dts-gen/src/cli-parser.ts
@@ -24,12 +24,6 @@ export const parse = (argv: string[]): ParsedArgs => {
   const program = new Command();
   program
     .option("--demo", "Generate Type definition from demo data.", false)
-
-    .option(
-      "--host [host]",
-      "A base URL for the Kintone environment. This will be replaced with the --base-url option",
-      null
-    )
     .option(
       "--base-url [baseUrl]",
       "A base URL for the Kintone environment",
@@ -100,7 +94,6 @@ export const parse = (argv: string[]): ParsedArgs => {
 
   const options = program.opts();
   const {
-    host,
     username,
     password,
     apiToken,
@@ -120,18 +113,13 @@ export const parse = (argv: string[]): ParsedArgs => {
   } = options;
 
   // warn deprecated options
-  if (host) {
-    console.warn(
-      "--host option will be deprecated, please use the --base-url option instead."
-    );
-  }
   if (proxyHost || proxyPort) {
     console.warn(
       "--proxy-host and --proxy-port options will be deprecated, please use the --proxy option instead"
     );
   }
 
-  const baseUrl = options.baseUrl || host;
+  const baseUrl = options.baseUrl;
   if (baseUrl === null) {
     throw new Error("--base-url (KINTONE_BASE_URL) must be specified");
   }

--- a/packages/dts-gen/src/integration-tests/setup-test-app.ts
+++ b/packages/dts-gen/src/integration-tests/setup-test-app.ts
@@ -10,8 +10,6 @@ program
   .option("-u, --username <username>")
   .option("-p, --password <password>")
   .option("--base-url <base-url>")
-  .option("--proxy-host [proxyHost]", "proxy host", null)
-  .option("--proxy-port [proxyPort]", "proxy port", null)
   .option("--proxy [proxy]", "proxy server", null)
   .option(
     "--basic-auth-username [basicAuthUsername]",
@@ -40,8 +38,6 @@ const handleSetupApp = async (command) => {
     password: command.password,
     apiToken: command.apiToken,
     oAuthToken: command.oAuthToken,
-    proxyHost: command.proxyHost,
-    proxyPort: command.proxyPort,
     proxy: command.proxy,
     basicAuthUsername: command.basicAuthUsername,
     basicAuthPassword: command.basicAuthPassword,

--- a/packages/dts-gen/src/integration-tests/setup-test-app.ts
+++ b/packages/dts-gen/src/integration-tests/setup-test-app.ts
@@ -9,6 +9,7 @@ program
   .version("0.0.1")
   .option("-u, --username <username>")
   .option("-p, --password <password>")
+  .option("--base-url <base-url>")
   .option("--proxy-host [proxyHost]", "proxy host", null)
   .option("--proxy-port [proxyPort]", "proxy port", null)
   .option("--proxy [proxy]", "proxy server", null)
@@ -34,7 +35,7 @@ program
 
 const handleSetupApp = async (command) => {
   const newClientInput = {
-    baseUrl: command.host,
+    baseUrl: command.baseUrl,
     username: command.username,
     password: command.password,
     apiToken: command.apiToken,

--- a/packages/dts-gen/src/integration-tests/setup-test-app.ts
+++ b/packages/dts-gen/src/integration-tests/setup-test-app.ts
@@ -7,7 +7,6 @@ import { log } from "../utils/logger";
 
 program
   .version("0.0.1")
-  .option("--host <host>")
   .option("-u, --username <username>")
   .option("-p, --password <password>")
   .option("--proxy-host [proxyHost]", "proxy host", null)

--- a/packages/dts-gen/src/kintone/clients/axios-utils.test.ts
+++ b/packages/dts-gen/src/kintone/clients/axios-utils.test.ts
@@ -22,8 +22,6 @@ describe("FormsClientImpl#constructor", () => {
       username: "username",
       password: "password",
       proxy: null,
-      proxyHost: null,
-      proxyPort: null,
       basicAuthPassword: null,
       basicAuthUsername: null,
     };
@@ -39,40 +37,12 @@ describe("FormsClientImpl#constructor", () => {
     assertConstructorWithArgs(input, expectedCalledWith);
   });
 
-  test("with proxyHost and proxyPort option", () => {
-    const input = {
-      baseUrl,
-      username: "username",
-      password: "password",
-      proxy: null,
-      proxyHost: "proxyHost",
-      proxyPort: "1234",
-      basicAuthPassword: null,
-      basicAuthUsername: null,
-    };
-
-    const headers = {
-      "X-Cybozu-Authorization": authToken,
-    };
-    const expectedCalledWith = {
-      headers,
-      baseURL: baseUrl,
-      proxy: {
-        host: "proxyHost",
-        port: 1234,
-      },
-    };
-    assertConstructorWithArgs(input, expectedCalledWith);
-  });
-
   test("with proxy option", () => {
     const input = {
       baseUrl,
       username: "username",
       password: "password",
       proxy: "http://admin:password@localhost:1234",
-      proxyHost: null,
-      proxyPort: null,
       basicAuthPassword: null,
       basicAuthUsername: null,
     };
@@ -101,8 +71,6 @@ describe("FormsClientImpl#constructor", () => {
       username: "username",
       password: "password",
       proxy: null,
-      proxyHost: null,
-      proxyPort: null,
       basicAuthPassword: "basicUsername",
       basicAuthUsername: "basicPassword",
     };

--- a/packages/dts-gen/src/kintone/clients/axios-utils.ts
+++ b/packages/dts-gen/src/kintone/clients/axios-utils.ts
@@ -12,8 +12,6 @@ export interface NewInstanceInput {
   oAuthToken: string | null;
   apiToken: string | null;
   proxy: string | null;
-  proxyHost: string | null;
-  proxyPort: string | null;
   basicAuthPassword: string | null;
   basicAuthUsername: string | null;
 }
@@ -30,11 +28,6 @@ const newAxiosInstance = (input: NewInstanceInput): AxiosInstance => {
         username: proxyUrl.username,
         password: proxyUrl.password,
       },
-    };
-  } else if (input.proxyHost !== null && input.proxyPort !== null) {
-    proxy = {
-      host: input.proxyHost,
-      port: parseInt(input.proxyPort, 10),
     };
   }
 

--- a/packages/dts-gen/src/kintone/clients/forms-client-impl.test.ts
+++ b/packages/dts-gen/src/kintone/clients/forms-client-impl.test.ts
@@ -64,8 +64,6 @@ describe("FormsClientImpl#fetchFormProperties", () => {
       password: "password",
       apiToken: null,
       oAuthToken: null,
-      proxyHost: null,
-      proxyPort: null,
       proxy: null,
       basicAuthPassword: null,
       basicAuthUsername: null,


### PR DESCRIPTION
## Why

This is a part of #530
The `--host`, `--proxyHost` and `--proxyPort` options have been deprecated(#869), in this PR will remove the options.

## What

remove to support following options.
- `--host`
- `--proxyHost`
- `--proxyPort`

## How to test

If execute below command  with `--host` or `--proxyHost` or `--proxyPort`, an error occurs as missing the option.
```
$ npx ts-node src/index.ts --host https://xxx.cybozu.com --username *** --password *** --app-id 3
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
