### PR TITLE
fix(data-loader): filter unsupported fields in Table when import CSV

### DIFF
--- a/packages/data-loader/src/parsers/parseCsv/__tests__/fixtures/unsupported_expected.json
+++ b/packages/data-loader/src/parsers/parseCsv/__tests__/fixtures/unsupported_expected.json
@@ -1,0 +1,52 @@
+[
+  {
+    "singleLineText": {
+      "value": "\"single line text\""
+    },
+    "subTable": {
+      "value": [
+        {
+          "id": "537306",
+          "value": {
+            "subTableText": {
+              "value": "text_line1"
+            }
+          }
+        },
+        {
+          "id": "537307",
+          "value": {
+            "subTableText": {
+              "value": "text_line2"
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "singleLineText": {
+      "value": "\"single line text\""
+    },
+    "subTable": {
+      "value": [
+        {
+          "id": "537308",
+          "value": {
+            "subTableText": {
+              "value": "text_line1"
+            }
+          }
+        },
+        {
+          "id": "537309",
+          "value": {
+            "subTableText": {
+              "value": "text_line2"
+            }
+          }
+        }
+      ]
+    }
+  }
+]

--- a/packages/data-loader/src/parsers/parseCsv/__tests__/fixtures/unsupported_fields.json
+++ b/packages/data-loader/src/parsers/parseCsv/__tests__/fixtures/unsupported_fields.json
@@ -1,0 +1,55 @@
+{
+  "revision": "29",
+  "properties": {
+    "singleLineText": {
+      "type": "SINGLE_LINE_TEXT",
+      "code": "singleLineText",
+      "label": "singleLineText",
+      "noLabel": false,
+      "required": false,
+      "minLength": "",
+      "maxLength": "",
+      "expression": "",
+      "hideExpression": false,
+      "unique": false,
+      "defaultValue": ""
+    },
+    "file": {
+      "type": "FILE",
+      "code": "file",
+      "label": "file",
+      "noLabel": false,
+      "required": false,
+      "thumbnailSize": "150"
+    },
+    "subTable": {
+      "type": "SUBTABLE",
+      "code": "subTable",
+      "noLabel": false,
+      "label": "subTable",
+      "fields": {
+        "subTableText": {
+          "type": "SINGLE_LINE_TEXT",
+          "code": "subTableText",
+          "label": "subTableText",
+          "noLabel": false,
+          "required": false,
+          "minLength": "",
+          "maxLength": "",
+          "expression": "",
+          "hideExpression": false,
+          "unique": false,
+          "defaultValue": ""
+        },
+        "subTableFile": {
+          "type": "FILE",
+          "code": "subTableFile",
+          "label": "subTableFile",
+          "noLabel": false,
+          "required": false,
+          "thumbnailSize": "150"
+        }
+      }
+    }
+  }
+}

--- a/packages/data-loader/src/parsers/parseCsv/__tests__/parseCsv.test.ts
+++ b/packages/data-loader/src/parsers/parseCsv/__tests__/parseCsv.test.ts
@@ -4,6 +4,8 @@ const expectedJson: KintoneRecordForResponse[] = require("./fixtures/expected.js
 const fieldsJson: FieldsJson = require("./fixtures/fields.json");
 const subtableExpectedJson: KintoneRecordForResponse[] = require("./fixtures/subtable_expected.json");
 const subtableFieldsJson: FieldsJson = require("./fixtures/subtable_fields.json");
+const unsupportedExpectedJson: KintoneRecordForResponse[] = require("./fixtures/unsupported_expected.json");
+const unsupportedFieldsJson: FieldsJson = require("./fixtures/unsupported_fields.json");
 
 describe("parseCsv", () => {
   it("should convert csv string to JSON correctly", () => {
@@ -35,5 +37,17 @@ text","2021-02-10T06:14:00Z","""sample2""","16","""sample3""
 sample4"
 `;
     expect(parseCsv(csv, subtableFieldsJson)).toEqual(subtableExpectedJson);
+  });
+  it("should convert unsupported fields included csv string to JSON correctly", () => {
+    const csv = `
+"*","singleLineText","file","subTable","subTableText","subTableFile"
+"*","""single line text""","file-9/test.txt\nfile-9/test (1).txt","537306","text_line1","file-9-0/test.txt\nfile-9-0/test (1).txt"
+"","""single line text""","file-9/test.txt\nfile-9/test (1).txt","537307","text_line2","file-9-1/test.txt\nfile-9-1/test (1).txt"
+"*","""single line text""","file-10/test.txt\nfile-10/test (1).txt","537308","text_line1","file-10-0/test.txt\nfile-10-0/test (1).txt"
+"","""single line text""","file-10/test.txt\nfile-10/test (1).txt","537309","text_line2","file-10-1/test.txt\nfile-10-1/test (1).txt"
+`;
+    expect(parseCsv(csv, unsupportedFieldsJson)).toEqual(
+      unsupportedExpectedJson
+    );
   });
 });

--- a/packages/data-loader/src/parsers/parseCsv/extractSubtableFieldsValue.ts
+++ b/packages/data-loader/src/parsers/parseCsv/extractSubtableFieldsValue.ts
@@ -1,6 +1,7 @@
 import { convertToKintoneRecordFormatValue } from "./convertToKintoneRecordFormatValue";
 import { CsvRows, FieldProperties, FieldsJson } from "../../types/kintone";
 import { KintoneFormFieldProperty } from "@kintone/rest-api-client";
+import { isImportSupportedFieldType } from "./isImportSupportedFieldType";
 
 type InSubtableFieldProperty = Record<
   string,
@@ -48,22 +49,24 @@ const buildSubtableValue = (
     .map((row) => {
       return {
         id: row[subtableFieldProperty.code],
-        value: Object.values(
-          subtableFieldProperty.fields
-        ).reduce<InSubtableFieldValue>(
-          (inSubtableFieldValue, inSubtableFieldProperty) => {
-            return {
-              ...inSubtableFieldValue,
-              [inSubtableFieldProperty.code]: {
-                value: convertToKintoneRecordFormatValue({
-                  fieldType: inSubtableFieldProperty.type,
-                  value: row[inSubtableFieldProperty.code],
-                }),
-              },
-            };
-          },
-          {}
-        ),
+        value: Object.values(subtableFieldProperty.fields)
+          .filter((inSubtableFieldProperty) =>
+            isImportSupportedFieldType(inSubtableFieldProperty.type)
+          )
+          .reduce<InSubtableFieldValue>(
+            (inSubtableFieldValue, inSubtableFieldProperty) => {
+              return {
+                ...inSubtableFieldValue,
+                [inSubtableFieldProperty.code]: {
+                  value: convertToKintoneRecordFormatValue({
+                    fieldType: inSubtableFieldProperty.type,
+                    value: row[inSubtableFieldProperty.code],
+                  }),
+                },
+              };
+            },
+            {}
+          ),
       };
     });
 };


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

When import CSV, unsupported fields are filtered, but fields in Table field pass through.

## What

<!-- What is a solution you want to add? -->

- [x] filter unsupported fields in Table field when import CSV
- [x] add test

## How to test

<!-- How can we test this pull request? -->

```sh
$ yarn build
$ yarn test
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
