### PR TITLE
chore(plugin-packer): do not use deprecated api

### DIFF
--- a/packages/plugin-packer/package.json
+++ b/packages/plugin-packer/package.json
@@ -50,6 +50,7 @@
     "yazl": "^2.5.1"
   },
   "devDependencies": {
+    "@reduxjs/toolkit": "^1.8.1",
     "@types/debug": "^4.1.7",
     "@types/stream-buffers": "^3.0.4",
     "@types/yauzl": "^2.10.0",

--- a/packages/plugin-packer/site/index.js
+++ b/packages/plugin-packer/site/index.js
@@ -2,7 +2,7 @@
 
 require("setimmediate"); // polyfill
 
-const { createStore, applyMiddleware } = require("redux");
+const { configureStore } = require("@reduxjs/toolkit");
 const thunk = require("redux-thunk").default;
 const logger = require("redux-logger").default;
 
@@ -84,7 +84,10 @@ if (process.env.NODE_ENV !== "production") {
   middlewares.push(logger);
 }
 
-const store = createStore(reducer, applyMiddleware(...middlewares));
+const store = configureStore({
+  reducer,
+  middleware: middlewares,
+});
 
 store.subscribe(() => {
   view.render(store.getState());

--- a/yarn.lock
+++ b/yarn.lock
@@ -3017,6 +3017,16 @@
   dependencies:
     "@octokit/openapi-types" "^5.2.1"
 
+"@reduxjs/toolkit@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.8.1.tgz#94ee1981b8cf9227cda40163a04704a9544c9a9f"
+  integrity sha512-Q6mzbTpO9nOYRnkwpDlFOAbQnd3g7zj7CtHAZWz5SzE5lcV97Tf8f3SzOO8BoPOMYBFgfZaqTUZqgGu+a0+Fng==
+  dependencies:
+    immer "^9.0.7"
+    redux "^4.1.2"
+    redux-thunk "^2.4.1"
+    reselect "^4.1.5"
+
 "@rollup/plugin-babel@^5.3.1":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz#04bc0608f4aa4b2e4b1aebf284344d0f68fda283"
@@ -7732,6 +7742,11 @@ ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
+immer@^9.0.7:
+  version "9.0.14"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.14.tgz#e05b83b63999d26382bb71676c9d827831248a48"
+  integrity sha512-ubBeqQutOSLIFCUBN03jGeOS6a3DoYlSYwYJTa+gSKEZKU5redJIqkIdZ3JVv/4RZpfcXdAWH5zCNLWPRv2WDw==
+
 import-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-3.0.0.tgz#20845547718015126ea9b3676b7592fb8bd4cf92"
@@ -11661,7 +11676,7 @@ redux-thunk@^2.4.1:
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.1.tgz#0dd8042cf47868f4b29699941de03c9301a75714"
   integrity sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==
 
-redux@^4.2.0:
+redux@^4.1.2, redux@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.0.tgz#46f10d6e29b6666df758780437651eeb2b969f13"
   integrity sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==
@@ -11825,6 +11840,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+reselect@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.5.tgz#852c361247198da6756d07d9296c2b51eddb79f6"
+  integrity sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

close #1492 

<!-- Why do you want the feature and why does it make sense for the package? -->


## What

Replace deprecated `createStore` with [`configureStore`](https://redux-toolkit.js.org/api/configureStore) provided by Redux Toolkit.
<!-- What is a solution you want to add? -->


## How to test

Run plugin-packer debug server by the following:
```
yarn workspace @kintone/plugin-packer start
```

then create a plugin on the site.

<!-- How can we test this pull request? -->

## Checklist

- [X] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [X] Updated documentation if it is required.
- [X] Added tests if it is required.
- [X] Passed `yarn lint` and `yarn test` on the root directory.
