### PR TITLE
fix(plugin-packer): Fix the vulnerability issue from browserify-sign

### DIFF
--- a/packages/plugin-packer/package.json
+++ b/packages/plugin-packer/package.json
@@ -61,6 +61,7 @@
     "array-flatten": "^3.0.0",
     "assert": "^2.1.0",
     "babel-plugin-replace-ts-export-assignment": "^0.0.2",
+    "browserify-sign": "^4.2.2",
     "browserify-zlib": "^0.2.0",
     "buffer": "^6.0.3",
     "constants-browserify": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,6 +302,9 @@ importers:
       babel-plugin-replace-ts-export-assignment:
         specifier: ^0.0.2
         version: 0.0.2
+      browserify-sign:
+        specifier: ^4.2.2
+        version: 4.2.2
       browserify-zlib:
         specifier: ^0.2.0
         version: 0.2.0
@@ -4094,8 +4097,9 @@ packages:
       randombytes: 2.1.0
     dev: true
 
-  /browserify-sign@4.2.1:
-    resolution: {integrity: sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==}
+  /browserify-sign@4.2.2:
+    resolution: {integrity: sha512-1rudGyeYY42Dk6texmv7c4VcQ0EsvVbLwZkA+AQB7SxvXxmcD93jcHie8bzecJ+ChDlmAm2Qyu0+Ccg5uhZXCg==}
+    engines: {node: '>= 4'}
     dependencies:
       bn.js: 5.2.1
       browserify-rsa: 4.1.0
@@ -4646,7 +4650,7 @@ packages:
     resolution: {integrity: sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==}
     dependencies:
       browserify-cipher: 1.0.1
-      browserify-sign: 4.2.1
+      browserify-sign: 4.2.2
       create-ecdh: 4.0.4
       create-hash: 1.2.0
       create-hmac: 1.1.7


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

A vulnerability issue of browserify-sign from version >= 2.6.0 and <= 4.2.1

Ref: https://github.com/kintone/js-sdk/security/dependabot/72

## What

- Temporary using the non-vulnerability version of browserify-sign 4.2.2

## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
