### PR TITLE
chore: enforce type imports as lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,5 +12,11 @@ module.exports = {
         },
       },
     ],
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      {
+        prefer: "type-imports",
+      },
+    ],
   },
 };

--- a/examples/rest-api-client-demo/src/app.ts
+++ b/examples/rest-api-client-demo/src/app.ts
@@ -1,4 +1,4 @@
-import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
 
 const APP_ID = 8;
 const RECORD_ID = 3;

--- a/examples/rest-api-client-demo/src/bulkRequest.ts
+++ b/examples/rest-api-client-demo/src/bulkRequest.ts
@@ -1,4 +1,4 @@
-import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
 
 const APP_ID = 8;
 const RECORD_ID = 3;

--- a/examples/rest-api-client-demo/src/file.ts
+++ b/examples/rest-api-client-demo/src/file.ts
@@ -1,4 +1,4 @@
-import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
 
 const APP_ID = 8;
 

--- a/examples/rest-api-client-demo/src/record.ts
+++ b/examples/rest-api-client-demo/src/record.ts
@@ -1,4 +1,4 @@
-import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
 
 const APP_ID = 8;
 const RECORD_ID = 3;

--- a/packages/create-plugin/src/__tests__/helpers/baseManifest.ts
+++ b/packages/create-plugin/src/__tests__/helpers/baseManifest.ts
@@ -1,4 +1,4 @@
-import { Manifest } from "../../manifest";
+import type { Manifest } from "../../manifest";
 
 export default function createBaseManifest(): Manifest {
   return {

--- a/packages/create-plugin/src/__tests__/qa.test.ts
+++ b/packages/create-plugin/src/__tests__/qa.test.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
-import { Answers, Question } from "inquirer";
+import type { Question } from "inquirer";
+import { Answers } from "inquirer";
 import { buildQuestions } from "../qa";
 
 const getQuestion = (

--- a/packages/create-plugin/src/__tests__/qa.test.ts
+++ b/packages/create-plugin/src/__tests__/qa.test.ts
@@ -1,6 +1,5 @@
 import assert from "assert";
 import type { Question } from "inquirer";
-import { Answers } from "inquirer";
 import { buildQuestions } from "../qa";
 
 const getQuestion = (

--- a/packages/create-plugin/src/deps.ts
+++ b/packages/create-plugin/src/deps.ts
@@ -1,7 +1,7 @@
 "use strict";
 
 import { spawnSync } from "child_process";
-import { Lang } from "./lang";
+import type { Lang } from "./lang";
 import { printLog } from "./logger";
 import { getMessage } from "./messages";
 

--- a/packages/create-plugin/src/generator.ts
+++ b/packages/create-plugin/src/generator.ts
@@ -4,10 +4,11 @@ import * as fs from "fs";
 import * as glob from "glob";
 import * as path from "path";
 import { installDependencies } from "./deps";
-import { Lang } from "./lang";
-import { Manifest } from "./manifest";
+import type { Lang } from "./lang";
+import type { Manifest } from "./manifest";
 import { generatePrivateKey } from "./privateKey";
-import { isNecessaryFile, processTemplateFile, TemplateType } from "./template";
+import type { TemplateType } from "./template";
+import { isNecessaryFile, processTemplateFile } from "./template";
 import normalize from "normalize-path";
 
 /**

--- a/packages/create-plugin/src/index.ts
+++ b/packages/create-plugin/src/index.ts
@@ -5,12 +5,12 @@ import * as fs from "fs";
 import * as inquirer from "inquirer";
 import rimraf from "rimraf";
 import { generatePlugin } from "./generator";
-import { Lang } from "./lang";
+import type { Lang } from "./lang";
 import { printError, printLog } from "./logger";
 import { buildManifest } from "./manifest";
 import { getBoundMessage, getMessage } from "./messages";
 import { buildQuestions } from "./qa";
-import { TemplateType } from "./template";
+import type { TemplateType } from "./template";
 
 /**
  * Verify whether the output directory is valid

--- a/packages/create-plugin/src/manifest.ts
+++ b/packages/create-plugin/src/manifest.ts
@@ -1,7 +1,7 @@
 "use strict";
 
-import { Answers } from "inquirer";
-import { TemplateType } from "./template";
+import type { Answers } from "inquirer";
+import type { TemplateType } from "./template";
 
 const jQueryURL = "https://js.cybozu.com/jquery/3.3.1/jquery.min.js";
 

--- a/packages/create-plugin/src/messages.ts
+++ b/packages/create-plugin/src/messages.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import { Lang } from "./lang";
+import type { Lang } from "./lang";
 
 type LangMap = { [lang in Lang]: string };
 type MessageMap = { [key in keyof typeof messages]: LangMap };

--- a/packages/create-plugin/src/qa.ts
+++ b/packages/create-plugin/src/qa.ts
@@ -1,7 +1,7 @@
 "use strict";
 
-import { Answers, Question } from "inquirer";
-import { Lang } from "./lang";
+import type { Answers, Question } from "inquirer";
+import type { Lang } from "./lang";
 import { getBoundMessage } from "./messages";
 
 const NAME_MAX_LENGTH = 64;

--- a/packages/create-plugin/src/template.ts
+++ b/packages/create-plugin/src/template.ts
@@ -3,7 +3,7 @@
 import * as fs from "fs";
 import * as _ from "lodash";
 import * as path from "path";
-import { Manifest } from "./manifest";
+import type { Manifest } from "./manifest";
 import sortPackageJson from "sort-package-json";
 import * as prettier from "prettier";
 

--- a/packages/customize-uploader/src/commands/__tests__/MockKintoneApiClient.ts
+++ b/packages/customize-uploader/src/commands/__tests__/MockKintoneApiClient.ts
@@ -1,7 +1,8 @@
-import KintoneApiClient, {
+import type {
   Option as ApiClientOption,
   UpdateAppCustomizeParameter,
 } from "../../KintoneApiClient";
+import KintoneApiClient from "../../KintoneApiClient";
 
 type MethodParameter = "GET" | "POST" | "PUT" | "DELETE";
 

--- a/packages/customize-uploader/src/commands/__tests__/import.test.ts
+++ b/packages/customize-uploader/src/commands/__tests__/import.test.ts
@@ -2,11 +2,8 @@ import assert from "assert";
 import * as fs from "fs";
 import { sep } from "path";
 import rimraf from "rimraf";
-import {
-  ImportCustomizeManifest,
-  importCustomizeSetting,
-  Option,
-} from "../import";
+import type { ImportCustomizeManifest, Option } from "../import";
+import { importCustomizeSetting } from "../import";
 import MockKintoneApiClient from "./MockKintoneApiClient";
 
 describe("import", () => {

--- a/packages/customize-uploader/src/commands/__tests__/index.test.ts
+++ b/packages/customize-uploader/src/commands/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
-import { CustomizeManifest, Option, Status, upload } from "../index";
+import type { CustomizeManifest, Option, Status } from "../index";
+import { upload } from "../index";
 import MockKintoneApiClient from "./MockKintoneApiClient";
 
 describe("index", () => {

--- a/packages/customize-uploader/src/commands/__tests__/init.test.ts
+++ b/packages/customize-uploader/src/commands/__tests__/init.test.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import fs from "fs";
 import rimraf from "rimraf";
-import { CustomizeManifest } from "../index";
+import type { CustomizeManifest } from "../index";
 import { generateCustomizeManifest, getInitCustomizeManifest } from "../init";
 
 describe("init", () => {

--- a/packages/customize-uploader/src/commands/import.ts
+++ b/packages/customize-uploader/src/commands/import.ts
@@ -2,9 +2,9 @@ import fs from "fs";
 import mkdirp from "mkdirp";
 import { sep } from "path";
 import { Constans } from "../constants";
-import { CustomizeManifest } from "./index";
+import type { CustomizeManifest } from "./index";
 import KintoneApiClient, { AuthenticationError } from "../KintoneApiClient";
-import { Lang } from "../lang";
+import type { Lang } from "../lang";
 import { getBoundMessage } from "../messages";
 import { wait } from "../util";
 

--- a/packages/customize-uploader/src/commands/index.ts
+++ b/packages/customize-uploader/src/commands/index.ts
@@ -1,7 +1,7 @@
 import chokidar from "chokidar";
 import fs from "fs";
 import KintoneApiClient, { AuthenticationError } from "../KintoneApiClient";
-import { Lang } from "../lang";
+import type { Lang } from "../lang";
 import { getBoundMessage } from "../messages";
 import { isUrlString, wait } from "../util";
 

--- a/packages/customize-uploader/src/commands/init.ts
+++ b/packages/customize-uploader/src/commands/init.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import mkdirp from "mkdirp";
-import { CustomizeManifest } from "./index";
-import { Lang } from "../lang";
+import type { CustomizeManifest } from "./index";
+import type { Lang } from "../lang";
 import { getBoundMessage } from "../messages";
 
 export const getInitCustomizeManifest = (

--- a/packages/customize-uploader/src/messages.ts
+++ b/packages/customize-uploader/src/messages.ts
@@ -1,4 +1,4 @@
-import { Lang } from "./lang";
+import type { Lang } from "./lang";
 
 const messages = {
   E_requiredManifestFile: {

--- a/packages/customize-uploader/src/params/index.ts
+++ b/packages/customize-uploader/src/params/index.ts
@@ -1,5 +1,5 @@
 import * as inquirer from "inquirer";
-import { Lang } from "../lang";
+import type { Lang } from "../lang";
 import { getBoundMessage } from "../messages";
 
 interface Params {

--- a/packages/customize-uploader/src/params/init.ts
+++ b/packages/customize-uploader/src/params/init.ts
@@ -1,5 +1,5 @@
 import * as inquirer from "inquirer";
-import { Lang } from "../lang";
+import type { Lang } from "../lang";
 import { getBoundMessage } from "../messages";
 
 export const inquireInitParams = (lang: Lang) => {

--- a/packages/dts-gen/src/converters/fieldtype-converters.test.ts
+++ b/packages/dts-gen/src/converters/fieldtype-converters.test.ts
@@ -1,5 +1,5 @@
 import { VisibleForTesting } from "./fileldtype-converter";
-import { SubTableFieldType } from "../kintone/clients/forms-client";
+import type { SubTableFieldType } from "../kintone/clients/forms-client";
 import { objectValues } from "../utils/objectvalues";
 
 describe("FileFieldTypeConverter", () => {

--- a/packages/dts-gen/src/converters/fileldtype-converter.ts
+++ b/packages/dts-gen/src/converters/fileldtype-converter.ts
@@ -1,4 +1,7 @@
-import { FieldType, SubTableFieldType } from "../kintone/clients/forms-client";
+import type {
+  FieldType,
+  SubTableFieldType,
+} from "../kintone/clients/forms-client";
 import { objectValues } from "../utils/objectvalues";
 
 type FieldTypesOrSubTableFieldTypes = FieldType[] | SubTableFieldType[];

--- a/packages/dts-gen/src/integration-tests/setup-test-utils.ts
+++ b/packages/dts-gen/src/integration-tests/setup-test-utils.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-import {
+import type {
   SetUpTestAppClient,
   AddFormFieldOutput,
   JsCustomizeOutput,

--- a/packages/dts-gen/src/kintone/clients/axios-utils.test.ts
+++ b/packages/dts-gen/src/kintone/clients/axios-utils.test.ts
@@ -1,5 +1,5 @@
 import { AxiosUtils, VisibleForTesting } from "./axios-utils";
-import { AxiosRequestConfig } from "axios";
+import type { AxiosRequestConfig } from "axios";
 
 describe("FormsClientImpl#constructor", () => {
   const baseUrl = "https://kintone.com";

--- a/packages/dts-gen/src/kintone/clients/axios-utils.ts
+++ b/packages/dts-gen/src/kintone/clients/axios-utils.ts
@@ -1,9 +1,10 @@
-import axios, {
+import type {
   AxiosInstance,
   AxiosProxyConfig,
   AxiosRequestConfig,
   AxiosRequestHeaders,
 } from "axios";
+import axios from "axios";
 import { IncomingHttpHeaders } from "http";
 
 export interface NewInstanceInput {

--- a/packages/dts-gen/src/kintone/clients/demo-client.ts
+++ b/packages/dts-gen/src/kintone/clients/demo-client.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   FetchFormPropertiesInput,
   FormsClient,
   FieldNameAndFieldOrSubTableField,

--- a/packages/dts-gen/src/kintone/clients/demo-fullwidth-symbol-client.ts
+++ b/packages/dts-gen/src/kintone/clients/demo-fullwidth-symbol-client.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   FetchFormPropertiesInput,
   FormsClient,
   FieldNameAndFieldOrSubTableField,

--- a/packages/dts-gen/src/kintone/clients/forms-client-impl.ts
+++ b/packages/dts-gen/src/kintone/clients/forms-client-impl.ts
@@ -1,11 +1,12 @@
-import {
+import type {
   FormsClient,
   FetchFormPropertiesInput,
   FieldNameAndFieldOrSubTableField,
 } from "./forms-client";
 
-import { AxiosUtils, NewInstanceInput } from "./axios-utils";
-import { AxiosInstance, AxiosRequestConfig } from "axios";
+import type { NewInstanceInput } from "./axios-utils";
+import { AxiosUtils } from "./axios-utils";
+import type { AxiosInstance, AxiosRequestConfig } from "axios";
 
 export class FormsClientImpl implements FormsClient {
   readonly client: AxiosInstance;

--- a/packages/dts-gen/src/kintone/clients/setup-test-app-client.ts
+++ b/packages/dts-gen/src/kintone/clients/setup-test-app-client.ts
@@ -1,8 +1,9 @@
-import { AxiosInstance, AxiosRequestConfig } from "axios";
+import type { AxiosInstance, AxiosRequestConfig } from "axios";
 import FormData from "form-data";
-import fs from "fs";
+import type fs from "fs";
 
-import { NewInstanceInput, AxiosUtils } from "./axios-utils";
+import type { NewInstanceInput } from "./axios-utils";
+import { AxiosUtils } from "./axios-utils";
 
 interface CreateAppInput {
   name: string;

--- a/packages/dts-gen/src/templates/converter.ts
+++ b/packages/dts-gen/src/templates/converter.ts
@@ -1,11 +1,11 @@
-import { FieldTypeGroups } from "../converters/fileldtype-converter";
+import type { FieldTypeGroups } from "../converters/fileldtype-converter";
 import * as F from "./expressions/fields";
 import { Namespace } from "./expressions/namespace";
 import {
   TypeDefinition,
   SavedTypeDefinition,
 } from "./expressions/typedefinitions";
-import { FieldType } from "../kintone/clients/forms-client";
+import type { FieldType } from "../kintone/clients/forms-client";
 
 export const convertToTsExpression = ({
   namespace,

--- a/packages/dts-gen/src/templates/expressions/expression.test.ts
+++ b/packages/dts-gen/src/templates/expressions/expression.test.ts
@@ -1,4 +1,5 @@
-import { TsExpression, toTsExpressions } from "./expression";
+import type { TsExpression } from "./expression";
+import { toTsExpressions } from "./expression";
 
 describe("toTsExpressions", () => {
   class TestExpression implements TsExpression {

--- a/packages/dts-gen/src/templates/expressions/fields.ts
+++ b/packages/dts-gen/src/templates/expressions/fields.ts
@@ -1,4 +1,5 @@
-import { TsExpression, toTsExpressions } from "./expression";
+import type { TsExpression } from "./expression";
+import { toTsExpressions } from "./expression";
 import { Converter as FieldTypeConverter } from "./typescriptfieldtypeconverter";
 
 export class FieldGroup implements TsExpression {

--- a/packages/dts-gen/src/templates/expressions/namespace.ts
+++ b/packages/dts-gen/src/templates/expressions/namespace.ts
@@ -1,5 +1,5 @@
-import { TypeDefinition, SavedTypeDefinition } from "./typedefinitions";
-import { TsExpression } from "./expression";
+import type { TypeDefinition, SavedTypeDefinition } from "./typedefinitions";
+import type { TsExpression } from "./expression";
 
 export class Namespace implements TsExpression {
   constructor(

--- a/packages/dts-gen/src/templates/expressions/typedefinitions.ts
+++ b/packages/dts-gen/src/templates/expressions/typedefinitions.ts
@@ -1,5 +1,6 @@
-import { FieldGroup, SubTableField, TsDefinedField } from "./fields";
-import { TsExpression, toTsExpressions } from "./expression";
+import type { FieldGroup, SubTableField, TsDefinedField } from "./fields";
+import type { TsExpression } from "./expression";
+import { toTsExpressions } from "./expression";
 
 export class TypeDefinition implements TsExpression {
   constructor(

--- a/packages/dts-gen/src/templates/template.ts
+++ b/packages/dts-gen/src/templates/template.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import * as prettier from "prettier";
 import { ESLint } from "eslint";
 
-import { FieldTypeGroups } from "../converters/fileldtype-converter";
+import type { FieldTypeGroups } from "../converters/fileldtype-converter";
 import { convertToTsExpression } from "./converter";
 
 interface RenderInput {

--- a/packages/plugin-manifest-validator/src/index.ts
+++ b/packages/plugin-manifest-validator/src/index.ts
@@ -1,6 +1,7 @@
 "use strict";
 
-import Ajv, { ErrorObject } from "ajv";
+import type { ErrorObject } from "ajv";
+import Ajv from "ajv";
 import bytes from "bytes";
 import jsonSchema from "../manifest-schema.json";
 import validateUrl from "./validate-https-url";

--- a/packages/plugin-manifest-validator/src/manifest-schema-test.ts
+++ b/packages/plugin-manifest-validator/src/manifest-schema-test.ts
@@ -1,4 +1,4 @@
-import { KintonePluginManifestJson } from "../manifest-schema";
+import type { KintonePluginManifestJson } from "../manifest-schema";
 
 const manifest: KintonePluginManifestJson = {
   manifest_version: 1,

--- a/packages/plugin-packer/src/zip.ts
+++ b/packages/plugin-packer/src/zip.ts
@@ -7,7 +7,7 @@ import * as streamBuffers from "stream-buffers";
 
 import { generateErrorMessages } from "./gen-error-msg";
 import { sourceList } from "./sourcelist";
-import internal from "stream";
+import type internal from "stream";
 
 type ManifestJson = any;
 type Entries = Map<string, any>;

--- a/packages/plugin-uploader/src/cli.ts
+++ b/packages/plugin-uploader/src/cli.ts
@@ -2,7 +2,8 @@ import osLocale from "os-locale";
 import meow from "meow";
 
 import { inquireParams } from "./params";
-import { getDefaultLang, Lang } from "./lang";
+import type { Lang } from "./lang";
+import { getDefaultLang } from "./lang";
 import { getMessage } from "./messages";
 import { run } from "./index";
 

--- a/packages/plugin-uploader/src/index.ts
+++ b/packages/plugin-uploader/src/index.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import puppeteer from "puppeteer";
 import type { Browser, Page } from "puppeteer";
 
-import { Lang } from "./lang";
+import type { Lang } from "./lang";
 import { getBoundMessage } from "./messages";
 
 const TIMEOUT_MS = 10000;

--- a/packages/plugin-uploader/src/messages.ts
+++ b/packages/plugin-uploader/src/messages.ts
@@ -1,4 +1,4 @@
-import { Lang } from "./lang";
+import type { Lang } from "./lang";
 
 type LangMap = { [lang in Lang]: string };
 type MessageMap = { [key in keyof typeof messages]: LangMap };

--- a/packages/plugin-uploader/src/params.ts
+++ b/packages/plugin-uploader/src/params.ts
@@ -1,5 +1,5 @@
 import * as inquirer from "inquirer";
-import { Lang } from "./lang";
+import type { Lang } from "./lang";
 import { getBoundMessage } from "./messages";
 
 interface Params {

--- a/packages/profile-loader/src/config.ts
+++ b/packages/profile-loader/src/config.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import os from "os";
 import toml from "toml";
-import { Profile } from "./index";
+import type { Profile } from "./index";
 
 const KINTONE_CONFIG_DIR = path.resolve(os.homedir(), ".kintone");
 const CONFIG_FILE_NAME = "config";

--- a/packages/profile-loader/src/env.ts
+++ b/packages/profile-loader/src/env.ts
@@ -1,4 +1,4 @@
-import { Profile } from ".";
+import type { Profile } from ".";
 
 export const loadEnv = <T extends Profile>(): Partial<T> => {
   const config: any = {

--- a/packages/rest-api-client/src/KintoneFields/exportTypes/__checks__/usecases/field.ts
+++ b/packages/rest-api-client/src/KintoneFields/exportTypes/__checks__/usecases/field.ts
@@ -2,7 +2,8 @@
   When you use this package, you can import them from package root like this:
   import { KintoneRestAPIClient, KintoneRecordField } from "@kintone/rest-api-client";
 */
-import { KintoneRestAPIClient, KintoneRecordField } from "../../../..";
+import type { KintoneRecordField } from "../../../..";
+import { KintoneRestAPIClient } from "../../../..";
 
 const client = new KintoneRestAPIClient({
   /* ... */

--- a/packages/rest-api-client/src/KintoneFields/exportTypes/__checks__/usecases/layout.ts
+++ b/packages/rest-api-client/src/KintoneFields/exportTypes/__checks__/usecases/layout.ts
@@ -2,7 +2,8 @@
   When you use this package, you can import them from package root like this:
   import { KintoneRestAPIClient, KintoneFormLayout } from "@kintone/rest-api-client";
 */
-import { KintoneRestAPIClient, KintoneFormLayout } from "../../../..";
+import type { KintoneFormLayout } from "../../../..";
+import { KintoneRestAPIClient } from "../../../..";
 
 const client = new KintoneRestAPIClient({
   /* ... */

--- a/packages/rest-api-client/src/KintoneFields/exportTypes/__checks__/usecases/property.ts
+++ b/packages/rest-api-client/src/KintoneFields/exportTypes/__checks__/usecases/property.ts
@@ -2,7 +2,8 @@
   When you use this package, you can import them from package root like this:
   import { KintoneRestAPIClient, KintoneFormFieldProperty } from "@kintone/rest-api-client";
 */
-import { KintoneRestAPIClient, KintoneFormFieldProperty } from "../../../..";
+import type { KintoneFormFieldProperty } from "../../../..";
+import { KintoneRestAPIClient } from "../../../..";
 
 const client = new KintoneRestAPIClient({
   /* ... */

--- a/packages/rest-api-client/src/KintoneFields/types/__checks__/field.ts
+++ b/packages/rest-api-client/src/KintoneFields/types/__checks__/field.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Subtable,
   ID,
   Revision,

--- a/packages/rest-api-client/src/KintoneFields/types/__checks__/layout.ts
+++ b/packages/rest-api-client/src/KintoneFields/types/__checks__/layout.ts
@@ -1,4 +1,4 @@
-import { Field, Row, Subtable, Group } from "../layout";
+import type { Field, Row, Subtable, Group } from "../layout";
 
 type Test_RowLayout_OK = Row<
   [

--- a/packages/rest-api-client/src/KintoneFields/types/__checks__/property.ts
+++ b/packages/rest-api-client/src/KintoneFields/types/__checks__/property.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   RecordNumber,
   Creator,
   CreatedTime,

--- a/packages/rest-api-client/src/KintoneRequestConfigBuilder.ts
+++ b/packages/rest-api-client/src/KintoneRequestConfigBuilder.ts
@@ -2,14 +2,14 @@ import FormData from "form-data";
 import qs from "qs";
 import { Base64 } from "js-base64";
 
-import {
+import type {
   RequestConfigBuilder,
   RequestConfig,
   HttpMethod,
   Params,
   ProxyConfig,
 } from "./http/HttpClientInterface";
-import { BasicAuth, DiscriminatedAuth } from "./types/auth";
+import type { BasicAuth, DiscriminatedAuth } from "./types/auth";
 import { platformDeps } from "./platform/";
 import type { Agent as HttpsAgent } from "https";
 

--- a/packages/rest-api-client/src/KintoneResponseHandler.ts
+++ b/packages/rest-api-client/src/KintoneResponseHandler.ts
@@ -1,14 +1,12 @@
-import {
+import type {
   ErrorResponse,
   HttpClientError,
   Response,
   ResponseHandler,
 } from "./http/HttpClientInterface";
 import { KintoneAbortSearchError } from "./error/KintoneAbortSearchError";
-import {
-  KintoneRestAPIError,
-  KintoneErrorResponse,
-} from "./error/KintoneRestAPIError";
+import type { KintoneErrorResponse } from "./error/KintoneRestAPIError";
+import { KintoneRestAPIError } from "./error/KintoneRestAPIError";
 
 export class KintoneResponseHandler implements ResponseHandler {
   private enableAbortSearchError: boolean;

--- a/packages/rest-api-client/src/KintoneRestAPIClient.ts
+++ b/packages/rest-api-client/src/KintoneRestAPIClient.ts
@@ -1,10 +1,11 @@
-import { BulkRequestClient, EndpointName } from "./client/BulkRequestClient";
+import type { EndpointName } from "./client/BulkRequestClient";
+import { BulkRequestClient } from "./client/BulkRequestClient";
 import { AppClient } from "./client/AppClient";
 import { RecordClient } from "./client/RecordClient";
 import { FileClient } from "./client/FileClient";
 import { DefaultHttpClient } from "./http/";
-import { ProxyConfig } from "./http/HttpClientInterface";
-import { BasicAuth, DiscriminatedAuth } from "./types/auth";
+import type { ProxyConfig } from "./http/HttpClientInterface";
+import type { BasicAuth, DiscriminatedAuth } from "./types/auth";
 import { KintoneRequestConfigBuilder } from "./KintoneRequestConfigBuilder";
 import { KintoneResponseHandler } from "./KintoneResponseHandler";
 import { platformDeps } from "./platform";

--- a/packages/rest-api-client/src/__tests__/KintoneResponseHandler.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneResponseHandler.test.ts
@@ -1,6 +1,6 @@
 import { KintoneRestAPIError } from "../error/KintoneRestAPIError";
 import { KintoneAbortSearchError } from "../error/KintoneAbortSearchError";
-import {
+import type {
   ErrorResponse,
   Response,
   HttpClientError,

--- a/packages/rest-api-client/src/client/AppClient.ts
+++ b/packages/rest-api-client/src/client/AppClient.ts
@@ -1,6 +1,6 @@
-import { HttpClient } from "../http";
+import type { HttpClient } from "../http";
 import { buildPath } from "../url";
-import {
+import type {
   AppID,
   RecordID,
   Revision,

--- a/packages/rest-api-client/src/client/BulkRequestClient.ts
+++ b/packages/rest-api-client/src/client/BulkRequestClient.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from "../http";
+import type { HttpClient } from "../http";
 import { buildPath } from "../url";
 
 export type EndpointName =

--- a/packages/rest-api-client/src/client/FileClient.ts
+++ b/packages/rest-api-client/src/client/FileClient.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from "../http";
+import type { HttpClient } from "../http";
 import { buildPath } from "../url";
 import FormData from "form-data";
 import { platformDeps } from "../platform";

--- a/packages/rest-api-client/src/client/RecordClient.ts
+++ b/packages/rest-api-client/src/client/RecordClient.ts
@@ -1,8 +1,8 @@
 import { buildPath } from "./../url";
-import { HttpClient } from "./../http/";
-import { BulkRequestClient } from "./BulkRequestClient";
+import type { HttpClient } from "./../http/";
+import type { BulkRequestClient } from "./BulkRequestClient";
 import { KintoneAllRecordsError } from "../error/KintoneAllRecordsError";
-import {
+import type {
   AppID,
   RecordID,
   Revision,

--- a/packages/rest-api-client/src/client/__tests__/AppClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/AppClient.test.ts
@@ -1,4 +1,5 @@
-import { MockClient, buildMockClient } from "../../http/MockClient";
+import type { MockClient } from "../../http/MockClient";
+import { buildMockClient } from "../../http/MockClient";
 import { AppClient } from "../AppClient";
 import { KintoneRequestConfigBuilder } from "../../KintoneRequestConfigBuilder";
 

--- a/packages/rest-api-client/src/client/__tests__/BulkRequestClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/BulkRequestClient.test.ts
@@ -1,4 +1,5 @@
-import { MockClient, buildMockClient } from "../../http/MockClient";
+import type { MockClient } from "../../http/MockClient";
+import { buildMockClient } from "../../http/MockClient";
 import { BulkRequestClient } from "../BulkRequestClient";
 import { KintoneRequestConfigBuilder } from "../../KintoneRequestConfigBuilder";
 

--- a/packages/rest-api-client/src/client/__tests__/File.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/File.test.ts
@@ -1,4 +1,5 @@
-import { MockClient, buildMockClient } from "../../http/MockClient";
+import type { MockClient } from "../../http/MockClient";
+import { buildMockClient } from "../../http/MockClient";
 import { FileClient } from "../FileClient";
 import FormData from "form-data";
 import { injectPlatformDeps } from "../../platform";

--- a/packages/rest-api-client/src/client/__tests__/RecordClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/RecordClient.test.ts
@@ -1,9 +1,10 @@
 import { RecordClient } from "../RecordClient";
 import { BulkRequestClient } from "../BulkRequestClient";
-import { MockClient, buildMockClient } from "../../http/MockClient";
+import type { MockClient } from "../../http/MockClient";
+import { buildMockClient } from "../../http/MockClient";
 import { KintoneAllRecordsError } from "../../error/KintoneAllRecordsError";
 import { KintoneRestAPIError } from "../../error/KintoneRestAPIError";
-import { Record } from "../types";
+import type { Record } from "../types";
 import { KintoneRequestConfigBuilder } from "../../KintoneRequestConfigBuilder";
 
 describe("RecordClient", () => {

--- a/packages/rest-api-client/src/client/types/app/action.ts
+++ b/packages/rest-api-client/src/client/types/app/action.ts
@@ -1,5 +1,5 @@
-import { Entity } from "../entity";
-import { AppID } from "../index";
+import type { Entity } from "../entity";
+import type { AppID } from "../index";
 
 // --- Types for request ---
 

--- a/packages/rest-api-client/src/client/types/app/form.ts
+++ b/packages/rest-api-client/src/client/types/app/form.ts
@@ -1,5 +1,5 @@
-import { OneOf as FieldProperty } from "../../../KintoneFields/types/property";
-import {
+import type { OneOf as FieldProperty } from "../../../KintoneFields/types/property";
+import type {
   Row,
   Subtable,
   Group,

--- a/packages/rest-api-client/src/client/types/app/notification.ts
+++ b/packages/rest-api-client/src/client/types/app/notification.ts
@@ -1,4 +1,4 @@
-import { Entity } from "../entity";
+import type { Entity } from "../entity";
 
 export type GeneralNotificationForParameter = {
   entity:

--- a/packages/rest-api-client/src/client/types/app/processManagement.ts
+++ b/packages/rest-api-client/src/client/types/app/processManagement.ts
@@ -1,4 +1,4 @@
-import { Entity } from "../entity";
+import type { Entity } from "../entity";
 
 type AssigneeEntityForResponse = {
   entity:

--- a/packages/rest-api-client/src/client/types/app/right.ts
+++ b/packages/rest-api-client/src/client/types/app/right.ts
@@ -1,4 +1,4 @@
-import { Entity } from "../entity";
+import type { Entity } from "../entity";
 
 type FieldRightAccessibility = "READ" | "WRITE" | "NONE";
 

--- a/packages/rest-api-client/src/client/types/record/index.ts
+++ b/packages/rest-api-client/src/client/types/record/index.ts
@@ -1,4 +1,4 @@
-import { OneOf as Field } from "../../../KintoneFields/types/field";
+import type { OneOf as Field } from "../../../KintoneFields/types/field";
 
 export type Record = {
   [fieldCode: string]: Field;

--- a/packages/rest-api-client/src/error/KintoneAllRecordsError.ts
+++ b/packages/rest-api-client/src/error/KintoneAllRecordsError.ts
@@ -1,4 +1,4 @@
-import { KintoneRestAPIError } from "./KintoneRestAPIError";
+import type { KintoneRestAPIError } from "./KintoneRestAPIError";
 
 export class KintoneAllRecordsError extends Error {
   processedRecordsResult: any;

--- a/packages/rest-api-client/src/error/KintoneRestAPIError.ts
+++ b/packages/rest-api-client/src/error/KintoneRestAPIError.ts
@@ -1,4 +1,4 @@
-import { ErrorResponse } from "../http/HttpClientInterface";
+import type { ErrorResponse } from "../http/HttpClientInterface";
 
 type SingleErrorResponseData = {
   id: string;

--- a/packages/rest-api-client/src/error/__tests__/KintoneAllRecordsError.test.ts
+++ b/packages/rest-api-client/src/error/__tests__/KintoneAllRecordsError.test.ts
@@ -1,6 +1,6 @@
 import { KintoneAllRecordsError } from "../KintoneAllRecordsError";
 import { KintoneRestAPIError } from "../KintoneRestAPIError";
-import { ErrorResponse } from "../../http/HttpClientInterface";
+import type { ErrorResponse } from "../../http/HttpClientInterface";
 
 describe("KintoneAllRecordsError", () => {
   let kintoneAllRecordsError: KintoneAllRecordsError;

--- a/packages/rest-api-client/src/http/AxiosClient.ts
+++ b/packages/rest-api-client/src/http/AxiosClient.ts
@@ -1,11 +1,11 @@
 import Axios from "axios";
-import {
+import type {
   HttpClient,
   RequestConfigBuilder,
   RequestConfig,
   ResponseHandler,
 } from "./HttpClientInterface";
-import FormData from "form-data";
+import type FormData from "form-data";
 
 export class AxiosClient implements HttpClient {
   private responseHandler: ResponseHandler;

--- a/packages/rest-api-client/src/http/HttpClientInterface.ts
+++ b/packages/rest-api-client/src/http/HttpClientInterface.ts
@@ -1,4 +1,4 @@
-import FormData from "form-data";
+import type FormData from "form-data";
 export interface HttpClient {
   get: <T extends object>(path: string, params: object) => Promise<T>;
   getData: (path: string, params: object) => Promise<ArrayBuffer>;

--- a/packages/rest-api-client/src/http/MockClient.ts
+++ b/packages/rest-api-client/src/http/MockClient.ts
@@ -1,10 +1,10 @@
-import {
+import type {
   HttpClient,
   RequestConfigBuilder,
   ResponseHandler,
-  Response,
 } from "./HttpClientInterface";
-import FormData from "form-data";
+import { Response } from "./HttpClientInterface";
+import type FormData from "form-data";
 import { KintoneResponseHandler } from "../KintoneResponseHandler";
 
 type Log = {

--- a/packages/rest-api-client/src/platform/browser.ts
+++ b/packages/rest-api-client/src/platform/browser.ts
@@ -1,5 +1,5 @@
 import { UnsupportedPlatformError } from "./UnsupportedPlatformError";
-import { DiscriminatedAuth } from "../types/auth";
+import type { DiscriminatedAuth } from "../types/auth";
 
 export const readFileFromPath = (filePath: string) => {
   throw new UnsupportedPlatformError("Browser");

--- a/packages/rest-api-client/src/platform/index.ts
+++ b/packages/rest-api-client/src/platform/index.ts
@@ -1,4 +1,4 @@
-import { DiscriminatedAuth } from "../types/auth";
+import type { DiscriminatedAuth } from "../types/auth";
 type PlatformDeps = {
   readFileFromPath: (
     filePath: string

--- a/packages/webpack-plugin-kintone-plugin/src/index.ts
+++ b/packages/webpack-plugin-kintone-plugin/src/index.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import mkdirp from "mkdirp";
 import path from "path";
-import { Compiler, WebpackPluginInstance } from "webpack";
+import type { Compiler, WebpackPluginInstance } from "webpack";
 
 import { generatePlugin, getAssetPaths } from "./plugin";
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

Fixes https://github.com/kintone/js-sdk/issues/1831


## What

- [x] lint rule [consistent-type-imports](https://typescript-eslint.io/rules/consistent-type-imports) is added
- [x] Related files are updated following this rule


## How to test

```
yarn build
yarn test
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
