### PR TITLE
fix(rest-api-client): remove trailing slash from baseUrl internally

### DIFF
--- a/packages/rest-api-client/src/KintoneRestAPIClient.ts
+++ b/packages/rest-api-client/src/KintoneRestAPIClient.ts
@@ -66,7 +66,9 @@ export class KintoneRestAPIClient {
   constructor(options: Options = {}) {
     validateOptions(options);
 
-    this.baseUrl = platformDeps.buildBaseUrl(options.baseUrl);
+    this.baseUrl = platformDeps
+      .buildBaseUrl(options.baseUrl)
+      .replace(/\/+$/, ""); // Remove trailing slash
 
     const auth = buildDiscriminatedAuth(options.auth ?? {});
     const requestConfigBuilder = new KintoneRequestConfigBuilder({

--- a/packages/rest-api-client/src/__tests__/KintoneRestAPIClient.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneRestAPIClient.test.ts
@@ -57,19 +57,26 @@ describe("KintoneRestAPIClient", () => {
 
     describe("Header", () => {
       const baseUrl = "https://example.com";
+      const USERNAME = "user";
+      const PASSWORD = "password";
+      const auth = {
+        username: USERNAME,
+        password: PASSWORD,
+      };
       it("should use a location object in browser environment if baseUrl param is not specified", () => {
         injectPlatformDeps(browserDeps);
         const client = new KintoneRestAPIClient();
         expect(client.getBaseUrl()).toBe("https://example.com");
       });
-
+      it("should remove trailing slash from baseUrl", () => {
+        const baseUrlWithTrailingSlash = "https://example.com/";
+        const client = new KintoneRestAPIClient({
+          baseUrl: baseUrlWithTrailingSlash,
+          auth,
+        });
+        expect(client.getBaseUrl()).toBe("https://example.com");
+      });
       it("should raise an error in Node.js environment if baseUrl param is not specified", () => {
-        const USERNAME = "user";
-        const PASSWORD = "password";
-        const auth = {
-          username: USERNAME,
-          password: PASSWORD,
-        };
         expect(() => new KintoneRestAPIClient({ auth })).toThrow(
           "in Node.js environment, baseUrl is required"
         );


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

When baseUrl with a trailing slash is given, generated request URL has a duplicated slash.
It causes an error when requesting to kintone.com environment.

e.g. with record.json...

- baseUrl: `https://example.kintone.com` => request URL: `https://example.kintone.com//k/v1/record.json` 🙆‍♂️ 
- baseUrl: `https://example.kintone.com/` =>  request URL: `https://example.kintone.com//k/v1/record.json` 🙅 

## What

<!-- What is a solution you want to add? -->

In this PR, remove the trailing slash from baseUrl internally.
Users still can use baseUrl with a trailing slash.

- [x] remove trailing slash from baseUrl in `KintoneRestApiClient` constructor

## How to test

<!-- How can we test this pull request? -->

```
$ yarn build
$ yarn lint && yarn test
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
