### PR TITLE
ci: stop using local checksum of yamory script

### DIFF
--- a/.github/workflows/yamory.yml
+++ b/.github/workflows/yamory.yml
@@ -18,14 +18,12 @@ jobs:
         node-version: 16.x
         cache: yarn
     - name: download and validate Yamory script
-      env:
-        # https://cli.yamory.io/yamory-app-library-scan-scripts/yamory-yarn-sha512sum.txt
-        YAMORY_YARN_SCRIPT_SHA512: "fa35d9b188d98a5985e8be9a27b9f810fdc8868db0d5228c063f30ebbf3293bcbfe6fd14b02f26483cbe9d46499b3e7857266c62f57e568a741254d5d9720b3e"
       working-directory: /tmp
       run: |
-        curl -sSf -L -o ./yamory-yarn.sh \
-        https://localscanner.yamory.io/script/yarn
-        echo "${YAMORY_YARN_SCRIPT_SHA512} yamory-yarn.sh" | sha512sum --check -
+        curl -sSf -L -o ./yamory-yarn.sh https://localscanner.yamory.io/script/yarn
+        curl -sSf -L -o ./yamory-yarn-sha512sum.txt \
+          https://cli.yamory.io/yamory-app-library-scan-scripts/yamory-yarn-sha512sum.txt
+        sha512sum --check yamory-yarn-sha512sum.txt
         chmod +x ./yamory-yarn.sh
     - name: run Yamory
       run: |


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Currently, we validate the yamory scan script with SHA512 checksum to detect falsification.
We store the checksum on the workflow’s environment variable because it's a possible situation where both script and checksum are falsified.
However, it makes CI fail when the yamory script is updated.
We cannot predict when the yamory script will be updated, So CI fails randomly in effect.

In https://github.com/kintone/cli-kintone/pull/295, we made the default workflow permission `read-only`.
So that yamory workflow can only read repository contents now.
Our repositories are public, so there is no risk in reading the repo.

Therefore, we can remove stored checksum and download checksum file on each CI run. 

## What

<!-- What is a solution you want to add? -->

- remove `YAMORY_YARN_SCRIPT_SHA512` env variable

## How to test

<!-- How can we test this pull request? -->

See the result of the latest CI run.
https://github.com/kintone/js-sdk/actions/runs/4618278806/jobs/8165529845?pr=2018

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
