### PR TITLE
fix: Ignore warning message in puppeteer

### DIFF
--- a/packages/plugin-uploader/src/index.ts
+++ b/packages/plugin-uploader/src/index.ts
@@ -19,7 +19,7 @@ const launchBrowser = (
   ignoreDefaultArgs?: string[]
 ): Promise<Browser> => {
   const args = proxy ? [`--proxy-server=${proxy}`] : [];
-  return puppeteer.launch({ args, ignoreDefaultArgs });
+  return puppeteer.launch({ args, ignoreDefaultArgs, headless: "new" });
 };
 
 const readyForUpload = async (


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
- Fix the warning message of Puppeteer package
- Avoid trouble in near future
<!-- Why do you want the feature and why does it make sense for the package? -->

## What
- Add new Headless mode as default
<!-- What is a solution you want to add? -->

## How to test
- Run plugin-uploader without warning message
<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
