### PR TITLE
fix: the errorIndex of KintoneAllRecordsError is incorrect

### DIFF
--- a/packages/rest-api-client/src/error/KintoneAllRecordsError.ts
+++ b/packages/rest-api-client/src/error/KintoneAllRecordsError.ts
@@ -7,9 +7,15 @@ export class KintoneAllRecordsError extends Error {
   errorIndex?: number;
 
   private static parseErrorIndex(errors: { [k: string]: any }) {
-    const firstErrorKey = Object.keys(errors)[0];
-    const result = firstErrorKey.match(/records\[(\d+)\]/);
-    return result ? Number(result[1]) : null;
+    const errorIndexes: number[] = [];
+    Object.keys(errors).forEach((errorKey: string) => {
+      const result = errorKey.match(/records\[(\d+)\]/);
+      if (result) {
+        errorIndexes.push(Number(result[1]));
+      }
+    });
+
+    return errorIndexes.length > 0 ? Math.min(...errorIndexes) : null;
   }
 
   private static extractErrorIndex(

--- a/packages/rest-api-client/src/error/KintoneAllRecordsError.ts
+++ b/packages/rest-api-client/src/error/KintoneAllRecordsError.ts
@@ -7,6 +7,7 @@ export class KintoneAllRecordsError extends Error {
   errorIndex?: number;
 
   private static parseErrorIndex(errors: { [k: string]: any }) {
+    // TODO: use matchAll after ES2020 support
     const errorIndexes: number[] = [];
     Object.keys(errors).forEach((errorKey: string) => {
       const result = errorKey.match(/records\[(\d+)\]/);

--- a/packages/rest-api-client/src/error/__tests__/KintoneAllRecordsError.test.ts
+++ b/packages/rest-api-client/src/error/__tests__/KintoneAllRecordsError.test.ts
@@ -143,5 +143,47 @@ describe("KintoneAllRecordsError", () => {
         numOfProcessedRecords + errorParseResult
       );
     });
+    it("should set errorIndex as the smallest value from the response errors", () => {
+      const largerErrorIndex = 9;
+      const smallestErrorIndex = 5;
+      errorResponse = {
+        data: {
+          results: [
+            {
+              id: "some id",
+              code: "some code",
+              message: "some error message",
+              errors: {
+                [`records[${largerErrorIndex}].Customer`]: {
+                  messages: ["key is missing"],
+                },
+                [`records[${smallestErrorIndex}].Customer`]: {
+                  messages: ["key is missing"],
+                },
+              },
+            },
+            {},
+            {},
+          ],
+        },
+        status: 500,
+        statusText: "Internal Server Error",
+        headers: {
+          "X-Some-Header": "error",
+        },
+      };
+      kintoneRestApiError = new KintoneRestAPIError(errorResponse);
+      kintoneAllRecordsError = new KintoneAllRecordsError(
+        processedRecordsResult,
+        unprocessedRecords,
+        numOfAllRecords,
+        kintoneRestApiError,
+        chunkLength
+      );
+
+      expect(kintoneAllRecordsError.errorIndex).toBe(
+        numOfProcessedRecords + smallestErrorIndex
+      );
+    });
   });
 });


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

fixes https://github.com/kintone/js-sdk/issues/1730.

## What

- [x] The `errorIndex` should be the smallest index of errors


## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
