### PR TITLE
fix(plugin-manifest-validator): update default non-existent file message

### DIFF
--- a/packages/plugin-manifest-validator/src/__tests__/index.ts
+++ b/packages/plugin-manifest-validator/src/__tests__/index.ts
@@ -380,7 +380,7 @@ describe("validator", () => {
         assert.deepStrictEqual(error, {
           instancePath,
           keyword: "fileExists",
-          message: `File not found: ${filePath}`,
+          message: `file should exist ("${filePath}")`,
           schemaPath,
         });
       }
@@ -420,7 +420,7 @@ describe("validator", () => {
             errorIndex = 1;
         }
 
-        const customMessage = "Custom message: File not found 404";
+        const customMessage = `Custom message: file should exist ("config/not_exist.js")`;
         const actual = validator(json(source), {
           fileExists: (path) => {
             return {

--- a/packages/plugin-manifest-validator/src/index.ts
+++ b/packages/plugin-manifest-validator/src/index.ts
@@ -109,7 +109,7 @@ export default (
     }
 
     const result = fileExists(filePath);
-    const defaultMessage = `File not found: ${filePath}`;
+    const defaultMessage = `file should exist ("${filePath}")`;
 
     if (result === false) {
       validateFileExists.errors = [


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
- New default non-existent file message will be more directive than the current message.
<!-- Why do you want the feature and why does it make sense for the package? -->

## What
- Update default message to "file should exist (`${filePath}`)"
<!-- What is a solution you want to add? -->

## How to test
<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.