### PR TITLE
chore: disable renovate rate limit

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "github>cybozu/renovate-config"
+    "github>cybozu/renovate-config",
+    "prConcurrentLimitNone"
   ],
   "ignorePaths": [
     "**/node_modules/**",


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Because we hold renovate PRs requiring approval and auto-mergeable PRs are rate limited.

## What

<!-- What is a solution you want to add? -->

- [x] Remove limit for open PRs at any time
  - extends [:prConcurrentLimitNone](https://docs.renovatebot.com/presets-default/#prconcurrentlimitnone)

## How to test

<!-- How can we test this pull request? -->

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
