### PR TITLE
fix(rest-api-client): Fix type resolution error on `moduleResolution: bundler`

### DIFF
--- a/packages/rest-api-client/package.json
+++ b/packages/rest-api-client/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@kintone/rest-api-client",
-  "version": "5.0.0",
+  "name": "test-rest-api-client1",
+  "version": "5.0.12",
   "publishConfig": {
     "access": "public"
   },
@@ -79,8 +79,8 @@
   "exports": {
     ".": {
       "types": {
-        "require": "./lib/src/index.d.ts",
         "import": "./esm/src/index.d.ts",
+        "require": "./lib/src/index.d.ts",
         "default": "./lib/src/index.d.ts"
       },
       "node": {

--- a/packages/rest-api-client/package.json
+++ b/packages/rest-api-client/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "test-rest-api-client1",
-  "version": "5.0.12",
+  "name": "@kintone/rest-api-client",
+  "version": "5.0.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/rest-api-client/package.json
+++ b/packages/rest-api-client/package.json
@@ -78,6 +78,11 @@
   },
   "exports": {
     ".": {
+      "types": {
+        "require": "./lib/src/index.d.ts",
+        "import": "./esm/src/index.d.ts",
+        "default": "./lib/src/index.d.ts"
+      },
       "node": {
         "import": "./index.mjs",
         "require": "./lib/src/index.js",


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
- We can use rest-api-client on modern environment with moduleResolution: bundler
<!-- Why do you want the feature and why does it make sense for the package? -->

## What
- Add types to the exports field in rest-api-client/package.json
<!-- What is a solution you want to add? -->

## How to test
- Follow the reproduction in [this issue](https://github.com/kintone/js-sdk/issues/2277)
<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
