### PR TITLE
build: using pnpm workspace protocol

### DIFF
--- a/packages/customize-uploader/package.json
+++ b/packages/customize-uploader/package.json
@@ -44,7 +44,7 @@
     "@types/inquirer": "8.2.6"
   },
   "dependencies": {
-    "@kintone/rest-api-client": "^4.1.0",
+    "@kintone/rest-api-client": "workspace:*",
     "chokidar": "^3.5.3",
     "inquirer": "^8.2.6",
     "meow": "^9.0.0",

--- a/packages/plugin-packer/package.json
+++ b/packages/plugin-packer/package.json
@@ -39,7 +39,7 @@
     "start": "npm-run-all -l -s clean build -p build:dev site:dev"
   },
   "dependencies": {
-    "@kintone/plugin-manifest-validator": "^9.0.1",
+    "@kintone/plugin-manifest-validator": "workspace:*",
     "chokidar": "^3.5.3",
     "debug": "^4.3.4",
     "denodeify": "^1.2.1",

--- a/packages/webpack-plugin-kintone-plugin/package.json
+++ b/packages/webpack-plugin-kintone-plugin/package.json
@@ -51,7 +51,7 @@
     "webpack": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
-    "@kintone/plugin-packer": "^7.0.4",
+    "@kintone/plugin-packer": "workspace:*",
     "mkdirp": "^3.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,7 +143,7 @@ importers:
   packages/customize-uploader:
     dependencies:
       '@kintone/rest-api-client':
-        specifier: ^4.1.0
+        specifier: workspace:*
         version: link:../rest-api-client
       chokidar:
         specifier: ^3.5.3
@@ -245,7 +245,7 @@ importers:
   packages/plugin-packer:
     dependencies:
       '@kintone/plugin-manifest-validator':
-        specifier: ^9.0.1
+        specifier: workspace:*
         version: link:../plugin-manifest-validator
       chokidar:
         specifier: ^3.5.3
@@ -473,7 +473,7 @@ importers:
   packages/webpack-plugin-kintone-plugin:
     dependencies:
       '@kintone/plugin-packer':
-        specifier: ^7.0.4
+        specifier: workspace:*
         version: link:../plugin-packer
       mkdirp:
         specifier: ^3.0.1


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

In pnpm, `pnpm-lock.yaml` is also updated when a dependent package in the workspace is updated.

Our release tool, `release-please`, doesn't update `pnpm-lock.yaml` in its release PR.

So, there is a mismatch version between `pnpm-lock.yaml` and `package.json`. [ref](https://github.com/kintone/js-sdk/actions/runs/6073131863/job/16474457528?pr=2227)

```
Run pnpm install --frozen-lockfile
Scope: all 11 workspace projects
 ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with packages/customize-uploader/package.json

Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"

    Failure reason:
    specifiers in the lockfile ({"@kintone/rest-api-client":"^4.1.0","chokidar":"^3.5.3","inquirer":"^8.2.[6](https://github.com/kintone/js-sdk/actions/runs/6073131863/job/16474457528?pr=2227#step:5:7)","meow":"^9.0.0","mkdirp":"^3.0.1","os-locale":"^5.0.0","rimraf":"^5.0.1","@types/inquirer":"[8](https://github.com/kintone/js-sdk/actions/runs/6073131863/job/16474457528?pr=2227#step:5:9).2.6"}) don't match specs in package.json ({"@types/inquirer":"8.2.6","@kintone/rest-api-client":"^4.1.1","chokidar":"^3.5.3","inquirer":"^8.2.6","meow":"^[9](https://github.com/kintone/js-sdk/actions/runs/6073131863/job/16474457528?pr=2227#step:5:10).0.0","mkdirp":"^3.0.1","os-locale":"^5.0.0","rimraf":"^5.0.1"})
```

## What

- [x] Replace the dependent packages by [pnpm workspace protocol](https://pnpm.io/workspaces#referencing-workspace-packages-through-aliases)

## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
