### PR TITLE
test(dts-gen): fix broken setup-test-app and integration-test

### DIFF
--- a/packages/dts-gen/src/integration-tests/dts-gen-api-test.ts
+++ b/packages/dts-gen/src/integration-tests/dts-gen-api-test.ts
@@ -117,10 +117,6 @@ const assertKintoneBuiltinFunctions = () => {
   assertFunction(kintone.portal.getContentSpaceElement);
   assertFunction(kintone.mobile.portal.getContentSpaceElement);
 
-  // kintone.$PLUGIN_ID
-  assert.ok(kintone.$PLUGIN_ID);
-  assert.ok(typeof kintone.$PLUGIN_ID === "string");
-
   // Space API
   assertFunction(kintone.space.portal.getContentSpaceElement);
   assertFunction(kintone.mobile.space.portal.getContentSpaceElement);

--- a/packages/dts-gen/src/integration-tests/setup-test-app.ts
+++ b/packages/dts-gen/src/integration-tests/setup-test-app.ts
@@ -1,35 +1,9 @@
-import * as program from "commander";
 import * as fs from "fs";
+import { Command } from "commander";
 
 import { SetUpTestAppClient } from "../kintone/clients/setup-test-app-client";
 import { SetupTestApp } from "./setup-test-utils";
 import { log } from "../utils/logger";
-
-program
-  .version("0.0.1")
-  .option("-u, --username <username>")
-  .option("-p, --password <password>")
-  .option("--base-url <base-url>")
-  .option("--proxy [proxy]", "proxy server", null)
-  .option(
-    "--basic-auth-username [basicAuthUsername]",
-    "username for basic authentication",
-    null
-  )
-  .option(
-    "--basic-auth-password [basicAuthPassword]",
-    "password for basic authentication",
-    null
-  )
-  .option(
-    "--integration-test-js-file <integrationTestJsFile>",
-    "path to integration js file which will be uploaded to test kintone app"
-  )
-  .parse(process.argv);
-
-(async () => {
-  await handleSetupApp(program);
-})();
 
 const handleSetupApp = async (command) => {
   const newClientInput = {
@@ -60,3 +34,31 @@ const handleSetupApp = async (command) => {
   log("Adding Demo Record");
   await SetupTestApp.addDemoRecord(client, app, command.integrationTestJsFile);
 };
+
+(async () => {
+  const program = new Command();
+  program
+    .version("0.0.1")
+    .option("-u, --username <username>")
+    .option("-p, --password <password>")
+    .option("--base-url <base-url>")
+    .option("--proxy [proxy]", "proxy server", null)
+    .option(
+      "--basic-auth-username [basicAuthUsername]",
+      "username for basic authentication",
+      null
+    )
+    .option(
+      "--basic-auth-password [basicAuthPassword]",
+      "password for basic authentication",
+      null
+    )
+    .option(
+      "--integration-test-js-file <integrationTestJsFile>",
+      "path to integration js file which will be uploaded to test kintone app"
+    )
+    .parse(process.argv);
+
+  const options = program.opts();
+  await handleSetupApp(options);
+})();

--- a/packages/dts-gen/src/kintone/clients/demo-datas.ts
+++ b/packages/dts-gen/src/kintone/clients/demo-datas.ts
@@ -214,6 +214,7 @@ const DemoDataFields: any = {
   Table: {
     type: "SUBTABLE",
     code: "Table",
+    label: "Table",
     fields: {
       Text_Table: {
         type: "SINGLE_LINE_TEXT",
@@ -278,6 +279,7 @@ const DemoDataFields: any = {
   Table_0: {
     type: "SUBTABLE",
     code: "Table_0",
+    label: "Table_0",
     fields: {
       Radio_button_Table: {
         type: "RADIO_BUTTON",

--- a/packages/dts-gen/webpack.config.js
+++ b/packages/dts-gen/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const webpack = require("webpack");
 
 module.exports = {
   entry: {
@@ -28,4 +29,9 @@ module.exports = {
     filename: "[name].js",
     path: path.resolve(__dirname, "dist"),
   },
+  plugins: [
+    new webpack.ProvidePlugin({
+      process: "process/browser",
+    }),
+  ],
 };

--- a/packages/dts-gen/webpack.config.js
+++ b/packages/dts-gen/webpack.config.js
@@ -1,8 +1,9 @@
-const path = require('path');
+const path = require("path");
 
 module.exports = {
   entry: {
-      'dts-gen-integration-test' : './src/integration-tests/dts-gen-integration-test.ts'
+    "dts-gen-integration-test":
+      "./src/integration-tests/dts-gen-integration-test.ts",
   },
   module: {
     rules: [
@@ -10,21 +11,21 @@ module.exports = {
         test: /\.tsx?$/,
         use: [
           {
-            loader: 'ts-loader',
-          }
+            loader: "ts-loader",
+          },
         ],
-        exclude: /node_modules/
-      }
-    ]
+        exclude: /node_modules/,
+      },
+    ],
   },
   resolve: {
-    extensions: [ '.tsx', '.ts', '.js' ],
+    extensions: [".tsx", ".ts", ".js"],
     fallback: {
       assert: false,
     },
   },
   output: {
-    filename: '[name].js',
-    path: path.resolve(__dirname, 'dist')
-  }
+    filename: "[name].js",
+    path: path.resolve(__dirname, "dist"),
+  },
 };


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

The integration-test  in dts-gen does not work cause of the following probrems:
Ref. https://github.com/kintone/js-sdk/issues/885

- The way of use has been changed in commander v7
  Ref. https://github.com/tj/commander.js/releases/tag/v7.0.0
- No longer include a polyfill for this Node.js variable in webpack v5
  Ref. https://webpack.js.org/migrate/5/#run-a-single-build-and-follow-advice
- Table field has added a label property

## What

- migrate commander v8 and webpack 5
- add a label property into Table field

## How to test

Execute the following commands.
```
$ cd packages/dts-gen
$ yarn build
$ node ./dist/integration-tests/setup-test-app.js --integration-test-js-file ./dist/dts-gen-integration-test.js
```

A kintone app is created in your kintone
Access the kintone app, this app includes 1 demo record data.
Edit the demo record, and you must set a value to user-select filed, group-select field, title-select field.
Open record list page and open web console


## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
