### PR TITLE
ci: harde code to Node 20.5 until Node 20.6 is fixed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,8 @@ jobs:
 
     strategy:
       matrix:
+        # TODO: replace to 20.x once Node 20.6 is fixed
+        # https://github.com/babel/babel/issues/15927
         node-version: [16.x, 18.x, 20.5]
         os: [ubuntu-latest, windows-latest]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.5]
         os: [ubuntu-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

Node 20.6 has just been released on 2023-09-04, [ref](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V20.md#2023-09-04-version-2060-current-juanarbol-prepared-by-ulisesgascon)

Node 20.6 breaks Babel, and Babel breaks our tools, [ref](https://github.com/babel/babel/issues/15927)

## What

- [x] Hard code the Node 20.x of the `test` workflow to 20.5

## How to test

```
pnpm build && pnpm test
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
