### PR TITLE
fix(examples): Run examples by ts-node

### DIFF
--- a/examples/rest-api-client-demo/package.json
+++ b/examples/rest-api-client-demo/package.json
@@ -24,7 +24,7 @@
     "lint": "run-p -l lint:*",
     "deploy": "rimraf scripts/dist && run-s webpack upload",
     "upload": "kintone-customize-uploader customize-manifest.json",
-    "run-script": "node dist/run-node.js",
+    "run-script": "ts-node src/run-node.ts",
     "webpack": "webpack"
   },
   "bugs": {
@@ -42,6 +42,7 @@
     "@kintone/customize-uploader": "^5.0.25",
     "@types/yargs": "^17.0.10",
     "ts-loader": "^9.3.0",
+    "ts-node": "^10.7.0",
     "webpack": "^5.72.0",
     "webpack-cli": "4.9.2"
   }

--- a/packages/create-plugin/package.json
+++ b/packages/create-plugin/package.json
@@ -34,8 +34,7 @@
     "@types/lodash": "^4.14.182",
     "@types/node-rsa": "^1.1.1",
     "@types/rimraf": "^3.0.2",
-    "cross-env": "^7.0.3",
-    "ts-node": "^10.7.0"
+    "cross-env": "^7.0.3"
   },
   "files": [
     "bin",

--- a/packages/customize-uploader/package.json
+++ b/packages/customize-uploader/package.json
@@ -42,8 +42,7 @@
   "devDependencies": {
     "@types/inquirer": "8.2.1",
     "@types/mkdirp": "^1.0.2",
-    "@types/rimraf": "^3.0.2",
-    "ts-node": "^10.7.0"
+    "@types/rimraf": "^3.0.2"
   },
   "dependencies": {
     "@kintone/rest-api-client": "^2.0.38",

--- a/packages/webpack-plugin-kintone-plugin/package.json
+++ b/packages/webpack-plugin-kintone-plugin/package.json
@@ -44,7 +44,6 @@
     "@types/rimraf": "^3.0.2",
     "adm-zip": "^0.5.9",
     "rimraf": "^3.0.2",
-    "ts-node": "^10.7.0",
     "webpack": "^5.72.0",
     "webpack-cli": "4.9.2"
   },


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

`yarn run-script` in examples does not work.

<!-- Why do you want the feature and why does it make sense for the package? -->


## What

Run examples by ts-node

<!-- What is a solution you want to add? -->


## How to test

Run the following in `examples/rest-api-client-demo` directory:

```
yarn run-script record getRecord
```

<!-- How can we test this pull request? -->

## Checklist

- [X] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [X] Updated documentation if it is required.
- [X] Added tests if it is required.
- [X] Passed `yarn lint` and `yarn test` on the root directory.
