### PR TITLE
chore: unify package badges

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
   "keywords": [
     "kintone"
   ],
-  "author": "kintone",
+  "author": {
+    "name": "Cybozu, Inc.",
+    "url": "https://cybozu.co.jp"
+  },
   "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.16.0",

--- a/packages/create-plugin/README.md
+++ b/packages/create-plugin/README.md
@@ -1,6 +1,8 @@
 # create-kintone-plugin
 
 [![npm version](https://badge.fury.io/js/%40kintone%2Fcreate-plugin.svg)](https://badge.fury.io/js/%40kintone%2Fcreate-plugin)
+![Node.js version](https://img.shields.io/badge/dynamic/json.svg?url=https://raw.githubusercontent.com/kintone/js-sdk/master/packages/create-plugin/package.json&label=node&query=$.engines.node&colorB=blue)
+![License](https://img.shields.io/npm/l/@kintone/create-plugin.svg)
 
 A CLI tool for creating a kintone plugin!
 

--- a/packages/create-plugin/package.json
+++ b/packages/create-plugin/package.json
@@ -57,6 +57,9 @@
   "keywords": [
     "kintone"
   ],
-  "author": "kintone",
+  "author": {
+    "name": "Cybozu, Inc.",
+    "url": "https://cybozu.co.jp"
+  },
   "license": "MIT"
 }

--- a/packages/customize-uploader/README.md
+++ b/packages/customize-uploader/README.md
@@ -1,6 +1,8 @@
 # kintone-customize-uploader
 
 [![npm version](https://badge.fury.io/js/%40kintone%2Fcustomize-uploader.svg)](https://badge.fury.io/js/%40kintone%2Fcustomize-uploader)
+![Node.js version](https://img.shields.io/badge/dynamic/json.svg?url=https://raw.githubusercontent.com/kintone/js-sdk/master/packages/customize-uploader/package.json&label=node&query=$.engines.node&colorB=blue)
+![License](https://img.shields.io/npm/l/@kintone/customize-uploader.svg)
 
 A kintone customize uploader
 
@@ -154,4 +156,5 @@ In this example, JavaScript and CSS Customization is set as below.
 ![Example screenshot of JavaScript and CSS Customization](docs/example_setting.PNG)
 
 ## LICENSE
+
 MIT License

--- a/packages/customize-uploader/package.json
+++ b/packages/customize-uploader/package.json
@@ -30,7 +30,10 @@
   "keywords": [
     "kintone"
   ],
-  "author": "kintone",
+  "author": {
+    "name": "Cybozu, Inc.",
+    "url": "https://cybozu.co.jp"
+  },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/kintone/js-sdk/issues"

--- a/packages/data-loader/README.md
+++ b/packages/data-loader/README.md
@@ -1,6 +1,8 @@
 # kintone-data-loader
 
 [![npm version](https://badge.fury.io/js/%40kintone%2Fdata-loader.svg)](https://badge.fury.io/js/%40kintone%2Fdata-loader)
+![Node.js version](https://img.shields.io/badge/dynamic/json.svg?url=https://raw.githubusercontent.com/kintone/js-sdk/master/packages/data-loader/package.json&label=node&query=$.engines.node&colorB=blue)
+![License](https://img.shields.io/npm/l/@kintone/data-loader.svg)
 
 A kintone record importer and exporter.
 

--- a/packages/dts-gen/README.md
+++ b/packages/dts-gen/README.md
@@ -1,6 +1,8 @@
 # kintone-dts-gen
 
 [![npm version](https://badge.fury.io/js/%40kintone%2Fdts-gen.svg)](https://badge.fury.io/js/%40kintone%2Fdts-gen)
+![Node.js version](https://img.shields.io/badge/dynamic/json.svg?url=https://raw.githubusercontent.com/kintone/js-sdk/master/packages/dts-gen/package.json&label=node&query=$.engines.node&colorB=blue)
+![License](https://img.shields.io/npm/l/@kintone/dts-gen.svg)
 
 Type definition for kintone customize and
 Type definition generation tool from kintone form settings.

--- a/packages/plugin-manifest-validator/README.md
+++ b/packages/plugin-manifest-validator/README.md
@@ -1,14 +1,11 @@
 @kintone/plugin-manifest-validator
 ====
 
-Validate `manifest.json` of kintone plugin. Used in [@kintone/plugin-packer](https://github.com/kintone/plugin-packer).
+[![npm version](https://badge.fury.io/js/%40kintone%2Fplugin-manifest-validator.svg)](https://badge.fury.io/js/%40kintone%2Fplugin-manifest-validator)
+![Node.js version](https://img.shields.io/badge/dynamic/json.svg?url=https://raw.githubusercontent.com/kintone/js-sdk/master/packages/create-plugin/package.json&label=node&query=$.engines.node&colorB=blue)
+![License](https://img.shields.io/npm/l/@kintone/plugin-manifest-validator.svg)
 
-[![npm version][npm-image]][npm-url]
-![Node.js Version Support][node-version]
-[![build status][circleci-image]][circleci-url]
-[![build status][travisci-image]][travisci-url]
-[![dependency status][deps-image]][deps-url]
-![License][license]
+Validate `manifest.json` of kintone plugin. Used in [@kintone/plugin-packer](https://github.com/kintone/plugin-packer).
 
 ## How to install
 
@@ -61,14 +58,3 @@ let manifest: KintonePluginManifestJson;
 ## License
 
 MIT License
-
-[npm-image]: https://img.shields.io/npm/v/@kintone/plugin-manifest-validator.svg
-[npm-url]: https://npmjs.org/package/@kintone/plugin-manifest-validator
-[circleci-image]: https://circleci.com/gh/kintone/plugin-manifest-validator.svg?style=shield
-[circleci-url]: https://circleci.com/gh/kintone/plugin-manifest-validator
-[travisci-image]: https://travis-ci.org/kintone/plugin-manifest-validator.svg?branch=master
-[travisci-url]: https://travis-ci.org/kintone/plugin-manifest-validator
-[deps-image]: https://img.shields.io/david/kintone/plugin-manifest-validator.svg
-[deps-url]: https://david-dm.org/kintone/plugin-manifest-validator
-[node-version]: https://img.shields.io/badge/Node.js%20support-v6,v8,v10-brightgreen.svg
-[license]: https://img.shields.io/npm/l/@kintone/plugin-manifest-validator.svg

--- a/packages/plugin-manifest-validator/package.json
+++ b/packages/plugin-manifest-validator/package.json
@@ -1,7 +1,10 @@
 {
   "name": "@kintone/plugin-manifest-validator",
   "version": "6.1.4",
-  "author": "Teppei Sato <teppeis@gmail.com>",
+  "author": {
+    "name": "Cybozu, Inc.",
+    "url": "https://cybozu.co.jp"
+  },
   "engines": {
     "node": ">=12"
   },

--- a/packages/plugin-packer/README.md
+++ b/packages/plugin-packer/README.md
@@ -1,9 +1,11 @@
 kintone-plugin-packer
 ====
 
-[kintone plugin package.sh](https://github.com/kintone-samples/plugin-samples) in JavaScript
-
 [![npm version](https://badge.fury.io/js/%40kintone%2Fplugin-packer.svg)](https://badge.fury.io/js/%40kintone%2Fplugin-packer)
+![Node.js version](https://img.shields.io/badge/dynamic/json.svg?url=https://raw.githubusercontent.com/kintone/js-sdk/master/packages/plugin-packer/package.json&label=node&query=$.engines.node&colorB=blue)
+![License](https://img.shields.io/npm/l/@kintone/plugin-packer.svg)
+
+[kintone plugin package.sh](https://github.com/kintone-samples/plugin-samples) in JavaScript
 
 It's written in pure JavaScript, so
 

--- a/packages/plugin-packer/package.json
+++ b/packages/plugin-packer/package.json
@@ -2,7 +2,10 @@
   "name": "@kintone/plugin-packer",
   "description": "Package your kintone plugin with pure JavaScript",
   "version": "5.0.27",
-  "author": "Teppei Sato <teppeis@gmail.com>",
+  "author": {
+    "name": "Cybozu, Inc.",
+    "url": "https://cybozu.co.jp"
+  },
   "engines": {
     "node": ">=12"
   },

--- a/packages/plugin-uploader/README.md
+++ b/packages/plugin-uploader/README.md
@@ -1,6 +1,8 @@
 # @kintone/plugin-uploader
 
 [![npm version](https://badge.fury.io/js/%40kintone%2Fplugin-uploader.svg)](https://badge.fury.io/js/%40kintone%2Fplugin-uploader)
+![Node.js version](https://img.shields.io/badge/dynamic/json.svg?url=https://raw.githubusercontent.com/kintone/js-sdk/master/packages/plugin-uploader/package.json&label=node&query=$.engines.node&colorB=blue)
+![License](https://img.shields.io/npm/l/@kintone/plugin-uploader.svg)
 
 A kintone plugin uploader using [puppeteer](https://github.com/GoogleChrome/puppeteer)
 

--- a/packages/profile-loader/README.md
+++ b/packages/profile-loader/README.md
@@ -1,5 +1,8 @@
 # `@kintone/profile-loader`
 
+![Node.js version](https://img.shields.io/badge/dynamic/json.svg?url=https://raw.githubusercontent.com/kintone/js-sdk/master/packages/profile-loader/package.json&label=node&query=$.engines.node&colorB=blue)
+![License](https://img.shields.io/badge/dynamic/json.svg?url=https://raw.githubusercontent.com/kintone/js-sdk/master/packages/profile-loader/package.json&label=license&query=$.license&colorB=green)
+
 A loader to retrive Kintone settings like `username`, `password`, `baseUrl`, and whatever you want.
 
 **THIS IS AN EXPERIMENTAL AND HAS BEEN PUBLISHED YET**

--- a/packages/rest-api-client/README.md
+++ b/packages/rest-api-client/README.md
@@ -1,6 +1,8 @@
 # kintone-rest-api-client
 
 [![npm version](https://badge.fury.io/js/%40kintone%2Frest-api-client.svg)](https://badge.fury.io/js/%40kintone%2Frest-api-client)
+![Node.js version](https://img.shields.io/badge/dynamic/json.svg?url=https://raw.githubusercontent.com/kintone/js-sdk/master/packages/rest-api-client/package.json&label=node&query=$.engines.node&colorB=blue)
+![License](https://img.shields.io/npm/l/@kintone/rest-api-client.svg)
 
 API client for Kintone REST API.
 It supports both browser environment (Kintone customization & plugin) and Node.js environment.

--- a/packages/webpack-plugin-kintone-plugin/README.md
+++ b/packages/webpack-plugin-kintone-plugin/README.md
@@ -1,6 +1,8 @@
 # webpack-plugin-kintone-plugin
 
 [![npm version](https://badge.fury.io/js/%40kintone%2Fwebpack-plugin-kintone-plugin.svg)](https://badge.fury.io/js/%40kintone%2Fwebpack-plugin-kintone-plugin)
+![Node.js version](https://img.shields.io/badge/dynamic/json.svg?url=https://raw.githubusercontent.com/kintone/js-sdk/master/packages/webpack-plugin-kintone-plugin/package.json&label=node&query=$.engines.node&colorB=blue)
+![License](https://img.shields.io/npm/l/@kintone/webpack-plugin-kintone-plugin.svg)
 
 A webpack plugin to create a plugin zip of Kintone.
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

The following points differ depending on package.
- `author` in package.json
- badge list in README.md

## What

Unify the above.


## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
