### PR TITLE
build: drop Node v14 support because of the EOL

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,14 +10,14 @@ on:
 
 jobs:
   build:
-    name: Node.js ubuntu-latest 16.x
+    name: Node.js ubuntu-latest 18.x
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js 16.x
+    - name: Use Node.js 18.x
       uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: 18.x
         cache: yarn
     - run:  yarn install --frozen-lockfile
     - run:  yarn build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
         with:
           # fetch all commits and tags (https://github.com/lerna/lerna/issues/2542)
           fetch-depth: "0"
-      - name: Use Node.js 16.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: yarn
       - run: yarn install --frozen-lockfile
       - name: Configure git user

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -15,10 +15,10 @@ jobs:
         with:
           # fetch all commits and tags (https://github.com/lerna/lerna/issues/2542)
           fetch-depth: "0"
-      - name: Use Node.js 16.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: yarn
       - run: yarn install --frozen-lockfile
       - name: Generate next release (dry-run)

--- a/.github/workflows/yamory.yml
+++ b/.github/workflows/yamory.yml
@@ -8,14 +8,14 @@ on:
       - yamory-*
 jobs:
   build:
-    name: Node.js ubuntu-latest 16.x
+    name: Node.js ubuntu-latest 18.x
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js 16.x
+    - name: Use Node.js 18.x
       uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: 18.x
         cache: yarn
     - name: download and validate Yamory script
       working-directory: /tmp

--- a/examples/rest-api-client-demo/package.json
+++ b/examples/rest-api-client-demo/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/kintone/js-sdk/issues"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "dependencies": {
     "@kintone/profile-loader": "^3.0.2",

--- a/packages/create-plugin/package.json
+++ b/packages/create-plugin/package.json
@@ -8,7 +8,7 @@
   },
   "main": "dist/src/index.js",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "repository": {
     "type": "git",

--- a/packages/customize-uploader/package.json
+++ b/packages/customize-uploader/package.json
@@ -7,7 +7,7 @@
   },
   "main": "dist/index.js",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "scripts": {
     "prebuild": "yarn clean",

--- a/packages/dts-gen/package.json
+++ b/packages/dts-gen/package.json
@@ -21,7 +21,7 @@
     "build:integration": "webpack --mode development --config webpack.config.js"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "author": {
     "name": "Cybozu, Inc.",

--- a/packages/plugin-manifest-validator/package.json
+++ b/packages/plugin-manifest-validator/package.json
@@ -6,7 +6,7 @@
     "url": "https://cybozu.co.jp"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "main": "dist/src/index.js",
   "files": [

--- a/packages/plugin-packer/package.json
+++ b/packages/plugin-packer/package.json
@@ -7,7 +7,7 @@
     "url": "https://cybozu.co.jp"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "main": "dist/index.js",
   "bin": {

--- a/packages/plugin-uploader/package.json
+++ b/packages/plugin-uploader/package.json
@@ -7,7 +7,7 @@
   },
   "main": "dist/index.js",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "scripts": {
     "start": "yarn build --watch",

--- a/packages/profile-loader/package.json
+++ b/packages/profile-loader/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/kintone/js-sdk/tree/master/packages/profile-loader#readme",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "scripts": {
     "prebuild": "yarn clean",

--- a/packages/rest-api-client/package.json
+++ b/packages/rest-api-client/package.json
@@ -54,7 +54,7 @@
   },
   "homepage": "https://github.com/kintone/js-sdk/tree/master/packages/rest-api-client#readme",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "devDependencies": {
     "@rollup/plugin-babel": "^6.0.3",

--- a/packages/webpack-plugin-kintone-plugin/package.json
+++ b/packages/webpack-plugin-kintone-plugin/package.json
@@ -4,7 +4,7 @@
   "description": "A webpack plugin to generate a plugin zip",
   "main": "dist/index.js",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "scripts": {
     "start": "yarn build --watch",


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
Node v14 has been in EOL since April 30th in 2023.


## What

<!-- What is a solution you want to add? -->
- drop Node v14 from the engines of each packages.
  - From this PR, the oldest supported version is v16.
- update Node version in CI ([14, 16, 18] → [16, 18, 20])


## How to test

<!-- How can we test this pull request? -->
N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
