### PR TITLE
fix(create-plugin): fix `include` of tsconfig

### DIFF
--- a/packages/create-plugin/tsconfig.json
+++ b/packages/create-plugin/tsconfig.json
@@ -9,7 +9,6 @@
       "types"
     ],
   },
-  "indlude": ["src/**/*.ts"],
-  "exclude": ["templates/**/*.ts"],
+  "include": ["src/**/*.ts"],
   "references": []
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

The `include` of the tsconfig of the create-plugin has typo to `indlude`.

## What

<!-- What is a solution you want to add? -->

- fix type `indlude` to `include`
- remove `exclude` that is unnecessary

## How to test

<!-- How can we test this pull request? -->

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
