### PR TITLE
ci: remove node-workspace in release-please

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.5]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.5]
+        node-version: [16.x, 18.x, 20.x]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,6 @@
   "include-v-in-tag": false,
   "tag-separator": "@",
   "monorepo-tags": true,
-  "plugins": ["node-workspace"],
   "packages": {
     "examples/rest-api-client-demo": {
       "package-name": "@kintone/rest-api-client-demo",


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

In pnpm, `pnpm-lock.yaml` is also updated when a dependent package in the workspace is updated.

Our release tool, `release-please`, doesn't update `pnpm-lock.yaml` in its release PR.

So, there is a mismatch version between `pnpm-lock.yaml` and `package.json`. [ref](https://github.com/kintone/js-sdk/actions/runs/6073131863/job/16474457528?pr=2227)

```
Run pnpm install --frozen-lockfile
Scope: all 11 workspace projects
 ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with packages/customize-uploader/package.json

Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"

    Failure reason:
    specifiers in the lockfile ({"@kintone/rest-api-client":"^4.1.0","chokidar":"^3.5.3","inquirer":"^8.2.[6](https://github.com/kintone/js-sdk/actions/runs/6073131863/job/16474457528?pr=2227#step:5:7)","meow":"^9.0.0","mkdirp":"^3.0.1","os-locale":"^5.0.0","rimraf":"^5.0.1","@types/inquirer":"[8](https://github.com/kintone/js-sdk/actions/runs/6073131863/job/16474457528?pr=2227#step:5:9).2.6"}) don't match specs in package.json ({"@types/inquirer":"8.2.6","@kintone/rest-api-client":"^4.1.1","chokidar":"^3.5.3","inquirer":"^8.2.6","meow":"^[9](https://github.com/kintone/js-sdk/actions/runs/6073131863/job/16474457528?pr=2227#step:5:10).0.0","mkdirp":"^3.0.1","os-locale":"^5.0.0","rimraf":"^5.0.1"})
```

## What

- [x] Remove [node-workspace](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#node-workspace)

## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
