### PR TITLE
chore(plugin-uploader): Add --waiting-dialog-ms option to Readme

### DIFF
--- a/packages/plugin-uploader/README.md
+++ b/packages/plugin-uploader/README.md
@@ -55,6 +55,7 @@ You can create a project based on `@kintone/plugin-packer` using [@kintone/creat
     --basic-auth-username username for Basic Authentication
     --basic-auth-password password for Basic Authentication
     --watch Watch the changes of plugin zip and re-run
+    --waiting-dialog-ms The waiting time for showing the input dialog in milliseconds
     --lang Using language (en or ja)
     --puppeteer-ignore-default-args Ignore default arguments of puppeteer
 

--- a/packages/plugin-uploader/src/cli.ts
+++ b/packages/plugin-uploader/src/cli.ts
@@ -29,7 +29,7 @@ const cli = meow(
     --basic-auth-username username for Basic Authentication
     --basic-auth-password password for Basic Authentication
     --watch Watch the changes of plugin zip and re-run
-    --waiting-dialog-ms A ms for waiting show a input dialog
+    --waiting-dialog-ms The waiting time for showing the input dialog in milliseconds
     --lang Using language (en or ja)
     --puppeteer-ignore-default-args Ignore default arguments of puppeteer
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

`--waiting-dialog-ms` option is missed in Readme
<!-- Why do you want the feature and why does it make sense for the package? -->

## What

- Add `--waiting-dialog-ms` option into Readme
- Update the description of `--waiting-dialog-ms` option 
<!-- What is a solution you want to add? -->

## How to test

N/A
<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
