### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Upload macos binary file
         if: "steps.version_after_release.outputs.data-loader == steps.version_before_release.outputs.data-loader"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload \
           "@kintone/data-loader@${{ steps.version_after_release.outputs.data-loader }}" \
@@ -51,7 +51,7 @@ jobs:
       - name: Upload linux binary file
         if: "steps.version_after_release.outputs.data-loader == steps.version_before_release.outputs.data-loader"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload \
           "@kintone/data-loader@${{ steps.version_after_release.outputs.data-loader }}" \
@@ -59,7 +59,7 @@ jobs:
       - name: Upload win binary file
         if: "steps.version_after_release.outputs.data-loader == steps.version_before_release.outputs.data-loader"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload \
           "@kintone/data-loader@${{ steps.version_after_release.outputs.data-loader }}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,9 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
       - name: Configure npm user
-        run: npm config set '//registry.npmjs.org/:_authToken=${NPM_TOKEN}'
+        run: npm config set "//registry.npmjs.org/:_authToken=${NPM_TOKEN}"
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Store data-loader version before release
         run: echo "::set-output name=data-loader::$(jq -r '.version' ./packages/data-loader/package.json)"
         id: version_before_release


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Release workflow has failed with the following error.

```
error An unexpected error occurred: "Failed to replace env in config: ${NPM_TOKEN}".
```

It's because the `NPM_TOKEN` env variable does not exist on the step.

https://github.com/kintone/js-sdk/actions/workflows/release.yml

## What

<!-- What is a solution you want to add? -->

- extract `NPM_TOKEN` on npm config step.
- replace `GITHUB_TOKEN` to `GH_TOKEN`

## How to test

<!-- How can we test this pull request? -->

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
