### PR TITLE
ci: add Node v18 to `test` workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        # TODO: add 18.x after vercel/pkg supports
-        # https://github.com/vercel/pkg/discussions/1628
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [ubuntu-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

vercel/pkg supports Node v18 on 5.7.0.
https://github.com/vercel/pkg/releases/tag/5.7.0

## What

<!-- What is a solution you want to add? -->

- [x] add Node v18 environment to `test` workflow

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
