### PR TITLE
fix(dts-gen): validate namespace and typename

### DIFF
--- a/packages/dts-gen/docs/field-type-definition-guide.md
+++ b/packages/dts-gen/docs/field-type-definition-guide.md
@@ -17,3 +17,9 @@ Additional to fields of `com.cybozu.kintone.AwesomeFields`,
 this type includes `$id`, `$revision`, create time, creator, update time and update time fields.
 
 This fields will be included when you refer to a saved record.
+
+## Notes
+
+`namespace` and `type-name` convention:
+- Starts with a letter (`a-z` or `A-Z`), underscore (`_`), or dollar sign (`$`).
+- Can be followed by any alphanumeric, underscores, or dollar signs.

--- a/packages/dts-gen/src/cli-parser.ts
+++ b/packages/dts-gen/src/cli-parser.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
+import { validateArgs } from "./validators/args";
 
-interface ParsedArgs {
+export interface ParsedArgs {
   baseUrl: string;
   username: string | null;
   password: string | null;
@@ -82,6 +83,7 @@ export const parse = (argv: string[]): ParsedArgs => {
 
   const options = program.opts();
   const {
+    baseUrl,
     username,
     password,
     apiToken,
@@ -98,12 +100,7 @@ export const parse = (argv: string[]): ParsedArgs => {
     output,
   } = options;
 
-  const baseUrl = options.baseUrl;
-  if (baseUrl === null) {
-    throw new Error("--base-url (KINTONE_BASE_URL) must be specified");
-  }
-
-  return {
+  const parsedArgs: ParsedArgs = {
     baseUrl,
     username,
     password,
@@ -120,4 +117,8 @@ export const parse = (argv: string[]): ParsedArgs => {
     namespace,
     output,
   };
+
+  validateArgs(parsedArgs);
+
+  return parsedArgs;
 };

--- a/packages/dts-gen/src/index.ts
+++ b/packages/dts-gen/src/index.ts
@@ -1,9 +1,11 @@
+import type { RenderInput } from "./types/template";
 import { FormsClientImpl } from "./kintone/clients/forms-client-impl";
 import { DemoClient } from "./kintone/clients/demo-client";
 import { FieldTypeConverter } from "./converters/fileldtype-converter";
 import { TypeDefinitionTemplate } from "./templates/template";
 import { objectValues } from "./utils/objectvalues";
 import { parse } from "./cli-parser";
+import { validateArgs } from "./validators/args";
 
 process.on("uncaughtException", (e) => {
   console.error(e.message);
@@ -22,11 +24,13 @@ const fetchFormPropertiesInput = {
 };
 
 const handler = async () => {
+  validateArgs({ namespace: args.namespace, typeName: args.typeName });
+
   const properties = await client.fetchFormProperties(fetchFormPropertiesInput);
   const fieldTypeGroups = FieldTypeConverter.convertFieldTypesToFieldTypeGroups(
     objectValues(properties)
   );
-  const input = {
+  const input: RenderInput = {
     typeName: args.typeName,
     namespace: args.namespace,
     fieldTypeGroups,

--- a/packages/dts-gen/src/index.ts
+++ b/packages/dts-gen/src/index.ts
@@ -1,11 +1,10 @@
-import type { RenderInput } from "./types/template";
+import type { RenderInput } from "./templates/template";
 import { FormsClientImpl } from "./kintone/clients/forms-client-impl";
 import { DemoClient } from "./kintone/clients/demo-client";
 import { FieldTypeConverter } from "./converters/fileldtype-converter";
 import { TypeDefinitionTemplate } from "./templates/template";
 import { objectValues } from "./utils/objectvalues";
 import { parse } from "./cli-parser";
-import { validateArgs } from "./validators/args";
 
 process.on("uncaughtException", (e) => {
   console.error(e.message);
@@ -24,8 +23,6 @@ const fetchFormPropertiesInput = {
 };
 
 const handler = async () => {
-  validateArgs({ namespace: args.namespace, typeName: args.typeName });
-
   const properties = await client.fetchFormProperties(fetchFormPropertiesInput);
   const fieldTypeGroups = FieldTypeConverter.convertFieldTypesToFieldTypeGroups(
     objectValues(properties)

--- a/packages/dts-gen/src/templates/converter.ts
+++ b/packages/dts-gen/src/templates/converter.ts
@@ -1,4 +1,4 @@
-import type { FieldTypeGroups } from "../converters/fileldtype-converter";
+import type { RenderInput } from "../types/template";
 import * as F from "./expressions/fields";
 import { Namespace } from "./expressions/namespace";
 import {
@@ -11,17 +11,13 @@ export const convertToTsExpression = ({
   namespace,
   typeName,
   fieldTypeGroups,
-}: {
-  namespace: string;
-  typeName: string;
-  fieldTypeGroups: FieldTypeGroups;
-}): Namespace => {
+}: RenderInput): Namespace => {
   const fieldGroup = convertToFieldGroup(fieldTypeGroups);
   const subTableFields = fieldTypeGroups.subTableFields.map(
     (f) => new F.SubTableField(f.code, f.type, convertToFieldGroup(f.fields))
   );
 
-  const typeDefenition = new TypeDefinition(
+  const typeDefinition = new TypeDefinition(
     typeName,
     fieldGroup,
     subTableFields
@@ -36,13 +32,13 @@ export const convertToTsExpression = ({
       (f) => new F.TsDefinedField(f.code, f.type)
     );
 
-  const savedTypeDefenition = new SavedTypeDefinition(
+  const savedTypeDefinition = new SavedTypeDefinition(
     typeName,
     userFields,
     stringFieldsInSavedRecord
   );
 
-  return new Namespace(namespace, typeDefenition, savedTypeDefenition);
+  return new Namespace(namespace, typeDefinition, savedTypeDefinition);
 };
 
 interface ConvertToFieldGroupInput {

--- a/packages/dts-gen/src/templates/converter.ts
+++ b/packages/dts-gen/src/templates/converter.ts
@@ -1,4 +1,4 @@
-import type { RenderInput } from "../types/template";
+import type { RenderInput } from "./template";
 import * as F from "./expressions/fields";
 import { Namespace } from "./expressions/namespace";
 import {

--- a/packages/dts-gen/src/templates/expressions/namespace.ts
+++ b/packages/dts-gen/src/templates/expressions/namespace.ts
@@ -4,14 +4,14 @@ import type { TsExpression } from "./expression";
 export class Namespace implements TsExpression {
   constructor(
     private namespace: string,
-    private typeDefenition: TypeDefinition,
-    private savedTypeDefenition: SavedTypeDefinition
+    private typeDefinition: TypeDefinition,
+    private savedTypeDefinition: SavedTypeDefinition
   ) {}
   tsExpression(): string {
     return `
 declare namespace ${this.namespace} {
-    ${this.typeDefenition.tsExpression()}
-    ${this.savedTypeDefenition.tsExpression()}
+    ${this.typeDefinition.tsExpression()}
+    ${this.savedTypeDefinition.tsExpression()}
 }`.trim();
   }
 }

--- a/packages/dts-gen/src/templates/template.ts
+++ b/packages/dts-gen/src/templates/template.ts
@@ -3,14 +3,8 @@ import * as path from "path";
 import * as prettier from "prettier";
 import { ESLint } from "eslint";
 
-import type { FieldTypeGroups } from "../converters/fileldtype-converter";
+import type { RenderInput } from "../types/template";
 import { convertToTsExpression } from "./converter";
-
-interface RenderInput {
-  typeName: string;
-  namespace: string;
-  fieldTypeGroups: FieldTypeGroups;
-}
 
 const renderAsFile = async (output: string, renderInput: RenderInput) => {
   const tsExpression = convertToTsExpression(renderInput);
@@ -32,8 +26,15 @@ const renderAsFile = async (output: string, renderInput: RenderInput) => {
   });
   const eslintResult = (await eslint.lintText(tsExpression.tsExpression()))[0];
   if (eslintResult.fatalErrorCount > 0) {
+    let errorMessage = "";
+    if (eslintResult.messages.length > 0) {
+      errorMessage = `Causes:`;
+      eslintResult.messages.forEach((error) => {
+        errorMessage += `\n- ${error.message}`;
+      });
+    }
     throw new Error(
-      "failed to fix lint errors on generated type definition file."
+      `Failed to fix lint errors on the generated type definition file.\n${errorMessage}`
     );
   }
   let eslintOutput = "";

--- a/packages/dts-gen/src/templates/template.ts
+++ b/packages/dts-gen/src/templates/template.ts
@@ -3,8 +3,14 @@ import * as path from "path";
 import * as prettier from "prettier";
 import { ESLint } from "eslint";
 
-import type { RenderInput } from "../types/template";
+import type { FieldTypeGroups } from "../converters/fileldtype-converter";
 import { convertToTsExpression } from "./converter";
+
+export interface RenderInput {
+  typeName: string;
+  namespace: string;
+  fieldTypeGroups: FieldTypeGroups;
+}
 
 const renderAsFile = async (output: string, renderInput: RenderInput) => {
   const tsExpression = convertToTsExpression(renderInput);

--- a/packages/dts-gen/src/types/template.ts
+++ b/packages/dts-gen/src/types/template.ts
@@ -1,7 +1,0 @@
-import type { FieldTypeGroups } from "../converters/fileldtype-converter";
-
-export type RenderInput = {
-  typeName: string;
-  namespace: string;
-  fieldTypeGroups: FieldTypeGroups;
-};

--- a/packages/dts-gen/src/types/template.ts
+++ b/packages/dts-gen/src/types/template.ts
@@ -1,0 +1,7 @@
+import type { FieldTypeGroups } from "../converters/fileldtype-converter";
+
+export type RenderInput = {
+  typeName: string;
+  namespace: string;
+  fieldTypeGroups: FieldTypeGroups;
+};

--- a/packages/dts-gen/src/validators/__tests__/args.test.ts
+++ b/packages/dts-gen/src/validators/__tests__/args.test.ts
@@ -1,0 +1,64 @@
+import { validateArgs } from "../args";
+
+const invalidNamespaceMessage = "Invalid namespace option!";
+const invalidTypeNameMessage = "Invalid type-name option!";
+const patterns = [
+  {
+    description:
+      "should not error when specifying valid namespace and type-name",
+    input: { namespace: "com.cybozu.kintone", typeName: "AwesomeFields" },
+    expected: {
+      failure: undefined,
+    },
+  },
+  {
+    description: "should error when namespace starts with a digit",
+    input: { namespace: "1test" },
+    expected: {
+      failure: {
+        errorMessage: invalidNamespaceMessage,
+      },
+    },
+  },
+  {
+    description: "should error when namespace contains invalid characters",
+    input: { namespace: "te-st" },
+    expected: {
+      failure: {
+        errorMessage: invalidNamespaceMessage,
+      },
+    },
+  },
+  {
+    description: "should error when type-name starts with a digit",
+    input: { typeName: "1test" },
+    expected: {
+      failure: {
+        errorMessage: invalidTypeNameMessage,
+      },
+    },
+  },
+  {
+    description: "should error when type-name contains invalid characters",
+    input: { typeName: "te-st" },
+    expected: {
+      failure: {
+        errorMessage: invalidTypeNameMessage,
+      },
+    },
+  },
+];
+
+describe("validateInput", () => {
+  test.each(patterns)("$description", (pattern) => {
+    if (pattern.expected.failure !== undefined) {
+      return expect(() => {
+        validateArgs(pattern.input);
+      }).toThrow(pattern.expected.failure.errorMessage);
+    }
+
+    return expect(() => {
+      validateArgs(pattern.input);
+    }).not.toThrow();
+  });
+});

--- a/packages/dts-gen/src/validators/__tests__/args.test.ts
+++ b/packages/dts-gen/src/validators/__tests__/args.test.ts
@@ -2,18 +2,51 @@ import { validateArgs } from "../args";
 
 const invalidNamespaceMessage = "Invalid namespace option!";
 const invalidTypeNameMessage = "Invalid type-name option!";
+const baseInput = {
+  baseUrl: "",
+  preview: false,
+  demo: false,
+  output: "",
+  username: null,
+  password: null,
+  oAuthToken: null,
+  apiToken: null,
+  proxy: null,
+  basicAuthPassword: null,
+  basicAuthUsername: null,
+  appId: null,
+  guestSpaceId: null,
+  typeName: "",
+  namespace: "",
+};
 const patterns = [
+  {
+    description: "should error when do not specify base-url",
+    input: {
+      ...baseInput,
+      baseUrl: null,
+    },
+    expected: {
+      failure: {
+        errorMessage: "--base-url (KINTONE_BASE_URL) must be specified",
+      },
+    },
+  },
   {
     description:
       "should not error when specifying valid namespace and type-name",
-    input: { namespace: "com.cybozu.kintone", typeName: "AwesomeFields" },
+    input: {
+      ...baseInput,
+      namespace: "com.cybozu.kintone",
+      typeName: "AwesomeFields",
+    },
     expected: {
       failure: undefined,
     },
   },
   {
     description: "should error when namespace starts with a digit",
-    input: { namespace: "1test" },
+    input: { ...baseInput, namespace: "1test" },
     expected: {
       failure: {
         errorMessage: invalidNamespaceMessage,
@@ -22,7 +55,7 @@ const patterns = [
   },
   {
     description: "should error when namespace contains invalid characters",
-    input: { namespace: "te-st" },
+    input: { ...baseInput, namespace: "te-st" },
     expected: {
       failure: {
         errorMessage: invalidNamespaceMessage,
@@ -31,7 +64,7 @@ const patterns = [
   },
   {
     description: "should error when type-name starts with a digit",
-    input: { typeName: "1test" },
+    input: { ...baseInput, typeName: "1test" },
     expected: {
       failure: {
         errorMessage: invalidTypeNameMessage,
@@ -40,7 +73,7 @@ const patterns = [
   },
   {
     description: "should error when type-name contains invalid characters",
-    input: { typeName: "te-st" },
+    input: { ...baseInput, typeName: "te-st" },
     expected: {
       failure: {
         errorMessage: invalidTypeNameMessage,

--- a/packages/dts-gen/src/validators/__tests__/args.test.ts
+++ b/packages/dts-gen/src/validators/__tests__/args.test.ts
@@ -1,7 +1,10 @@
 import { validateArgs } from "../args";
 
-const invalidNamespaceMessage = "Invalid namespace option!";
-const invalidTypeNameMessage = "Invalid type-name option!";
+const identifierConventionMsg = `The namespace and type-name convention:
+- Starts with a letter (\`a-z\` or \`A-Z\`), underscore (\`_\`), or dollar sign (\`$\`).
+- Can be followed by any alphanumeric, underscores, or dollar signs.`;
+const invalidNamespaceMessage = `Invalid namespace option!\n${identifierConventionMsg}`;
+const invalidTypeNameMessage = `Invalid type-name option!\n${identifierConventionMsg}`;
 const baseInput = {
   baseUrl: "",
   preview: false,
@@ -87,7 +90,7 @@ describe("validateInput", () => {
     if (pattern.expected.failure !== undefined) {
       return expect(() => {
         validateArgs(pattern.input);
-      }).toThrow(pattern.expected.failure.errorMessage);
+      }).toThrow(new Error(pattern.expected.failure.errorMessage));
     }
 
     return expect(() => {

--- a/packages/dts-gen/src/validators/args.ts
+++ b/packages/dts-gen/src/validators/args.ts
@@ -1,0 +1,20 @@
+type Args = {
+  namespace?: string;
+  typeName?: string;
+};
+
+export const validateArgs = (args: Args) => {
+  if (args.namespace && !isValidIdentifier(args.namespace)) {
+    throw new Error("Invalid namespace option!");
+  }
+
+  if (args.typeName && !isValidIdentifier(args.typeName)) {
+    throw new Error("Invalid type-name option!");
+  }
+};
+
+const isValidIdentifier = (targetIdentifier: string): boolean => {
+  const identifiers = targetIdentifier.split(".");
+  const identifierRegex = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
+  return identifiers.every((identifier) => identifierRegex.test(identifier));
+};

--- a/packages/dts-gen/src/validators/args.ts
+++ b/packages/dts-gen/src/validators/args.ts
@@ -1,18 +1,27 @@
-type Args = {
-  namespace?: string;
-  typeName?: string;
-};
+import type { ParsedArgs } from "../cli-parser";
 
-export const validateArgs = (args: Args) => {
+export const validateArgs = (args: ParsedArgs) => {
+  if (args.baseUrl === null) {
+    throw new Error("--base-url (KINTONE_BASE_URL) must be specified");
+  }
+
+  const identifierConventionMsg = `The namespace and type-name convention:
+- Starts with a letter (\`a-z\` or \`A-Z\`), underscore (\`_\`), or dollar sign (\`$\`).
+- Can be followed by any alphanumeric, underscores, or dollar signs.`;
+
   if (args.namespace && !isValidIdentifier(args.namespace)) {
-    throw new Error("Invalid namespace option!");
+    throw new Error(`Invalid namespace option!\n${identifierConventionMsg}`);
   }
 
   if (args.typeName && !isValidIdentifier(args.typeName)) {
-    throw new Error("Invalid type-name option!");
+    throw new Error(`Invalid type-name option!\n${identifierConventionMsg}`);
   }
 };
 
+/**
+ * https://developer.mozilla.org/en-US/docs/Glossary/Identifier
+ * @param targetIdentifier
+ */
 const isValidIdentifier = (targetIdentifier: string): boolean => {
   const identifiers = targetIdentifier.split(".");
   const identifierRegex = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

An unclear message is shown when specifying an invalid `namespace` or `type-name` option.
For example:

```
$ kintone-dts-gen --base-url https://*****.cybozu-dev.com -u ****** -p ****** --app-id 1 --type-name SampleFields --namespace sample-fields
```

** Invalid `namespace`: `sample-fields`
** Valid `namespace`: `sampleFields`

Current error message:
```
Error: failed to fix lint errors on generated type definition file.
    at /Users/h000953/Development/js-sdk/packages/dts-gen/dist/templates/template.js:61:15
    at Generator.next (<anonymous>)
    at fulfilled (/Users/h000953/Development/js-sdk/packages/dts-gen/dist/templates/template.js:28:58)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```


## What

- [x] Showing a detailed error message
- [x] Validate `namespace` and `type-name` option

## How to test

Run command

```
$ kintone-dts-gen --base-url https://*****.cybozu-dev.com -u ****** -p ****** --app-id 1 --type-name SampleFields --namespace sample-fields
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
