### PR TITLE
chore(deps): update caniuse-lite

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,6 @@
     "prettier": "^2.5.1",
     "rimraf": "^3.0.2",
     "typescript": "^4.5.4"
-  }
+  },
+  "dependencies": {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4494,20 +4494,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001219:
-  version "1.0.30001228"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz#bfdc5942cd3326fa51ee0b42fbef4da9d492a7fa"
-  integrity sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==
-
-caniuse-lite@^1.0.30001274:
-  version "1.0.30001275"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001275.tgz#26f5076629fe4e52bbd245f9046ad7b90aafdf57"
-  integrity sha512-ihJVvj8RX0kn9GgP43HKhb5q9s2XQn4nEQhdldEJvZhCsuiB2XOq6fAMYQZaN6FPWfsr2qU0cdL0CSbETwbJAg==
-
-caniuse-lite@^1.0.30001280:
-  version "1.0.30001282"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz#38c781ee0a90ccfe1fe7fefd00e43f5ffdcb96fd"
-  integrity sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001274, caniuse-lite@^1.0.30001280:
+  version "1.0.30001298"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001298.tgz"
+  integrity sha512-AcKqikjMLlvghZL/vfTHorlQsLDhGRalYf1+GmWCf5SCMziSGjRYQW/JEksj14NaYHIR6KIhrFAy0HV5C25UzQ==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

caniuse-lite db is outdated.

```shell
$ yarn build
...
@kintone/rest-api-client: Browserslist: caniuse-lite is outdated. Please run:
@kintone/rest-api-client: npx browserslist@latest --update-db
@kintone/rest-api-client: Why you should do it regularly:
@kintone/rest-api-client: https://github.com/browserslist/browserslist#browsers-data-updating
...
```

## What

- [x] update caniuse-lite db

### Version changes
- new version: `1.0.30001298`
- old versions: `1.0.30001228`, `1.0.30001275`, `1.0.30001282`

### Target browser changes

```diff
Target browser changes:
- and_chr 95
+ and_chr 96
- and_ff 92
+ and_ff 95
- android 95
+ android 96
- chrome 93
- chrome 92
+ chrome 97
- edge 95
- edge 94
+ edge 97
+ edge 96
- firefox 93
- firefox 92
+ firefox 95
- ios_saf 15
+ ios_saf 15.2
+ ios_saf 15.0-15.1
- opera 80
- opera 79
+ opera 82
- safari 15
+ safari 15.2
```

## How to test

<!-- How can we test this pull request? -->

```shell
$ yarn install
$ yarn build
$ yarn lint && yarn test
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
