### PR TITLE
chore(rest-api-client): Add warning message in Readme of getAllRecordsWithOffset

### DIFF
--- a/packages/rest-api-client/docs/record.md
+++ b/packages/rest-api-client/docs/record.md
@@ -205,7 +205,7 @@ The returned array is sorted by `id` in ascending order.
 Retrieves details of all records from an app by specifying the app ID, fields, condition, and sort order.
 This method can retrieve the records exceeding the [REST API limitation](https://kintone.dev/en/docs/kintone/rest-api/overview/kintone-rest-api-overview/#limitations).
 
-:warning: **If you'd like to get over 10000 records, please consider using [getAllRecordsWithCursor](#getAllRecordsWithCursor) instead.**
+:warning: **An error will occur if the app has over 10.000 records. If you'd like to get over 10.000 records, please consider using [getAllRecordsWithCursor](#getAllRecordsWithCursor) instead.**
 
 #### Parameters
 

--- a/packages/rest-api-client/docs/record.md
+++ b/packages/rest-api-client/docs/record.md
@@ -205,7 +205,7 @@ The returned array is sorted by `id` in ascending order.
 Retrieves details of all records from an app by specifying the app ID, fields, condition, and sort order.
 This method can retrieve the records exceeding the [REST API limitation](https://kintone.dev/en/docs/kintone/rest-api/overview/kintone-rest-api-overview/#limitations).
 
-:warning: **If the app has over 10.000 records, please consider using [getAllRecordsWithCursor](#getAllRecordsWithCursor) instead.**
+:warning: **If the app has over 10,000 records, please consider using [getAllRecordsWithCursor](#getAllRecordsWithCursor) instead.**
 
 #### Parameters
 

--- a/packages/rest-api-client/docs/record.md
+++ b/packages/rest-api-client/docs/record.md
@@ -205,7 +205,7 @@ The returned array is sorted by `id` in ascending order.
 Retrieves details of all records from an app by specifying the app ID, fields, condition, and sort order.
 This method can retrieve the records exceeding the [REST API limitation](https://kintone.dev/en/docs/kintone/rest-api/overview/kintone-rest-api-overview/#limitations).
 
-:warning: **An error will occur if the app has over 10.000 records. If you'd like to get over 10.000 records, please consider using [getAllRecordsWithCursor](#getAllRecordsWithCursor) instead.**
+:warning: **If the app has over 10.000 records, please consider using [getAllRecordsWithCursor](#getAllRecordsWithCursor) instead.**
 
 #### Parameters
 

--- a/packages/rest-api-client/docs/record.md
+++ b/packages/rest-api-client/docs/record.md
@@ -205,7 +205,7 @@ The returned array is sorted by `id` in ascending order.
 Retrieves details of all records from an app by specifying the app ID, fields, condition, and sort order.
 This method can retrieve the records exceeding the [REST API limitation](https://kintone.dev/en/docs/kintone/rest-api/overview/kintone-rest-api-overview/#limitations).
 
-:warning: **The maximum number of records that can be retrieved with the getAllRecordsWithOffset API is 10000.**
+:warning: **If you'd like to get over 10000 records, please consider using [getAllRecordsWithCursor](#getAllRecordsWithCursor) instead.**
 
 #### Parameters
 

--- a/packages/rest-api-client/docs/record.md
+++ b/packages/rest-api-client/docs/record.md
@@ -205,6 +205,8 @@ The returned array is sorted by `id` in ascending order.
 Retrieves details of all records from an app by specifying the app ID, fields, condition, and sort order.
 This method can retrieve the records exceeding the [REST API limitation](https://kintone.dev/en/docs/kintone/rest-api/overview/kintone-rest-api-overview/#limitations).
 
+:warning: **The maximum number of records that can be retrieved with the getAllRecordsWithOffset API is 10000.**
+
 #### Parameters
 
 | Name      |       Type       | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                               |


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->
## Why

The error occurs when using getAllRecordsWithOffset with an application containing more than 10,000 records

## What

Add warning message in Readme of getAllRecordsWithOffset

## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
