### PR TITLE
fix: downgrade axios to 0.27.2

### DIFF
--- a/packages/dts-gen/package.json
+++ b/packages/dts-gen/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "dependencies": {
     "@cybozu/eslint-config": "^18.0.2",
-    "axios": "^1.3.4",
+    "axios": "^0.27.2",
     "commander": "^10.0.0",
     "eslint": "^8.36.0",
     "form-data": "^4.0.0",

--- a/packages/dts-gen/src/kintone/clients/axios-utils.test.ts
+++ b/packages/dts-gen/src/kintone/clients/axios-utils.test.ts
@@ -1,6 +1,5 @@
 import { AxiosUtils, VisibleForTesting } from "./axios-utils";
 import type { AxiosRequestConfig } from "axios";
-import { AxiosHeaders } from "axios";
 
 describe("FormsClientImpl#constructor", () => {
   const baseUrl = "https://kintone.com";
@@ -27,9 +26,9 @@ describe("FormsClientImpl#constructor", () => {
       basicAuthUsername: null,
     };
 
-    const headers = new AxiosHeaders({
+    const headers = {
       "X-Cybozu-Authorization": authToken,
-    });
+    };
     const expectedCalledWith = {
       headers,
       baseURL: baseUrl,
@@ -48,45 +47,19 @@ describe("FormsClientImpl#constructor", () => {
       basicAuthUsername: null,
     };
 
-    const headers = new AxiosHeaders({
+    const headers = {
       "X-Cybozu-Authorization": authToken,
-    });
+    };
     const expectedCalledWith = {
       headers,
       baseURL: baseUrl,
       proxy: {
-        protocol: "http:",
         host: "localhost",
         port: 1234,
         auth: {
           username: "admin",
           password: "password",
         },
-      },
-    };
-    assertConstructorWithArgs(input, expectedCalledWith);
-  });
-
-  test("with proxy option and empty proxy authorization", () => {
-    const input = {
-      baseUrl,
-      username: "username",
-      password: "password",
-      proxy: "https://localhost:1234",
-      basicAuthPassword: null,
-      basicAuthUsername: null,
-    };
-
-    const headers = new AxiosHeaders({
-      "X-Cybozu-Authorization": authToken,
-    });
-    const expectedCalledWith = {
-      headers,
-      baseURL: baseUrl,
-      proxy: {
-        protocol: "https:",
-        host: "localhost",
-        port: 1234,
       },
     };
     assertConstructorWithArgs(input, expectedCalledWith);
@@ -102,10 +75,10 @@ describe("FormsClientImpl#constructor", () => {
       basicAuthUsername: "basicPassword",
     };
 
-    const headers = new AxiosHeaders({
+    const headers = {
       "X-Cybozu-Authorization": authToken,
       Authorization: "Basic YmFzaWNQYXNzd29yZDpiYXNpY1VzZXJuYW1l",
-    });
+    };
     const expectedCalledWith = {
       headers,
       baseURL: baseUrl,

--- a/packages/dts-gen/src/kintone/clients/axios-utils.ts
+++ b/packages/dts-gen/src/kintone/clients/axios-utils.ts
@@ -4,7 +4,7 @@ import type {
   AxiosRequestConfig,
   AxiosRequestHeaders,
 } from "axios";
-import axios, { AxiosHeaders } from "axios";
+import axios from "axios";
 
 export interface NewInstanceInput {
   baseUrl: string;
@@ -21,32 +21,32 @@ const newAxiosInstance = (input: NewInstanceInput): AxiosInstance => {
   let proxy: AxiosProxyConfig | undefined;
   // parse the proxy URL like http://admin:pass@localhost:8000
   if (input.proxy) {
-    const { protocol, hostname, port, username, password } = new URL(
-      input.proxy
-    );
+    const proxyUrl = new URL(input.proxy);
     proxy = {
-      protocol,
-      host: hostname,
-      port: parseInt(port, 10),
+      host: proxyUrl.hostname,
+      port: parseInt(proxyUrl.port, 10),
+      auth: {
+        username: proxyUrl.username,
+        password: proxyUrl.password,
+      },
     };
-
-    if (username.length > 0 && password.length > 0) {
-      proxy.auth = {
-        username,
-        password,
-      };
-    }
   }
 
-  const headers: AxiosRequestHeaders = new AxiosHeaders();
+  let headers: AxiosRequestHeaders;
   if (input.username && input.password) {
-    headers["X-Cybozu-Authorization"] = Buffer.from(
-      `${input.username}:${input.password}`
-    ).toString("base64");
+    headers = {
+      "X-Cybozu-Authorization": Buffer.from(
+        `${input.username}:${input.password}`
+      ).toString("base64"),
+    };
   } else if (input.apiToken) {
-    headers["X-Cybozu-API-Token"] = input.apiToken;
+    headers = {
+      "X-Cybozu-API-Token": input.apiToken,
+    };
   } else if (input.oAuthToken) {
-    headers.Authorization = `Bearer ${input.oAuthToken}`;
+    headers = {
+      Authorization: `Bearer ${input.oAuthToken}`,
+    };
   } else {
     throw new Error("cannot get an authentication input");
   }

--- a/packages/rest-api-client/package.json
+++ b/packages/rest-api-client/package.json
@@ -73,7 +73,7 @@
     "rollup-plugin-terser": "^7.0.2"
   },
   "dependencies": {
-    "axios": "^1.3.4",
+    "axios": "^0.27.2",
     "core-js": "^3.29.1",
     "form-data": "^4.0.0",
     "js-base64": "^3.7.5",

--- a/packages/rest-api-client/src/KintoneRequestConfigBuilder.ts
+++ b/packages/rest-api-client/src/KintoneRequestConfigBuilder.ts
@@ -15,8 +15,6 @@ import type { Agent as HttpsAgent } from "https";
 
 type Data = Params | FormData;
 
-const HTTP_PROXY_PROTOCOL = "http:";
-
 type KintoneAuthHeader =
   | {
       "X-Cybozu-Authorization": string;
@@ -104,7 +102,7 @@ export class KintoneRequestConfigBuilder implements RequestConfigBuilder {
         httpsAgent: this.httpsAgent,
         clientCertAuth: this.clientCertAuth,
       }),
-      proxy: this.buildProxy(this.proxy),
+      proxy: this.proxy,
     };
 
     switch (method) {
@@ -161,24 +159,6 @@ export class KintoneRequestConfigBuilder implements RequestConfigBuilder {
         throw new Error(`${method} method is not supported`);
       }
     }
-  }
-
-  private buildProxy(targetProxy?: ProxyConfig): ProxyConfig | undefined {
-    if (!targetProxy) {
-      return targetProxy;
-    }
-
-    const proxy: ProxyConfig = { ...targetProxy };
-    if (
-      proxy.auth &&
-      (proxy.auth.username.length === 0 || proxy.auth.password.length === 0)
-    ) {
-      proxy.auth = undefined;
-    }
-
-    proxy.protocol = proxy.protocol ?? HTTP_PROXY_PROTOCOL;
-
-    return proxy;
   }
 
   private buildRequestUrl(path: string, params: Data): string {

--- a/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
+++ b/packages/rest-api-client/src/__tests__/KintoneRequestConfigBuilder.test.ts
@@ -1,4 +1,3 @@
-import type { ProxyConfig } from "../http/HttpClientInterface";
 import { KintoneRequestConfigBuilder } from "../KintoneRequestConfigBuilder";
 import FormData from "form-data";
 import { injectPlatformDeps } from "../platform";
@@ -336,7 +335,7 @@ describe("options", () => {
       "X-Cybozu-API-Token": apiToken,
       "User-Agent": expectedDefaultUa,
     };
-    const proxy: ProxyConfig = {
+    const proxy = {
       host: "localhost",
       port: 8000,
       auth: {
@@ -359,14 +358,11 @@ describe("options", () => {
       "/k/v1/record.json",
       { key: "value" }
     );
-    const expectedProxy = Object.assign({}, proxy);
-    expectedProxy.protocol = "http:";
-
     expect(requestConfig).toStrictEqual({
       method: "get",
       url: `${baseUrl}/k/v1/record.json?key=value`,
       headers,
-      proxy: expectedProxy,
+      proxy,
     });
   });
 

--- a/packages/rest-api-client/src/http/HttpClientInterface.ts
+++ b/packages/rest-api-client/src/http/HttpClientInterface.ts
@@ -30,7 +30,6 @@ export type ProxyConfig = {
     username: string;
     password: string;
   };
-  protocol?: string;
 };
 
 export interface HttpClientError<T = ErrorResponse> extends Error {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4292,7 +4292,15 @@ axe-core@^4.6.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.6.3.tgz#fc0db6fdb65cc7a80ccf85286d91d64ababa3ece"
   integrity sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==
 
-axios@^1.0.0, axios@^1.3.4:
+axios@^0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+  dependencies:
+    follow-redirects "^1.14.9"
+    form-data "^4.0.0"
+
+axios@^1.0.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.3.4.tgz#f5760cefd9cfb51fd2481acf88c05f67c4523024"
   integrity sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==
@@ -7204,7 +7212,7 @@ follow-redirects@^1.0.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
   integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
 
-follow-redirects@^1.15.0:
+follow-redirects@^1.14.9, follow-redirects@^1.15.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

After upgrading Axios package to version 1.3.4 for rest-api-client and dts-gen #1763,
There is a critical issue with vercel/pkg package.

```
pkg/prelude/bootstrap.js:1872
      throw error;
      ^

Error: Cannot find module '/snapshot/cli-kintone/node_modules/axios/dist/node/axios.cjs'
1) If you want to compile the package/file into executable, please pay attention to compilation warnings and specify a literal in 'require' call. 2) If you don't want to compile the package/file into executable and want to 'require' it from filesystem (likely plugin), specify an absolute path in 'require' call using process.cwd() or process.execPath.
    at createEsmNotFoundErr (node:internal/modules/cjs/loader:960:15)
    at finalizeEsmResolution (node:internal/modules/cjs/loader:953:15)
    at resolveExports (node:internal/modules/cjs/loader:482:14)
    at Function.Module._findPath (node:internal/modules/cjs/loader:522:31)
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:919:27)
    at Function._resolveFilename (pkg/prelude/bootstrap.js:1951:46)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at Module.require (pkg/prelude/bootstrap.js:1851:31)
    at require (node:internal/modules/cjs/helpers:102:18) {
  code: 'MODULE_NOT_FOUND',
  path: '/snapshot/cli-kintone/node_modules/axios/package.json',
  pkg: true
}
```

## What

- [x] Downgrade Axios to v0.27.2 for rest-api-client and dts-gen


## How to test

`yarn build & yarn test`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
