### PR TITLE
ci: change Node version from 20.5 to 20.x in test CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        # TODO: replace to 20.x once Node 20.6 is fixed
-        # https://github.com/babel/babel/issues/15927
-        node-version: [16.x, 18.x, 20.5]
+        node-version: [16.x, 18.x, 20.x]
         os: [ubuntu-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
- Make the test workflow always tests with the latest version of Node 20
<!-- Why do you want the feature and why does it make sense for the package? -->

## What
- Revert to Node 20.x in test ci workflow
<!-- What is a solution you want to add? -->

## How to test
- N/A
<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
