### PR TITLE
fix(data-loader): export csv correctly when Table value is empty array

### DIFF
--- a/packages/data-loader/src/printers/printAsCsv/__tests__/convertKintoneRecordsToCsv.test.ts
+++ b/packages/data-loader/src/printers/printAsCsv/__tests__/convertKintoneRecordsToCsv.test.ts
@@ -9,6 +9,7 @@ const fileWithoutAttachmentsDirRecords: DataLoaderRecord[] = require("./fixtures
 const fileFieldsJson: FieldsJson = require("./fixtures/file_fields.json");
 const subtableRecords: DataLoaderRecord[] = require("./fixtures/subtable_input.json");
 const subtableWithoutAttachmentsDirRecords: DataLoaderRecord[] = require("./fixtures/subtable_input_without_attachments_dir.json");
+const subtableWithEmptyTable: DataLoaderRecord[] = require("./fixtures/subtable_input_with_empty_table.json");
 const subtableFieldsJson: FieldsJson = require("./fixtures/subtable_fields.json");
 
 describe("convertKintoneRecordsToCsv", () => {
@@ -95,6 +96,20 @@ sample4"
     expect(
       convertRecordsToCsv({
         records: subtableWithoutAttachmentsDirRecords,
+        fieldProperties: subtableFieldsJson.properties,
+      })
+    ).toBe(expectedCsv);
+  });
+  it("should convert kintone records to csv string correctly when SUBTABLE value is an empty array", () => {
+    const expectedCsv = `"*","recordNumber","updatedTime","dropDown","creator","subTable","subTableText","subTableCheckbox","subTableFile","modifier","richText","singleLineText","number","radioButton","multiLineText","createdTime","checkBox","calc","multiSelect"
+*,"9","2021-02-16T02:43:00Z","sample1","username",,,,,"username","<div><div>rich text editor<br /></div></div><div>rich text editor<br /></div><div>rich text editor<br /></div>","""single line text""","8","sample2","multi
+line
+text","2021-02-10T06:14:00Z","""sample2""","16","""sample3""
+sample4"
+`;
+    expect(
+      convertRecordsToCsv({
+        records: subtableWithEmptyTable,
         fieldProperties: subtableFieldsJson.properties,
       })
     ).toBe(expectedCsv);

--- a/packages/data-loader/src/printers/printAsCsv/__tests__/fixtures/subtable_input_with_empty_table.json
+++ b/packages/data-loader/src/printers/printAsCsv/__tests__/fixtures/subtable_input_with_empty_table.json
@@ -1,0 +1,78 @@
+[
+  {
+    "recordNumber": {
+      "type": "RECORD_NUMBER",
+      "value": "9"
+    },
+    "updatedTime": {
+      "type": "UPDATED_TIME",
+      "value": "2021-02-16T02:43:00Z"
+    },
+    "dropDown": {
+      "type": "DROP_DOWN",
+      "value": "sample1"
+    },
+    "creator": {
+      "type": "CREATOR",
+      "value": {
+        "code": "username",
+        "name": "username"
+      }
+    },
+    "modifier": {
+      "type": "MODIFIER",
+      "value": {
+        "code": "username",
+        "name": "username"
+      }
+    },
+    "$revision": {
+      "type": "__REVISION__",
+      "value": "7"
+    },
+    "richText": {
+      "type": "RICH_TEXT",
+      "value": "<div><div>rich text editor<br /></div></div><div>rich text editor<br /></div><div>rich text editor<br /></div>"
+    },
+    "singleLineText": {
+      "type": "SINGLE_LINE_TEXT",
+      "value": "\"single line text\""
+    },
+    "number": {
+      "type": "NUMBER",
+      "value": "8"
+    },
+    "radioButton": {
+      "type": "RADIO_BUTTON",
+      "value": "sample2"
+    },
+    "multiLineText": {
+      "type": "MULTI_LINE_TEXT",
+      "value": "multi\nline\ntext"
+    },
+    "createdTime": {
+      "type": "CREATED_TIME",
+      "value": "2021-02-10T06:14:00Z"
+    },
+    "checkBox": {
+      "type": "CHECK_BOX",
+      "value": ["\"sample2\""]
+    },
+    "calc": {
+      "type": "CALC",
+      "value": "16"
+    },
+    "multiSelect": {
+      "type": "MULTI_SELECT",
+      "value": ["\"sample3\"", "sample4"]
+    },
+    "$id": {
+      "type": "__ID__",
+      "value": "9"
+    },
+    "subTable": {
+      "type": "SUBTABLE",
+      "value": []
+    }
+  }
+]

--- a/packages/data-loader/src/printers/printAsCsv/convertKintoneRecordsToCsv.ts
+++ b/packages/data-loader/src/printers/printAsCsv/convertKintoneRecordsToCsv.ts
@@ -134,25 +134,27 @@ const buildSubTableRowObjects = ({
 }) => {
   const rowObjects = subtableFieldCodes.reduce<RowObject[]>(
     (ret, subtableFieldCode) => {
-      return ret.concat(
-        recordObject[subtableFieldCode].map(
-          (field: { [k: string]: string }) => ({
-            ...primaryRowObject,
-            ...Object.keys(field).reduce<Record<string, string>>(
-              (rowObject, fieldCode) => {
-                return {
-                  ...rowObject,
-                  // NOTE: If fieldCode is `id`, use field code of subtable itself
-                  // to avoid conflicts between each subtable.
-                  [fieldCode === "id" ? subtableFieldCode : fieldCode]:
-                    field[fieldCode],
-                };
-              },
-              {}
-            ),
-          })
-        )
-      );
+      return recordObject[subtableFieldCode].length === 0
+        ? [primaryRowObject]
+        : ret.concat(
+            recordObject[subtableFieldCode].map(
+              (field: { [k: string]: string }) => ({
+                ...primaryRowObject,
+                ...Object.keys(field).reduce<Record<string, string>>(
+                  (rowObject, fieldCode) => {
+                    return {
+                      ...rowObject,
+                      // NOTE: If fieldCode is `id`, use field code of subtable itself
+                      // to avoid conflicts between each subtable.
+                      [fieldCode === "id" ? subtableFieldCode : fieldCode]:
+                        field[fieldCode],
+                    };
+                  },
+                  {}
+                ),
+              })
+            )
+          );
     },
     []
   );


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

When a Table's value is an empty array, exporting in csv format results in an empty row, even though there're values in fields outside the Table that I want to export.
This happens as Table value was always supposed to be non-empty.
※Table with value of an empty array is rare but not impossible. One way of reproducing this would be adding a Table to a kintone APP with existing records - the Table value for those records would be `[]`.


## What

<!-- What is a solution you want to add? -->

- [x] support CSV export when Table value is an empty array
- [x] fix tests

## How to test

<!-- How can we test this pull request? -->

```sh
$ yarn build
$ yarn lint && yarn test
```

```sh
$ yarn build
$ cd packages/data-loader
$ node lib/main.js export --format="csv" --app <appId>
```


## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
