### PR TITLE
fix(rest-api-client): return version from package.json instead of hardcode

### DIFF
--- a/packages/rest-api-client/package.json
+++ b/packages/rest-api-client/package.json
@@ -9,10 +9,10 @@
     "url": "https://cybozu.co.jp"
   },
   "description": "Kintone REST API client for JavaScript",
-  "main": "lib/index.js",
-  "module": "esm/index.js",
-  "browser": "lib/index.browser.js",
-  "types": "lib/index.d.ts",
+  "main": "lib/src/index.js",
+  "module": "esm/src/index.js",
+  "browser": "lib/src/index.browser.js",
+  "types": "lib/src/index.d.ts",
   "scripts": {
     "prebuild": "yarn clean",
     "build": "tsc --build --force",
@@ -70,7 +70,6 @@
     "rollup-plugin-license": "^3.0.1",
     "rollup-plugin-node-builtins": "^2.1.2",
     "rollup-plugin-node-globals": "^1.4.0",
-    "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-terser": "^7.0.2"
   },
   "dependencies": {
@@ -85,10 +84,10 @@
     ".": {
       "node": {
         "import": "./index.mjs",
-        "require": "./lib/index.js",
-        "default": "./lib/index.js"
+        "require": "./lib/src/index.js",
+        "default": "./lib/src/index.js"
       },
-      "browser": "./lib/index.browser.js"
+      "browser": "./lib/src/index.browser.js"
     },
     "./package.json": "./package.json"
   }

--- a/packages/rest-api-client/rollup.config.mjs
+++ b/packages/rest-api-client/rollup.config.mjs
@@ -4,14 +4,6 @@ import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
 import { terser } from "rollup-plugin-terser";
 import license from "rollup-plugin-license";
-
-// TODO: After importing JSON module become stable, we can import package.json as follows
-// JSON module: https://github.com/tc39/proposal-json-modules
-// Import Assertions: https://github.com/tc39/proposal-import-assertions
-// import pkgJson from "./package.json" assert { type: "json" };
-import { createRequire } from 'module';
-const pkgJson = createRequire(import.meta.url)("./package.json");
-
 import builtins from "rollup-plugin-node-builtins";
 import globals from "rollup-plugin-node-globals";
 import babel from "@rollup/plugin-babel";

--- a/packages/rest-api-client/rollup.config.mjs
+++ b/packages/rest-api-client/rollup.config.mjs
@@ -3,7 +3,6 @@ import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
 import { terser } from "rollup-plugin-terser";
-import replace from "rollup-plugin-replace";
 import license from "rollup-plugin-license";
 
 // TODO: After importing JSON module become stable, we can import package.json as follows
@@ -89,9 +88,6 @@ export default defineConfig({
       ],
     }),
     json(),
-    replace({
-      PACKAGE_VERSION: JSON.stringify(pkgJson.version),
-    }),
     globals(),
     builtins(),
     isProd && terser(),

--- a/packages/rest-api-client/src/platform/browser.ts
+++ b/packages/rest-api-client/src/platform/browser.ts
@@ -1,8 +1,7 @@
 import { UnsupportedPlatformError } from "./UnsupportedPlatformError";
 import type { DiscriminatedAuth } from "../types/auth";
 import mime from "mime/lite";
-
-const packageJson = require("../../package.json");
+import packageJson from "../../package.json";
 
 export const readFileFromPath = (filePath: string) => {
   throw new UnsupportedPlatformError("Browser");

--- a/packages/rest-api-client/src/platform/browser.ts
+++ b/packages/rest-api-client/src/platform/browser.ts
@@ -2,6 +2,8 @@ import { UnsupportedPlatformError } from "./UnsupportedPlatformError";
 import type { DiscriminatedAuth } from "../types/auth";
 import mime from "mime/lite";
 
+const packageJson = require("../../package.json");
+
 export const readFileFromPath = (filePath: string) => {
   throw new UnsupportedPlatformError("Browser");
 };
@@ -64,5 +66,5 @@ export const buildBaseUrl = (baseUrl?: string) => {
 };
 
 export const getVersion = () => {
-  return PACKAGE_VERSION;
+  return packageJson.version;
 };

--- a/packages/rest-api-client/tsconfig.json
+++ b/packages/rest-api-client/tsconfig.json
@@ -13,6 +13,5 @@
     "resolveJsonModule": true
   },
   "include": ["src/**/*", "package.json"],
-  "exclude": ["node_modules"],
   "references": []
 }

--- a/packages/rest-api-client/tsconfig.json
+++ b/packages/rest-api-client/tsconfig.json
@@ -4,13 +4,15 @@
     "target": "es5",
     "lib": ["es5", "es2015.promise", "es2015.iterable", "es2015.symbol", "es2015.symbol.wellknown"],
     "outDir": "./lib",
-    "rootDir": "./src",
+    "rootDir": "./",
     "typeRoots": [
       "node_modules/@types",
       "../../node_modules/@types",
       "types"
-    ]
+    ],
+    "resolveJsonModule": true
   },
-  "include": ["src/"],
+  "include": ["src/**/*", "package.json"],
+  "exclude": ["node_modules"],
   "references": []
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9775,13 +9775,6 @@ magic-string@^0.22.5:
   dependencies:
     vlq "^0.2.2"
 
-magic-string@^0.25.2:
-  version "0.25.7"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
-  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
-  dependencies:
-    sourcemap-codec "^1.4.4"
-
 magic-string@^0.27.0:
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.27.0.tgz#e4a3413b4bab6d98d2becffd48b4a257effdbbf3"
@@ -12569,14 +12562,6 @@ rollup-plugin-node-globals@^1.4.0:
     process-es6 "^0.11.6"
     rollup-pluginutils "^2.3.1"
 
-rollup-plugin-replace@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-replace/-/rollup-plugin-replace-2.2.0.tgz#f41ae5372e11e7a217cde349c8b5d5fd115e70e3"
-  integrity sha512-/5bxtUPkDHyBJAKketb4NfaeZjL5yLZdeUihSfbF2PQMz+rSTEb8ARKoOl3UBT4m7/X+QOXJo3sLTcq+yMMYTA==
-  dependencies:
-    magic-string "^0.25.2"
-    rollup-pluginutils "^2.6.0"
-
 rollup-plugin-terser@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz#e8fbba4869981b2dc35ae7e8a502d5c6c04d324d"
@@ -12587,7 +12572,7 @@ rollup-plugin-terser@^7.0.2:
     serialize-javascript "^4.0.0"
     terser "^5.0.0"
 
-rollup-pluginutils@^2.3.1, rollup-pluginutils@^2.6.0:
+rollup-pluginutils@^2.3.1:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
   integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
@@ -13021,7 +13006,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-sourcemap-codec@^1.4.4, sourcemap-codec@^1.4.8:
+sourcemap-codec@^1.4.8:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

Fixes #2111 


## What

- Return version from package.json instead of hardcode PACKAGE_VERSION


## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
