### PR TITLE
chore(deps): update js-base64 to v3.x

### DIFF
--- a/packages/rest-api-client/package.json
+++ b/packages/rest-api-client/package.json
@@ -62,7 +62,7 @@
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.1.3",
     "@types/core-js": "^2.5.5",
-    "@types/js-base64": "^2.3.2",
+    "@types/js-base64": "^3.0.0",
     "@types/qs": "^6.9.7",
     "rollup": "^2.61.1",
     "rollup-plugin-ecma-version-validator": "^0.1.6",
@@ -75,7 +75,7 @@
     "axios": "^0.24.0",
     "core-js": "^3.20.2",
     "form-data": "^4.0.0",
-    "js-base64": "^2.6.4",
+    "js-base64": "^3.7.2",
     "qs": "^6.10.2"
   },
   "exports": {

--- a/packages/rest-api-client/rollup.config.js
+++ b/packages/rest-api-client/rollup.config.js
@@ -31,18 +31,6 @@ export default defineConfig({
           "@babel/preset-env",
           {
             corejs: 3,
-            targets: {
-              // see kintone's supported browsers https://get.kintone.help/general/en/user/list_start/webbrowser.html
-              browsers: [
-                "IE 11",
-                "last 2 edge versions",
-                "last 2 firefox version",
-                "last 2 chrome versions",
-                "last 2 safari versions",
-                "iOS >= 11",
-                "last 2 and_chr versions",
-              ],
-            },
             useBuiltIns: "usage",
           },
         ],
@@ -56,6 +44,28 @@ export default defineConfig({
       preferBuiltins: false,
     }),
     commonjs({ extensions }),
+    babel({
+      babelHelpers: "bundled",
+      presets: [
+        [
+          "@babel/preset-env",
+          {
+            targets: {
+              // see kintone's supported browsers https://get.kintone.help/general/en/user/list_start/webbrowser.html
+              browsers: [
+                "IE 11",
+                "last 2 edge versions",
+                "last 2 firefox version",
+                "last 2 chrome versions",
+                "last 2 safari versions",
+                "iOS >= 11",
+                "last 2 and_chr versions",
+              ],
+            },
+          },
+        ],
+      ],
+    }),
     json(),
     replace({
       PACKAGE_VERSION: JSON.stringify(pkgJson.version),

--- a/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
@@ -3,6 +3,7 @@ import FormData from "form-data";
 import { injectPlatformDeps } from "../platform";
 import * as browserDeps from "../platform/browser";
 import os from "os";
+import { Base64 } from "js-base64";
 
 const packageJson = require("../../package.json");
 const nodeVersion = process.version;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3020,10 +3020,12 @@
     jest-diff "^27.0.0"
     pretty-format "^27.0.0"
 
-"@types/js-base64@^2.3.2":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@types/js-base64/-/js-base64-2.3.2.tgz#266be882b28b52649b1d34db9515e54c8ef783f2"
-  integrity sha512-iGjZEnheu9n53fhlU+QLovdKHsdwPJ79iammNM0opTEp18zcJ/nNAIthuMilJoDPNUQHoqRAJdDNI5rxHY4nkA==
+"@types/js-base64@^3.0.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/js-base64/-/js-base64-3.3.1.tgz#36c2d6dc126277ea28a4d0599d0cafbf547b51e6"
+  integrity sha512-Zw33oQNAvDdAN9b0IE5stH0y2MylYvtU7VVTKEJPxhyM2q57CVaNJhtJW258ah24NRtaiA23tptUmVn3dmTKpw==
+  dependencies:
+    js-base64 "*"
 
 "@types/json-schema@*", "@types/json-schema@^7.0.6":
   version "7.0.6"
@@ -8502,10 +8504,10 @@ jest@^27.4.7:
     import-local "^3.0.2"
     jest-cli "^27.4.7"
 
-js-base64@^2.6.4:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
-  integrity sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
+js-base64@*, js-base64@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.2.tgz#816d11d81a8aff241603d19ce5761e13e41d7745"
+  integrity sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

[js-base64 v3.x](https://github.com/dankogai/js-base64/tags) is released

## What

Update js-base64 to latest version.  The `yarn build` fails with the latest js-base64, so the generated script can include ES6 `const` and [ecma-version-validator](https://github.com/koba04/rollup-plugin-ecma-version-validator).  To prevent the issue, fix rollup config in rest-api-client as the following:
1. Transpile TypeScripts to ES6 by the babel plugin.
1. Resolve node modules by the node-resolve plugin.
1. Convert CommonJS modules to ES6 by the commonjs plugin
1. Transform ES6 to ES5 by the babel plugin.

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [X] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [X] Updated documentation if it is required.
- [X] Added tests if it is required.
- [X] Passed `yarn lint` and `yarn test` on the root directory.
