### PR TITLE
fix(create-plugin): fix generation of the wepack.config.js of the modern template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 *.tsbuildinfo
 yarn-error.log
+/.idea/

--- a/packages/create-plugin/package.json
+++ b/packages/create-plugin/package.json
@@ -26,7 +26,8 @@
     "node-rsa": "^1.1.1",
     "os-locale": "^5.0.0",
     "rimraf": "^3.0.2",
-    "sort-package-json": "^1.57.0"
+    "sort-package-json": "^1.57.0",
+    "prettier": "^2.7.1"
   },
   "devDependencies": {
     "@types/glob": "^7.2.0",

--- a/packages/create-plugin/src/__tests__/template.test.ts
+++ b/packages/create-plugin/src/__tests__/template.test.ts
@@ -11,13 +11,14 @@ import os from "os";
 
 describe("template", () => {
   describe("getTemplateType", () => {
-    it("should return be mimimum", () => {
+    it("should return be minimum", () => {
       assert.strictEqual(getTemplateType(createBaseManifest()), "minimum");
     });
   });
   describe("isNecessaryFile", () => {
     it("should returns a boolean that shows whether the file should include or not", () => {
       const manifest = createBaseManifest();
+      assert(!isNecessaryFile(manifest, "with-plugin-uploader.json"));
       assert(!isNecessaryFile(manifest, "js/mobile.js"));
       assert(!isNecessaryFile(manifest, "js/config.js"));
       assert(isNecessaryFile(manifest, "js/other.js"));
@@ -44,7 +45,7 @@ describe("template", () => {
       ];
 
     it.each(patterns)(
-      "should convert package.json correctly (template: $template, $enablePluginUploader: $enablePluginUploader)",
+      "should convert package.json correctly (template: $template, enablePluginUploader: $enablePluginUploader)",
       async ({ template, enablePluginUploader }) => {
         const srcDir = path.resolve(
           __dirname,
@@ -77,8 +78,9 @@ describe("template", () => {
         }
       }
     );
+
     it.each(patterns)(
-      "should convert template file correctly (template: $template, $enablePluginUploader: $enablePluginUploader)",
+      "should convert template file correctly (template: $template, enablePluginUploader: $enablePluginUploader)",
       async ({ template, enablePluginUploader }) => {
         const srcDir = path.resolve(
           __dirname,
@@ -109,7 +111,7 @@ describe("template", () => {
       }
     );
     it.each(patterns)(
-      "should copy normal file correctly (template: $template, $enablePluginUploader: $enablePluginUploader)",
+      "should copy normal file correctly (template: $template, enablePluginUploader: $enablePluginUploader)",
       async ({ template, enablePluginUploader }) => {
         const srcDir = path.resolve(
           __dirname,
@@ -132,5 +134,19 @@ describe("template", () => {
         assert(await fs.stat(path.resolve(destDir, ".gitignore")));
       }
     );
+
+    it("should convert webpack.config.js correctly with modern template", async () => {
+      const srcDir = path.resolve(__dirname, "..", "..", "templates", "modern");
+
+      processTemplateFile(
+        path.resolve(srcDir, "webpack.config.template.js"),
+        srcDir,
+        destDir,
+        manifest,
+        false
+      );
+      const destFile = path.resolve(destDir, "webpack.config.js");
+      assert(await fs.stat(destFile));
+    });
   });
 });

--- a/packages/create-plugin/src/__tests__/template.test.ts
+++ b/packages/create-plugin/src/__tests__/template.test.ts
@@ -18,6 +18,7 @@ describe("template", () => {
   describe("isNecessaryFile", () => {
     it("should returns a boolean that shows whether the file should include or not", () => {
       const manifest = createBaseManifest();
+      assert(!isNecessaryFile(manifest, "webpack.entry.json"));
       assert(!isNecessaryFile(manifest, "with-plugin-uploader.json"));
       assert(!isNecessaryFile(manifest, "js/mobile.js"));
       assert(!isNecessaryFile(manifest, "js/config.js"));

--- a/packages/create-plugin/src/template.ts
+++ b/packages/create-plugin/src/template.ts
@@ -133,13 +133,13 @@ export const processTemplateFile = (
       : webpackEntryJson.default;
     const entries: string[] = [];
     for (const [key, value] of Object.entries(webpackEntry)) {
-      const entryStr = `${key}: "${value}",`;
+      const entryStr = `${key}: "${value}"`;
       entries.push(entryStr);
     }
-    const entriesStr = `{${entries.join("\n")}}`;
+    const entriesStr = `{${entries.join(",")}}`;
     let webpackConfigContent: string = fs.readFileSync(filePath, "utf-8");
     webpackConfigContent = webpackConfigContent.replace(
-      /'%%replaced_webpack_entry%%'/g,
+      /'%%placeholder_webpack_entry%%'/,
       entriesStr
     );
     const prettySource = prettier.format(webpackConfigContent, {

--- a/packages/create-plugin/src/template.ts
+++ b/packages/create-plugin/src/template.ts
@@ -24,23 +24,16 @@ export const getTemplateType = (manifest: Manifest): TemplateType => {
 };
 
 /**
- * return `true` if `file` is a exclude file.
- * @param file
- */
-const isExcludedFiles = (file: string): boolean => {
-  const excludeFiles = ["with-plugin-uploader.json", "webpack.entry.json"];
-  return excludeFiles.some(
-      (excludeFile) => path.basename(file) === excludeFile
-  );
-};
-
-/**
  * return `true` if `file` is necessary.
  * @param manifest
  * @param file
  */
 export const isNecessaryFile = (manifest: Manifest, file: string): boolean => {
-  if (isExcludedFiles(file)) {
+  const excludedFiles = ["with-plugin-uploader.json", "webpack.entry.json"];
+  const isExcludedFile = excludedFiles.some(
+      (excludeFile) => path.basename(file) === excludeFile
+  );
+  if (isExcludedFile) {
     return false;
   }
 

--- a/packages/create-plugin/src/template.ts
+++ b/packages/create-plugin/src/template.ts
@@ -29,9 +29,9 @@ export const getTemplateType = (manifest: Manifest): TemplateType => {
  */
 const isExcludedFiles = (file: string): boolean => {
   const excludeFiles = ["with-plugin-uploader.json", "webpack.entry.json"];
-  const patterns = `${excludeFiles.join("|")}`;
-  const regexp = new RegExp(patterns, "g");
-  return regexp.test(file);
+  return excludeFiles.some(
+      (excludeFile) => path.basename(file) === excludeFile
+  );
 };
 
 /**

--- a/packages/create-plugin/src/template.ts
+++ b/packages/create-plugin/src/template.ts
@@ -28,14 +28,11 @@ export const getTemplateType = (manifest: Manifest): TemplateType => {
  * @param file
  */
 const isExcludedFiles = (file: string): boolean => {
-  const excludeFiles = [
-    "with-plugin-uploader.json",
-    "webpack.entry.json"
-  ]
+  const excludeFiles = ["with-plugin-uploader.json", "webpack.entry.json"];
   const patterns = `${excludeFiles.join("|")}`;
-  const regexp = new RegExp(patterns, 'g');
+  const regexp = new RegExp(patterns, "g");
   return regexp.test(file);
-}
+};
 
 /**
  * return `true` if `file` is necessary.
@@ -43,7 +40,7 @@ const isExcludedFiles = (file: string): boolean => {
  * @param file
  */
 export const isNecessaryFile = (manifest: Manifest, file: string): boolean => {
-  if(isExcludedFiles(file)){
+  if (isExcludedFiles(file)) {
     return false;
   }
 
@@ -124,26 +121,31 @@ export const processTemplateFile = (
       JSON.stringify(packageJson, null, 2)
     );
     fs.writeFileSync(destFilePath, sortedPackageJson);
-  } else if (path.resolve(filePath) === path.resolve(srcDir, "webpack.config.template.js")) {
+  } else if (
+    path.resolve(filePath) ===
+    path.resolve(srcDir, "webpack.config.template.js")
+  ) {
     const webpackEntryJson: WebpackEntryJson = JSON.parse(
-        fs.readFileSync(path.join(srcDir, "webpack.entry.json"), "utf-8")
+      fs.readFileSync(path.join(srcDir, "webpack.entry.json"), "utf-8")
     );
-    let webpackEntry = !!manifest.mobile ? webpackEntryJson.mobile : webpackEntryJson.default;
-    let entries: Array<string> = [];
+    const webpackEntry = manifest.mobile
+      ? webpackEntryJson.mobile
+      : webpackEntryJson.default;
+    const entries: string[] = [];
     for (const [key, value] of Object.entries(webpackEntry)) {
       const entryStr = `${key}: "${value}",`;
-      entries.push(entryStr)
+      entries.push(entryStr);
     }
-    const entriesStr = `{${entries.join('\n')}}`;
+    const entriesStr = `{${entries.join("\n")}}`;
     let webpackConfigContent: string = fs.readFileSync(filePath, "utf-8");
-    webpackConfigContent = webpackConfigContent.replace(/'%%replaced_webpack_entry%%'/g, entriesStr);
+    webpackConfigContent = webpackConfigContent.replace(
+      /'%%replaced_webpack_entry%%'/g,
+      entriesStr
+    );
     const prettySource = prettier.format(webpackConfigContent, {
       parser: "typescript",
     });
-    const destPath = path.join(
-        path.dirname(destFilePath),
-        'webpack.config.js'
-    );
+    const destPath = path.join(path.dirname(destFilePath), "webpack.config.js");
     fs.writeFileSync(destPath, prettySource);
   } else if (fs.statSync(filePath).isDirectory()) {
     fs.mkdirSync(destFilePath);

--- a/packages/create-plugin/src/template.ts
+++ b/packages/create-plugin/src/template.ts
@@ -31,7 +31,7 @@ export const getTemplateType = (manifest: Manifest): TemplateType => {
 export const isNecessaryFile = (manifest: Manifest, file: string): boolean => {
   const excludedFiles = ["with-plugin-uploader.json", "webpack.entry.json"];
   const isExcludedFile = excludedFiles.some(
-      (excludeFile) => path.basename(file) === excludeFile
+    (excludeFile) => path.basename(file) === excludeFile
   );
   if (isExcludedFile) {
     return false;

--- a/packages/create-plugin/templates/modern/webpack.config.template.js
+++ b/packages/create-plugin/templates/modern/webpack.config.template.js
@@ -7,7 +7,7 @@ const isProduction = process.env.NODE_ENV === "production";
 module.exports = {
   mode: isProduction ? "production" : "development",
   devtool: isProduction ? false : "inline-cheap-module-source-map",
-  entry: '%%replaced_webpack_entry%%',
+  entry: '%%placeholder_webpack_entry%%',
   output: {
     path: path.resolve(__dirname, "plugin", "js"),
     filename: "[name].js",

--- a/packages/create-plugin/templates/modern/webpack.config.template.js
+++ b/packages/create-plugin/templates/modern/webpack.config.template.js
@@ -7,11 +7,7 @@ const isProduction = process.env.NODE_ENV === "production";
 module.exports = {
   mode: isProduction ? "production" : "development",
   devtool: isProduction ? false : "inline-cheap-module-source-map",
-  entry: {
-    config: "./src/js/config.ts",
-    desktop: "./src/js/desktop.ts",
-    mobile: "./src/js/mobile.ts",
-  },
+  entry: '%%replaced_webpack_entry%%',
   output: {
     path: path.resolve(__dirname, "plugin", "js"),
     filename: "[name].js",

--- a/packages/create-plugin/templates/modern/webpack.entry.json
+++ b/packages/create-plugin/templates/modern/webpack.entry.json
@@ -1,0 +1,11 @@
+{
+  "default": {
+    "config": "./src/js/config.ts",
+    "desktop": "./src/js/desktop.ts"
+  },
+  "mobile": {
+    "config": "./src/js/config.ts",
+    "desktop": "./src/js/desktop.ts",
+    "mobile": "./src/js/mobile.ts"
+  }
+}


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

fixes https://github.com/kintone/js-sdk/issues/1742.


## What

<!-- What is a solution you want to add? -->

- [x] exclude mobile setting from the `entry` property of webpack.config.js when mobile is disabled
- [x] add tests of generating webpack.config.js

## How to test

<!-- How can we test this pull request? -->

```shell
yarn install
yarn build

yarn test

cd packages/create-plugin
node ./bin/cli.js --template modern path/to/generate/plugin
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
