### PR TITLE
docs(create-plugin): replacing devnet URL to new version link

### DIFF
--- a/packages/create-plugin/README.md
+++ b/packages/create-plugin/README.md
@@ -131,7 +131,7 @@ npm run lint
 kintoneプラグイン開発をはじめましょう！
 開発に関する情報はcybozu developer network:
 
-  https://developer.cybozu.io
+  https://cybozu.dev/ja/
 ```
 
 ## Templates (Experimental)

--- a/packages/create-plugin/src/messages.ts
+++ b/packages/create-plugin/src/messages.ts
@@ -128,7 +128,7 @@ kintoneプラグインのプロジェクトを作成するために、いくつ�
     en: "",
     ja: `開発に関する情報はcybozu developer network:
 
-  https://developer.cybozu.io
+  https://cybozu.dev/ja/
 `,
   },
   Error_alreadyExists: {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

The new devnet will be released on February, and devnet url will be changed.
So, now we need to change to the new one.

| old | new |
| ---| --- |
| https://developer.cybozu.io/ | https://cybozu.dev/ |

## What

- [x] replacing devnet URL from old version link to new version link

## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `yarn lint` and `yarn test` on the root directory.
