### PR TITLE
An error is caught, ends with exit status 1

### DIFF
--- a/packages/dts-gen/src/index.ts
+++ b/packages/dts-gen/src/index.ts
@@ -37,5 +37,5 @@ const handler = async () => {
 handler().catch((err) => {
   console.error(err);
   // eslint-disable-next-line no-process-exit
-  process.exit(2);
+  process.exit(1);
 });

--- a/packages/dts-gen/src/index.ts
+++ b/packages/dts-gen/src/index.ts
@@ -34,4 +34,8 @@ const handler = async () => {
   await TypeDefinitionTemplate.renderAsFile(args.output, input);
 };
 
-handler().catch((err) => console.error(err));
+handler().catch((err) => {
+  console.error(err);
+  // eslint-disable-next-line no-process-exit
+  process.exit(2);
+});


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

When an error is caught by the handler() function, the command exits with exit status 0, so I'm unable to do error handling from a parent process.

Specifically, I am calling kintone-dts-gen in a loop within my tool "Goqoo on kintone" as follows, and I want to judge if the dts file creation succeeded or failed.
https://github.com/goqoo-on-kintone/goqoo/blob/267c1fbbf87b80f52e4882a0955c8f10ee6e8a01/src/generator/dts/index.ts#L53-L84

## What

<!-- What is a solution you want to add? -->

An error is caught, ends with exit status other than 0.
I returned 2 because there was already a process that returned 1, but it can be anything other than 2.

## How to test

<!-- How can we test this pull request? -->

```shell
$ kintone-dts-gen --base-url example.cybozu.com -u hoge -p fuga --app-id 0 # Failed
$ echo $? # Before:0 / After:2
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
