### PR TITLE
fix(dts-gen): remove unnecessary `exclude` from tsconfig

### DIFF
--- a/packages/dts-gen/docs/how-to-use.md
+++ b/packages/dts-gen/docs/how-to-use.md
@@ -123,9 +123,6 @@ npx tsc --init
   ],
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    "dist",
   ]
 }
 ```


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Currently, the document of the dts-gen guide to add `files`, `include`, and `exclude` to tsconfig.json.
However, `exclude` is to filter out some files from the result of `include`, so that is unnecessary in this case.

> exclude only changes which files are included as a result of the include setting.
https://www.typescriptlang.org/tsconfig#include
https://www.typescriptlang.org/tsconfig#exclude

## What

<!-- What is a solution you want to add? -->

- remove `exclude` from tsconfig of the document

## How to test

<!-- How can we test this pull request? -->

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
