### PR TITLE
ci: fix version bumps of `release` workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          # fetch all commits and tags (https://github.com/lerna/lerna/issues/2542)
+          fetch-depth: "0"
       - name: Use Node.js 16.x
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          # fetch all commits and tags (https://github.com/lerna/lerna/issues/2542)
+          fetch-depth: "0"
       - name: Use Node.js 16.x
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

When we release packages with release workflow, all packages have version bumps even if no changes.

workflow: https://github.com/kintone/js-sdk/actions/workflows/release.yml
log: https://github.com/kintone/js-sdk/runs/4849837084?check_suite_focus=true

Maybe it's because `actions/checkout@v2`fetches only the latest commit by default (lerna/lerna#2542 ).

## What

<!-- What is a solution you want to add? -->

fix it.

## How to test

<!-- How can we test this pull request? -->

At the following commit, only the plugin-uploader has not been changed since the last release.
commit: https://github.com/kintone/js-sdk/tree/16734db15cb5ec56a8b86f2047a0b099af9bbac6/packages

Then the result of the `version` workflow is as follows.
plugin-uploader does not have version bumps.
version workflow: https://github.com/kintone/js-sdk/runs/6506285728?check_suite_focus=true
```
Changes:
 - @kintone/rest-api-client-demo: 3.0.0 => 3.0.1 (private)
 - @kintone/create-plugin: 5.0.0 => 5.0.1
 - @kintone/customize-uploader: 6.0.0 => 6.0.1
 - @kintone/data-loader: 0.10.0 => 0.10.1
 - @kintone/dts-gen: 6.0.0 => 6.0.1
 - @kintone/plugin-manifest-validator: 7.0.0 => 7.0.1
 - @kintone/plugin-packer: 6.0.0 => 6.0.1
 - @kintone/profile-loader: 3.0.0 => 3.0.1 (private)
 - @kintone/rest-api-client: 3.0.0 => 3.1.0
 - @kintone/webpack-plugin-kintone-plugin: 6.0.0 => 6.0.1
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
