### PR TITLE
chore!: drop Node v12 support because of the EOL (BREAKING CHANGE)

### DIFF
--- a/.github/workflows/compile-data-loader-binary.yml
+++ b/.github/workflows/compile-data-loader-binary.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 14.x
+      - name: Use Node.js 16.x
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
       - name: yarn install, and yarn workspace @kintone/data-loader pkg
         run: |
           yarn install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,14 +10,14 @@ on:
 
 jobs:
   build:
-    name: Node.js ubuntu-latest 14.x
+    name: Node.js ubuntu-latest 16.x
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js 14.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v3
       with:
-        node-version: 14.x
+        node-version: 16.x
     - name: yarn install, and yarn lint
       run: |
         yarn install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,9 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        # TODO: add 18.x after vercel/pkg supports
+        # https://github.com/vercel/pkg/discussions/1628
+        node-version: [14.x, 16.x]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/yamory.yml
+++ b/.github/workflows/yamory.yml
@@ -8,14 +8,14 @@ on:
       - yamory-*
 jobs:
   build:
-    name: Node.js ubuntu-latest 14.x
+    name: Node.js ubuntu-latest 16.x
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js 14.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v3
       with:
-        node-version: 14.x
+        node-version: 16.x
     - name: run Yamory
       run: |
         ls -1 -d packages/*/ | xargs -I {} bash -c "$(curl -sSf -L https://localscanner.yamory.io/script/yarn)" --  --manifest {}/package.json

--- a/examples/rest-api-client-demo/package.json
+++ b/examples/rest-api-client-demo/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/kintone/js-sdk/issues"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "dependencies": {
     "@kintone/profile-loader": "^2.0.7",

--- a/packages/create-plugin/package.json
+++ b/packages/create-plugin/package.json
@@ -8,7 +8,7 @@
   },
   "main": "dist/src/index.js",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "repository": {
     "type": "git",

--- a/packages/customize-uploader/package.json
+++ b/packages/customize-uploader/package.json
@@ -7,7 +7,7 @@
   },
   "main": "dist/index.js",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "scripts": {
     "prebuild": "yarn clean",

--- a/packages/data-loader/package.json
+++ b/packages/data-loader/package.json
@@ -47,7 +47,7 @@
   },
   "homepage": "https://github.com/kintone/js-sdk/tree/master/packages/data-loader#readme",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "devDependencies": {
     "@types/yargs": "^17.0.10",

--- a/packages/dts-gen/package.json
+++ b/packages/dts-gen/package.json
@@ -21,7 +21,7 @@
     "build:integration": "webpack --mode development --config webpack.config.js"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "author": {
     "name": "Cybozu, Inc.",

--- a/packages/plugin-manifest-validator/package.json
+++ b/packages/plugin-manifest-validator/package.json
@@ -6,7 +6,7 @@
     "url": "https://cybozu.co.jp"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "main": "dist/src/index.js",
   "files": [

--- a/packages/plugin-packer/package.json
+++ b/packages/plugin-packer/package.json
@@ -7,7 +7,7 @@
     "url": "https://cybozu.co.jp"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "main": "dist/index.js",
   "bin": {

--- a/packages/plugin-uploader/package.json
+++ b/packages/plugin-uploader/package.json
@@ -7,7 +7,7 @@
   },
   "main": "dist/index.js",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "scripts": {
     "start": "yarn build --watch",

--- a/packages/profile-loader/package.json
+++ b/packages/profile-loader/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/kintone/js-sdk/tree/master/packages/profile-loader#readme",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "scripts": {
     "prebuild": "yarn clean",

--- a/packages/rest-api-client/package.json
+++ b/packages/rest-api-client/package.json
@@ -54,7 +54,7 @@
   },
   "homepage": "https://github.com/kintone/js-sdk/tree/master/packages/rest-api-client#readme",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "devDependencies": {
     "@rollup/plugin-babel": "^5.3.1",

--- a/packages/webpack-plugin-kintone-plugin/package.json
+++ b/packages/webpack-plugin-kintone-plugin/package.json
@@ -4,7 +4,7 @@
   "description": "A webpack plugin to generate a plugin zip",
   "main": "dist/index.js",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "scripts": {
     "start": "yarn build --watch",


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Node v12 has been in EOL since April 30th.

## What

<!-- What is a solution you want to add? -->

- [x] drop Node v12 from the `engines` of each package.
  - from this PR, the oldest supported version is v14.
- [x] update Node version in CI ( [12, 14, 16] -> [14, 16])

## How to test

<!-- How can we test this pull request? -->

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
