### PR TITLE
ci: pin version of third party actions

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,5 +1,8 @@
 {
-  extends: ["github>cybozu/renovate-config", ":prConcurrentLimitNone"],
+  extends: [
+    "github>cybozu/renovate-config",
+    ":prConcurrentLimitNone"
+  ],
   ignorePaths: [
     "**/node_modules/**",
     "**/bower_components/**",
@@ -16,11 +19,30 @@
     packageRules: [
       {
         // automerge minor updates of devDependencies
-        matchPackagePatterns: ["*"],
-        matchDepTypes: ["devDependencies"],
-        matchUpdateTypes: ["minor"],
+        matchPackagePatterns: [
+          "*"
+        ],
+        matchDepTypes: [
+          "devDependencies"
+        ],
+        matchUpdateTypes: [
+          "minor"
+        ],
         automerge: true,
       },
     ],
   },
+  "packageRules": [
+    {
+      // Third party actions should be pinned with digest
+      "matchDepTypes": [
+        "action"
+      ],
+      excludePackagePrefixes: [
+        "actions/",
+        "cybozu/"
+      ],
+      "pinDigests": true
+    }
+  ]
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

To use digest pinning but want to follow the action version tag on updating third party actions

## What

<!-- What is a solution you want to add? -->

- Specify version to third party actions

https://docs.renovatebot.com/modules/manager/github-actions/#additional-information
https://zenn.dev/roottool/scraps/5a73b98e88d4d1

## How to test

<!-- How can we test this pull request? -->

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `yarn lint` and `yarn test` on the root directory.
