### PR TITLE
build: release packages on GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+
+name: release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  version:
+    name: Release packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+      - run: yarn install
+      - name: Release packages
+        run: yarn release --yes
+        env:
+          GIT_AUTHOR_NAME: "github-actions[bot]"
+          GIT_AUTHOR_EMAIL: "github-actions[bot]@users.noreply.github.com"
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,23 @@
+
+name: version
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  version:
+    name: Dry-run next release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+      - run: yarn install
+      - name: Generate next release (dry-run)
+        run: yarn run lerna version --conventional-commits --no-git-tag-version --no-push --yes
+      - name: Show CHANGELOG.md
+        run: git diff ./packages/*/CHANGELOG.md


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Because we don't want to release js-sdk packages from local machine anymore.

## What

<!-- What is a solution you want to add? -->

- [x] add `version` workflow which dry-run next release.
- [x] add `release` workflow which release packages.

The release sequence is as follows.

![ZLDDRzim3BthLn0-3DiXsJre0dGxh0EsIpTinu6M6LkrBHcYNBV_Vf8ZnvzPTp1WaOzVxv65oWZEnhZKl0WkbMxGOWqedR4_t6j5W1sngKdq9aY-ezBEVsGJG8Rw-XGPEaoH2I0nLkLAVwoHNSHTB1S3tDt15-NWaqKj2pYTX3JQMLF1vwy_YTszphxvh24iSVuDxw0Axz_6bkVAT4bCyD2cS2-TCfhdINwHPM_j4pp7__yE](https://user-images.githubusercontent.com/33759872/147216164-6d21e2f4-b0d4-4d1b-aa65-94357cff03d7.png)

## How to test

<!-- How can we test this pull request? -->

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
