### PR TITLE
feat(rest-api-client): add numOfProcessedRecords and numOfAllRecords to KintoneAllRecordsError

### DIFF
--- a/packages/rest-api-client/docs/errorHandling.md
+++ b/packages/rest-api-client/docs/errorHandling.md
@@ -40,7 +40,7 @@ The following methods could throw `KintoneAllRecordsError`.
 `KintoneAllRecordsError` has the following properties.
 
 | Name                   |                    Type                     | Description                                                                                                                                 |
-|------------------------|:-------------------------------------------:|---------------------------------------------------------------------------------------------------------------------------------------------|
+| ---------------------- | :-----------------------------------------: | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | processedRecordsResult |                   Object                    | The result of the records that have been processed successfully. This is the same type specified in the **Returns** section of each method. |
 | unprocessedRecords     |                    Array                    | The records that have not been processed. This is a part of `records` passed as an argument.                                                |
 | numOfProcessedRecords  |                   Number                    | The number of records that have been processed successfully.                                                                                |
@@ -64,7 +64,7 @@ In this case, rest-api-client split the `records` into 3 chunks of records, and 
 Then the properties of `KintoneAllRecordsError` is:
 
 | Name                   | Content                                    |
-|------------------------|--------------------------------------------|
+| ---------------------- | ------------------------------------------ |
 | processedRecordsResult | `{ records: results[0] - results[1999] }`  |
 | unprocessedRecords     | `records[2000] - records[4999]`            |
 | numOfProcessedRecords  | `2000`                                     |

--- a/packages/rest-api-client/docs/errorHandling.md
+++ b/packages/rest-api-client/docs/errorHandling.md
@@ -40,9 +40,11 @@ The following methods could throw `KintoneAllRecordsError`.
 `KintoneAllRecordsError` has the following properties.
 
 | Name                   |                    Type                     | Description                                                                                                                                 |
-| ---------------------- | :-----------------------------------------: | ------------------------------------------------------------------------------------------------------------------------------------------- |
+|------------------------|:-------------------------------------------:|---------------------------------------------------------------------------------------------------------------------------------------------|
 | processedRecordsResult |                   Object                    | The result of the records that have been processed successfully. This is the same type specified in the **Returns** section of each method. |
 | unprocessedRecords     |                    Array                    | The records that have not been processed. This is a part of `records` passed as an argument.                                                |
+| numOfProcessedRecords  |                   Number                    | The number of records that have been processed successfully.                                                                                |
+| numOfAllRecords        |                   Number                    | The number of all records.                                                                                                                  |
 | error                  | [KintoneRestAPIError](#KintoneRestAPIError) | The instance of `KintoneRestAPIError`                                                                                                       |
 | errorIndex             |         Number or<br />`undefined`          | The index that an error ocurred.                                                                                                            |
 
@@ -62,9 +64,11 @@ In this case, rest-api-client split the `records` into 3 chunks of records, and 
 Then the properties of `KintoneAllRecordsError` is:
 
 | Name                   | Content                                    |
-| ---------------------- | ------------------------------------------ |
+|------------------------|--------------------------------------------|
 | processedRecordsResult | `{ records: results[0] - results[1999] }`  |
 | unprocessedRecords     | `records[2000] - records[4999]`            |
+| numOfProcessedRecords  | `2000`                                     |
+| numOfAllRecords        | `5000`                                     |
 | error                  | An instance of `KintoneRestAPIError`       |
 | errorIndex             | `2499` (If Kintone returns) or `undefined` |
 

--- a/packages/rest-api-client/src/error/KintoneAllRecordsError.ts
+++ b/packages/rest-api-client/src/error/KintoneAllRecordsError.ts
@@ -5,6 +5,8 @@ export class KintoneAllRecordsError extends Error {
   unprocessedRecords: any[];
   error: KintoneRestAPIError;
   errorIndex?: number;
+  numOfProcessedRecords: number;
+  numOfAllRecords: number;
 
   private static parseErrorIndex(errors: { [k: string]: any }) {
     // TODO: use matchAll after ES2020 support
@@ -81,6 +83,8 @@ export class KintoneAllRecordsError extends Error {
     this.error = error;
     this.errorIndex = errorIndex;
     this.message = message;
+    this.numOfProcessedRecords = numOfProcessedRecords;
+    this.numOfAllRecords = numOfAllRecords;
 
     // https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
     // Set the prototype explicitly.

--- a/packages/rest-api-client/src/error/__tests__/KintoneAllRecordsError.test.ts
+++ b/packages/rest-api-client/src/error/__tests__/KintoneAllRecordsError.test.ts
@@ -55,12 +55,18 @@ describe("KintoneAllRecordsError", () => {
           errorParseResult
       );
     });
-    it("should set processedRecordsResult, unprocessedRecords, and error properties", () => {
+    it("should set processedRecordsResult, unprocessedRecords, numOfAllRecords, numOfProcessedRecords, and error properties", () => {
       expect(kintoneAllRecordsError.processedRecordsResult).toStrictEqual(
         processedRecordsResult
       );
       expect(kintoneAllRecordsError.unprocessedRecords).toStrictEqual(
         unprocessedRecords
+      );
+      expect(kintoneAllRecordsError.numOfAllRecords).toStrictEqual(
+        numOfAllRecords
+      );
+      expect(kintoneAllRecordsError.numOfProcessedRecords).toStrictEqual(
+        numOfProcessedRecords
       );
       expect(kintoneAllRecordsError.error).toStrictEqual(kintoneRestApiError);
     });


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

Currently, KintoneAllRecordsError calculates numOfProcessedRecords and numOfAllRecords internally to print an error message.
This information should be provided to upper errors as the object property.


## What

- [x] Add numOfProcessedRecords and numOfAllRecords fields to KintoneAllRecordsError.


## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
