### PR TITLE
test(rest-api-client): skip Vite test for investigating

### DIFF
--- a/packages/rest-api-client/src/__tests__/e2e.vite.test.ts
+++ b/packages/rest-api-client/src/__tests__/e2e.vite.test.ts
@@ -12,7 +12,7 @@ const tempDir = fs.mkdtempSync(
 
 const TESTCASE_TIMEOUT = 30000;
 
-describe("Vite Bundler tests", function () {
+describe.skip("Vite Bundler tests", function () {
   it(
     `should be able to build with Vite successfully`,
     async () => {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

There is an issue with Vite e2e test case.

## What

- Skip Vite test while investigating

## How to test

```
pnpm test
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
