### PR TITLE
feat(data-loader): support import attachment field with subtable 

### DIFF
--- a/packages/data-loader/README.md
+++ b/packages/data-loader/README.md
@@ -8,7 +8,6 @@ A kintone record importer and exporter.
 
 **THIS IS EXPERIMENTAL, AND THESE FEATURES ARE NOT SUPPORTED YET.**
 
-- Import Attachment field inside Table
 - Update records when importing
 
 We plan to support them in the future release.

--- a/packages/data-loader/src/kintone/__tests__/fixtures/can_upload_files_in_subtable.ts
+++ b/packages/data-loader/src/kintone/__tests__/fixtures/can_upload_files_in_subtable.ts
@@ -1,0 +1,89 @@
+import { DataLoaderRecordForParameter } from "../../../types/data-loader";
+import { KintoneFormFieldProperty } from "@kintone/rest-api-client";
+import path from "path";
+import { KintoneRecordForParameter } from "../../../types/kintone";
+
+export const input: DataLoaderRecordForParameter[] = [
+  {
+    singleLineText: {
+      value: "value1",
+    },
+    table: {
+      value: [
+        {
+          value: {
+            attachmentInSubtable: {
+              value: [
+                {
+                  localFilePath: path.join("attachment-1", "test.txt"),
+                },
+                {
+                  localFilePath: path.join("attachment-1", "test (1).txt"),
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  },
+];
+
+export const expected: KintoneRecordForParameter[] = [
+  {
+    singleLineText: {
+      value: "value1",
+    },
+    table: {
+      value: [
+        {
+          id: undefined,
+          value: {
+            attachmentInSubtable: {
+              value: [
+                {
+                  fileKey: "abcde",
+                },
+                {
+                  fileKey: "fghij",
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  },
+];
+
+export const properties: Record<string, KintoneFormFieldProperty.OneOf> = {
+  singleLineText: {
+    type: "SINGLE_LINE_TEXT",
+    code: "singleLineText",
+    label: "singleLineText",
+    noLabel: false,
+    required: false,
+    minLength: "",
+    maxLength: "",
+    expression: "",
+    hideExpression: false,
+    unique: false,
+    defaultValue: "",
+  },
+  table: {
+    type: "SUBTABLE",
+    code: "table",
+    noLabel: false,
+    label: "table",
+    fields: {
+      attachmentInSubtable: {
+        type: "FILE",
+        code: "attachmentInSubtable",
+        label: "attachmentInSubtable",
+        noLabel: false,
+        required: false,
+        thumbnailSize: "150",
+      },
+    },
+  },
+};

--- a/packages/data-loader/src/kintone/upload.ts
+++ b/packages/data-loader/src/kintone/upload.ts
@@ -3,10 +3,7 @@ import {
   KintoneFormFieldProperty,
   KintoneRestAPIClient,
 } from "@kintone/rest-api-client";
-import {
-  DataLoaderFields,
-  DataLoaderRecordForParameter,
-} from "../types/data-loader";
+import { DataLoaderRecordForParameter } from "../types/data-loader";
 import path from "path";
 
 const CHUNK_LENGTH = 100;

--- a/packages/data-loader/src/kintone/upload.ts
+++ b/packages/data-loader/src/kintone/upload.ts
@@ -152,7 +152,6 @@ const fieldProcessor: (
         newRows.push({ id: row.id, value: fieldsInRow });
       }
       return {
-        type: "SUBTABLE",
         value: newRows,
       };
     }

--- a/packages/data-loader/src/parsers/parseCsv/isImportSupportedFieldType.ts
+++ b/packages/data-loader/src/parsers/parseCsv/isImportSupportedFieldType.ts
@@ -41,6 +41,7 @@ export const isImportSupportedFieldTypeInSubtable = (
     "USER_SELECT",
     "ORGANIZATION_SELECT",
     "GROUP_SELECT",
+    "FILE",
   ];
   return fieldTypes.includes(fieldType);
 };


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature, and why does it make sense for the package? -->

File upload and import are vital features for Data-loader users.


## What

<!-- What is a solution you want to add? -->

To upload and import local files by including a local file path in the original CSV/JSON file.


## How to test

<!-- How can we test this pull request? -->

```
$ yarn build
$ yarn lint && yarn test
```
```
$ yarn build
$ cd packages/data-loader
$ node lib/main.js import --app <appId> --file-path <path-to-csv-file>
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
