### PR TITLE
fix(rest-api-client): throw an error if `location` is undefined on browser

### DIFF
--- a/packages/rest-api-client/src/platform/browser.ts
+++ b/packages/rest-api-client/src/platform/browser.ts
@@ -49,7 +49,7 @@ export const buildBaseUrl = (baseUrl?: string) => {
   }
 
   if (location === undefined) {
-    throw new Error("in this environment, baseUrl is required");
+    throw new Error("The baseUrl parameter is required for this environment");
   }
 
   const { host, protocol } = location;

--- a/packages/rest-api-client/src/platform/browser.ts
+++ b/packages/rest-api-client/src/platform/browser.ts
@@ -48,8 +48,11 @@ export const buildBaseUrl = (baseUrl?: string) => {
     return baseUrl;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const { host, protocol } = location!;
+  if (location === undefined) {
+    throw new Error("in this environment, baseUrl is required");
+  }
+
+  const { host, protocol } = location;
 
   return `${protocol}//${host}`;
 };


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

fixes https://github.com/kintone/js-sdk/issues/934

## What

<!-- What is a solution you want to add? -->

- [x] throw error if `location` is not defined on browser environments

## How to test

<!-- How can we test this pull request? -->

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
