### PR TITLE
fix(dts-gen): dts-gen does not output with the absolute path

### DIFF
--- a/packages/dts-gen/src/templates/template.ts
+++ b/packages/dts-gen/src/templates/template.ts
@@ -49,7 +49,7 @@ const renderAsFile = async (output: string, renderInput: RenderInput) => {
   const prettySource = prettier.format(eslintOutput, {
     parser: "typescript",
   });
-  const outputPath = path.join(process.cwd(), output);
+  const outputPath = path.resolve(output);
 
   await fs.promises.mkdir(path.dirname(outputPath), { recursive: true });
   await fs.promises.writeFile(outputPath, prettySource);


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

fixes https://github.com/kintone/js-sdk/issues/1743


## What

- [x] the output should work correctly with the absolute path


## How to test

```console
$ kintone-dts-gen \
    --base-url https://******.kintone.com --app-id 1 --username ******** --password ******** \
    -o /tmp/my-fields.d.ts
```

## Expected behavior

```console
$ ls /tmp/my-fields.d.ts
/tmp/my-fields.d.ts

$ ls ./tmp/my-fields.d.ts 
ls: ./tmp/my-fields.d.ts: No such file or directory
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] ~Added tests if it is required.~
- [x] Passed `yarn lint` and `yarn test` on the root directory.
