### PR TITLE
chore!(create-plugin): remove jQuery from the minimum template

### DIFF
--- a/packages/create-plugin/src/__tests__/fixtures/manifest.json
+++ b/packages/create-plugin/src/__tests__/fixtures/manifest.json
@@ -3,7 +3,7 @@
   "version": 1,
   "type": "APP",
   "desktop": {
-    "js": ["https://js.cybozu.com/jquery/3.3.1/jquery.min.js", "js/desktop.js"],
+    "js": ["js/desktop.js"],
     "css": ["css/51-modern-default.css", "css/desktop.css"]
   },
   "icon": "image/icon.png",
@@ -14,11 +14,11 @@
     "en": "kintone-plugin-demo"
   },
   "mobile": {
-    "js": ["https://js.cybozu.com/jquery/3.3.1/jquery.min.js", "js/mobile.js"]
+    "js": ["js/mobile.js"]
   },
   "config": {
     "html": "html/config.html",
-    "js": ["https://js.cybozu.com/jquery/3.3.1/jquery.min.js", "js/config.js"],
+    "js": ["js/config.js"],
     "css": ["css/51-modern-default.css", "css/config.css"],
     "required_params": []
   }

--- a/packages/create-plugin/src/manifest.ts
+++ b/packages/create-plugin/src/manifest.ts
@@ -3,20 +3,18 @@
 import type { Answers } from "inquirer";
 import type { TemplateType } from "./template";
 
-const jQueryURL = "https://js.cybozu.com/jquery/3.3.1/jquery.min.js";
-
 const minimumManifest = {
   manifest_version: 1,
   version: 1,
   type: "APP",
   desktop: {
-    js: [jQueryURL, "js/desktop.js"],
+    js: ["js/desktop.js"],
     css: ["css/51-modern-default.css", "css/desktop.css"],
   },
   icon: "image/icon.png",
   config: {
     html: "html/config.html",
-    js: [jQueryURL, "js/config.js"],
+    js: ["js/config.js"],
     css: ["css/51-modern-default.css", "css/config.css"],
     required_params: ["message"],
   },
@@ -121,10 +119,7 @@ export const buildManifest = (
       ...manifest,
       ...{
         mobile: {
-          js:
-            templateType === "minimum"
-              ? [jQueryURL, "js/mobile.js"]
-              : ["js/mobile.js"],
+          js: templateType === "minimum" ? ["js/mobile.js"] : ["js/mobile.js"],
           css: ["css/mobile.css"],
         },
       },

--- a/packages/create-plugin/src/manifest.ts
+++ b/packages/create-plugin/src/manifest.ts
@@ -119,7 +119,7 @@ export const buildManifest = (
       ...manifest,
       ...{
         mobile: {
-          js: templateType === "minimum" ? ["js/mobile.js"] : ["js/mobile.js"],
+          js: ["js/mobile.js"],
           css: ["css/mobile.css"],
         },
       },

--- a/packages/create-plugin/templates/minimum/.eslintrc.js
+++ b/packages/create-plugin/templates/minimum/.eslintrc.js
@@ -3,11 +3,11 @@ module.exports = {
     '@cybozu/eslint-config/globals/kintone.js',
     '@cybozu/eslint-config/lib/base.js',
     '@cybozu/eslint-config/lib/kintone.js',
+    '@cybozu/eslint-config/lib/prettier.js',
   ],
   rules: {
     'prettier/prettier': ['error', { singleQuote: true }],
     'space-before-function-paren': 0,
     'object-curly-spacing': 0,
   },
-  plugins: ['eslint-plugin-prettier'],
 };

--- a/packages/create-plugin/templates/minimum/.eslintrc.js
+++ b/packages/create-plugin/templates/minimum/.eslintrc.js
@@ -9,4 +9,5 @@ module.exports = {
     'space-before-function-paren': 0,
     'object-curly-spacing': 0,
   },
+  plugins: ['eslint-plugin-prettier'],
 };

--- a/packages/create-plugin/templates/minimum/.eslintrc.js
+++ b/packages/create-plugin/templates/minimum/.eslintrc.js
@@ -1,5 +1,12 @@
-'use strict';
-
 module.exports = {
-  extends: ['@cybozu/eslint-config/presets/kintone-customize-es5']
+  extends: [
+    '@cybozu/eslint-config/globals/kintone.js',
+    '@cybozu/eslint-config/lib/base.js',
+    '@cybozu/eslint-config/lib/kintone.js',
+  ],
+  rules: {
+    'prettier/prettier': ['error', { singleQuote: true }],
+    'space-before-function-paren': 0,
+    'object-curly-spacing': 0,
+  },
 };

--- a/packages/create-plugin/templates/minimum/src/js/config.js
+++ b/packages/create-plugin/templates/minimum/src/js/config.js
@@ -1,27 +1,25 @@
 (function (PLUGIN_ID) {
   "use strict";
 
-  var $form = document.querySelectorAll(".js-submit-settings");
-  var $cancelButton = document.querySelectorAll(".js-cancel-button");
-  var $message = document.querySelectorAll(".js-text-message");
-  if (!($form.length > 0 && $cancelButton.length > 0 && $message.length > 0)) {
+  var $form = document.querySelector(".js-submit-settings");
+  var $cancelButton = document.querySelector(".js-cancel-button");
+  var $message = document.querySelector(".js-text-message");
+  if (!($form && $cancelButton && $message)) {
     throw new Error("Required elements do not exist.");
   }
   var config = kintone.plugin.app.getConfig(PLUGIN_ID);
 
   if (config.message) {
-    $message[0].value = config.message;
+    $message.value = config.message;
   }
-  $form[0].addEventListener("submit", function (e) {
+  $form.addEventListener("submit", function (e) {
     e.preventDefault();
-    kintone.plugin.app.setConfig({ message: $message[0].value }, function () {
+    kintone.plugin.app.setConfig({ message: $message.value }, function () {
       alert("The plug-in settings have been saved. Please update the app!");
       window.location.href = "../../flow?app=" + kintone.app.getId();
     });
   });
-  $cancelButton.forEach((element) => {
-    element.addEventListener("click", function () {
-      window.location.href = "../../" + kintone.app.getId() + "/plugin/";
-    });
+  $cancelButton.addEventListener("click", function () {
+    window.location.href = "../../" + kintone.app.getId() + "/plugin/";
   });
 })(kintone.$PLUGIN_ID);

--- a/packages/create-plugin/templates/minimum/src/js/config.js
+++ b/packages/create-plugin/templates/minimum/src/js/config.js
@@ -1,7 +1,7 @@
 (function (PLUGIN_ID) {
   "use strict";
 
-  var $form = document.querySelectorAll(".js-submit-settings").length;
+  var $form = document.querySelectorAll(".js-submit-settings");
   var $cancelButton = document.querySelectorAll(".js-cancel-button");
   var $message = document.querySelectorAll(".js-text-message");
   if (!($form.length > 0 && $cancelButton.length > 0 && $message.length > 0)) {

--- a/packages/create-plugin/templates/minimum/src/js/config.js
+++ b/packages/create-plugin/templates/minimum/src/js/config.js
@@ -1,9 +1,9 @@
 (function (PLUGIN_ID) {
   "use strict";
 
-  var $form = document.querySelector(".js-submit-settings");
-  var $cancelButton = document.querySelector(".js-cancel-button");
-  var $message = document.querySelector(".js-text-message");
+  var $form = document.querySelectorAll(".js-submit-settings").length;
+  var $cancelButton = document.querySelectorAll(".js-cancel-button");
+  var $message = document.querySelectorAll(".js-text-message");
   if (!($form.length > 0 && $cancelButton.length > 0 && $message.length > 0)) {
     throw new Error("Required elements do not exist.");
   }
@@ -12,14 +12,14 @@
   if (config.message) {
     $message.val(config.message);
   }
-  $form.on("submit", function (e) {
+  $form.addEventListener("submit", function (e) {
     e.preventDefault();
     kintone.plugin.app.setConfig({ message: $message.val() }, function () {
       alert("The plug-in settings have been saved. Please update the app!");
       window.location.href = "../../flow?app=" + kintone.app.getId();
     });
   });
-  $cancelButton.on("click", function () {
+  $cancelButton.addEventListener("click", function () {
     window.location.href = "../../" + kintone.app.getId() + "/plugin/";
   });
 })(kintone.$PLUGIN_ID);

--- a/packages/create-plugin/templates/minimum/src/js/config.js
+++ b/packages/create-plugin/templates/minimum/src/js/config.js
@@ -10,16 +10,18 @@
   var config = kintone.plugin.app.getConfig(PLUGIN_ID);
 
   if (config.message) {
-    $message.val(config.message);
+    $message[0].value = config.message;
   }
-  $form.addEventListener("submit", function (e) {
+  $form[0].addEventListener("submit", function (e) {
     e.preventDefault();
-    kintone.plugin.app.setConfig({ message: $message.val() }, function () {
+    kintone.plugin.app.setConfig({ message: $message[0].value }, function () {
       alert("The plug-in settings have been saved. Please update the app!");
       window.location.href = "../../flow?app=" + kintone.app.getId();
     });
   });
-  $cancelButton.addEventListener("click", function () {
-    window.location.href = "../../" + kintone.app.getId() + "/plugin/";
+  $cancelButton.forEach((element) => {
+    element.addEventListener("click", function () {
+      window.location.href = "../../" + kintone.app.getId() + "/plugin/";
+    });
   });
 })(kintone.$PLUGIN_ID);

--- a/packages/create-plugin/templates/minimum/src/js/config.js
+++ b/packages/create-plugin/templates/minimum/src/js/config.js
@@ -1,25 +1,29 @@
 (function (PLUGIN_ID) {
   "use strict";
 
-  var $form = document.querySelector(".js-submit-settings");
-  var $cancelButton = document.querySelector(".js-cancel-button");
-  var $message = document.querySelector(".js-text-message");
-  if (!($form && $cancelButton && $message)) {
+  let formEl = document.querySelector(".js-submit-settings");
+  let cancelButtonEl = document.querySelector(".js-cancel-button");
+  let messageEl = document.querySelector(".js-text-message");
+  if (
+    !(formEl.length > 0 && cancelButtonEl.length > 0 && messageEl.length > 0)
+  ) {
     throw new Error("Required elements do not exist.");
   }
-  var config = kintone.plugin.app.getConfig(PLUGIN_ID);
 
+  const config = kintone.plugin.app.getConfig(PLUGIN_ID);
   if (config.message) {
-    $message.value = config.message;
+    messageEl.value = config.message;
   }
-  $form.addEventListener("submit", function (e) {
+
+  formEl.addEventListener("submit", function (e) {
     e.preventDefault();
-    kintone.plugin.app.setConfig({ message: $message.value }, function () {
+    kintone.plugin.app.setConfig({ message: messageEl.value }, function () {
       alert("The plug-in settings have been saved. Please update the app!");
       window.location.href = "../../flow?app=" + kintone.app.getId();
     });
   });
-  $cancelButton.addEventListener("click", function () {
+
+  cancelButtonEl.addEventListener("click", function () {
     window.location.href = "../../" + kintone.app.getId() + "/plugin/";
   });
 })(kintone.$PLUGIN_ID);

--- a/packages/create-plugin/templates/minimum/src/js/config.js
+++ b/packages/create-plugin/templates/minimum/src/js/config.js
@@ -1,13 +1,11 @@
 (function (PLUGIN_ID) {
-  "use strict";
-
-  let formEl = document.querySelector(".js-submit-settings");
-  let cancelButtonEl = document.querySelector(".js-cancel-button");
-  let messageEl = document.querySelector(".js-text-message");
+  const formEl = document.querySelector('.js-submit-settings');
+  const cancelButtonEl = document.querySelector('.js-cancel-button');
+  const messageEl = document.querySelector('.js-text-message');
   if (
     !(formEl.length > 0 && cancelButtonEl.length > 0 && messageEl.length > 0)
   ) {
-    throw new Error("Required elements do not exist.");
+    throw new Error('Required elements do not exist.');
   }
 
   const config = kintone.plugin.app.getConfig(PLUGIN_ID);
@@ -15,15 +13,15 @@
     messageEl.value = config.message;
   }
 
-  formEl.addEventListener("submit", function (e) {
+  formEl.addEventListener('submit', (e) => {
     e.preventDefault();
-    kintone.plugin.app.setConfig({ message: messageEl.value }, function () {
-      alert("The plug-in settings have been saved. Please update the app!");
-      window.location.href = "../../flow?app=" + kintone.app.getId();
+    kintone.plugin.app.setConfig({ message: messageEl.value }, () => {
+      alert('The plug-in settings have been saved. Please update the app!');
+      window.location.href = '../../flow?app=' + kintone.app.getId();
     });
   });
 
-  cancelButtonEl.addEventListener("click", function () {
-    window.location.href = "../../" + kintone.app.getId() + "/plugin/";
+  cancelButtonEl.addEventListener('click', () => {
+    window.location.href = '../../' + kintone.app.getId() + '/plugin/';
   });
 })(kintone.$PLUGIN_ID);

--- a/packages/create-plugin/templates/minimum/src/js/config.js
+++ b/packages/create-plugin/templates/minimum/src/js/config.js
@@ -2,9 +2,7 @@
   const formEl = document.querySelector('.js-submit-settings');
   const cancelButtonEl = document.querySelector('.js-cancel-button');
   const messageEl = document.querySelector('.js-text-message');
-  if (
-    !(formEl.length > 0 && cancelButtonEl.length > 0 && messageEl.length > 0)
-  ) {
+  if (!(formEl && cancelButtonEl && messageEl)) {
     throw new Error('Required elements do not exist.');
   }
 

--- a/packages/create-plugin/templates/minimum/src/js/config.js
+++ b/packages/create-plugin/templates/minimum/src/js/config.js
@@ -1,27 +1,25 @@
-jQuery.noConflict();
+(function (PLUGIN_ID) {
+  "use strict";
 
-(function($, PLUGIN_ID) {
-  'use strict';
-
-  var $form = $('.js-submit-settings');
-  var $cancelButton = $('.js-cancel-button');
-  var $message = $('.js-text-message');
+  var $form = document.querySelector(".js-submit-settings");
+  var $cancelButton = document.querySelector(".js-cancel-button");
+  var $message = document.querySelector(".js-text-message");
   if (!($form.length > 0 && $cancelButton.length > 0 && $message.length > 0)) {
-    throw new Error('Required elements do not exist.');
+    throw new Error("Required elements do not exist.");
   }
   var config = kintone.plugin.app.getConfig(PLUGIN_ID);
 
   if (config.message) {
     $message.val(config.message);
   }
-  $form.on('submit', function(e) {
+  $form.on("submit", function (e) {
     e.preventDefault();
-    kintone.plugin.app.setConfig({message: $message.val()}, function() {
-      alert('The plug-in settings have been saved. Please update the app!');
-      window.location.href = '../../flow?app=' + kintone.app.getId();
+    kintone.plugin.app.setConfig({ message: $message.val() }, function () {
+      alert("The plug-in settings have been saved. Please update the app!");
+      window.location.href = "../../flow?app=" + kintone.app.getId();
     });
   });
-  $cancelButton.on('click', function() {
-    window.location.href = '../../' + kintone.app.getId() + '/plugin/';
+  $cancelButton.on("click", function () {
+    window.location.href = "../../" + kintone.app.getId() + "/plugin/";
   });
-})(jQuery, kintone.$PLUGIN_ID);
+})(kintone.$PLUGIN_ID);

--- a/packages/create-plugin/templates/minimum/src/js/desktop.js
+++ b/packages/create-plugin/templates/minimum/src/js/desktop.js
@@ -2,23 +2,23 @@
   "use strict";
 
   kintone.events.on("app.record.index.show", function () {
-    var config = kintone.plugin.app.getConfig(PLUGIN_ID);
-
-    var spaceElement = kintone.app.getHeaderSpaceElement();
-    if (spaceElement === null) {
-      throw new Error("The header element is unavailable on this page");
+    let spaceEl = kintone.app.getHeaderSpaceElement();
+    if (spaceEl === null) {
+      throw new Error("The header element is unavailable on this page.");
     }
-    var fragment = document.createDocumentFragment();
-    var headingEl = document.createElement("h3");
-    var messageEl = document.createElement("p");
 
-    messageEl.classList.add("plugin-space-message");
+    let fragment = document.createDocumentFragment();
+    let headingEl = document.createElement("h3");
+    let messageEl = document.createElement("p");
+
+    const config = kintone.plugin.app.getConfig(PLUGIN_ID);
     messageEl.textContent = config.message;
-    headingEl.classList.add("plugin-space-heading");
+    messageEl.classList.add("plugin-space-message");
     headingEl.textContent = "Hello kintone plugin!";
+    headingEl.classList.add("plugin-space-heading");
 
     fragment.appendChild(headingEl);
     fragment.appendChild(messageEl);
-    spaceElement.appendChild(fragment);
+    spaceEl.appendChild(fragment);
   });
 })(kintone.$PLUGIN_ID);

--- a/packages/create-plugin/templates/minimum/src/js/desktop.js
+++ b/packages/create-plugin/templates/minimum/src/js/desktop.js
@@ -1,21 +1,19 @@
 (function (PLUGIN_ID) {
-  "use strict";
-
-  kintone.events.on("app.record.index.show", function () {
-    let spaceEl = kintone.app.getHeaderSpaceElement();
+  kintone.events.on('app.record.index.show', () => {
+    const spaceEl = kintone.app.getHeaderSpaceElement();
     if (spaceEl === null) {
-      throw new Error("The header element is unavailable on this page.");
+      throw new Error('The header element is unavailable on this page.');
     }
 
-    let fragment = document.createDocumentFragment();
-    let headingEl = document.createElement("h3");
-    let messageEl = document.createElement("p");
+    const fragment = document.createDocumentFragment();
+    const headingEl = document.createElement('h3');
+    const messageEl = document.createElement('p');
 
     const config = kintone.plugin.app.getConfig(PLUGIN_ID);
     messageEl.textContent = config.message;
-    messageEl.classList.add("plugin-space-message");
-    headingEl.textContent = "Hello kintone plugin!";
-    headingEl.classList.add("plugin-space-heading");
+    messageEl.classList.add('plugin-space-message');
+    headingEl.textContent = 'Hello kintone plugin!';
+    headingEl.classList.add('plugin-space-heading');
 
     fragment.appendChild(headingEl);
     fragment.appendChild(messageEl);

--- a/packages/create-plugin/templates/minimum/src/js/desktop.js
+++ b/packages/create-plugin/templates/minimum/src/js/desktop.js
@@ -1,26 +1,24 @@
-jQuery.noConflict();
+(function (PLUGIN_ID) {
+  "use strict";
 
-(function($, PLUGIN_ID) {
-  'use strict';
-
-  kintone.events.on('app.record.index.show', function() {
+  kintone.events.on("app.record.index.show", function () {
     var config = kintone.plugin.app.getConfig(PLUGIN_ID);
 
     var spaceElement = kintone.app.getHeaderSpaceElement();
     if (spaceElement === null) {
-      throw new Error('The header element is unavailable on this page');
+      throw new Error("The header element is unavailable on this page");
     }
     var fragment = document.createDocumentFragment();
-    var headingEl = document.createElement('h3');
-    var messageEl = document.createElement('p');
+    var headingEl = document.createElement("h3");
+    var messageEl = document.createElement("p");
 
-    messageEl.classList.add('plugin-space-message');
+    messageEl.classList.add("plugin-space-message");
     messageEl.textContent = config.message;
-    headingEl.classList.add('plugin-space-heading');
-    headingEl.textContent = 'Hello kintone plugin!';
+    headingEl.classList.add("plugin-space-heading");
+    headingEl.textContent = "Hello kintone plugin!";
 
     fragment.appendChild(headingEl);
     fragment.appendChild(messageEl);
     spaceElement.appendChild(fragment);
   });
-})(jQuery, kintone.$PLUGIN_ID);
+})(kintone.$PLUGIN_ID);

--- a/packages/create-plugin/templates/minimum/src/js/mobile.js
+++ b/packages/create-plugin/templates/minimum/src/js/mobile.js
@@ -1,21 +1,19 @@
 (function (PLUGIN_ID) {
-  "use strict";
-
-  kintone.events.on("mobile.app.record.index.show", function () {
-    let spaceEl = kintone.mobile.app.getHeaderSpaceElement();
+  kintone.events.on('mobile.app.record.index.show', () => {
+    const spaceEl = kintone.mobile.app.getHeaderSpaceElement();
     if (spaceEl === null) {
-      throw new Error("The header element is unavailable on this page.");
+      throw new Error('The header element is unavailable on this page.');
     }
 
-    let fragment = document.createDocumentFragment();
-    let headingEl = document.createElement("h3");
-    let messageEl = document.createElement("p");
+    const fragment = document.createDocumentFragment();
+    const headingEl = document.createElement('h3');
+    const messageEl = document.createElement('p');
 
     const config = kintone.plugin.app.getConfig(PLUGIN_ID);
     messageEl.textContent = config.message;
-    messageEl.classList.add("plugin-space-message");
-    headingEl.textContent = "Hello kintone plugin!";
-    headingEl.classList.add("plugin-space-heading");
+    messageEl.classList.add('plugin-space-message');
+    headingEl.textContent = 'Hello kintone plugin!';
+    headingEl.classList.add('plugin-space-heading');
 
     fragment.appendChild(headingEl);
     fragment.appendChild(messageEl);

--- a/packages/create-plugin/templates/minimum/src/js/mobile.js
+++ b/packages/create-plugin/templates/minimum/src/js/mobile.js
@@ -1,26 +1,24 @@
-jQuery.noConflict();
+(function (PLUGIN_ID) {
+  "use strict";
 
-(function($, PLUGIN_ID) {
-  'use strict';
-
-  kintone.events.on('mobile.app.record.index.show', function() {
+  kintone.events.on("mobile.app.record.index.show", function () {
     var config = kintone.plugin.app.getConfig(PLUGIN_ID);
 
     var spaceElement = kintone.mobile.app.getHeaderSpaceElement();
     if (spaceElement === null) {
-      throw new Error('The header element is unavailable on this page');
+      throw new Error("The header element is unavailable on this page");
     }
     var fragment = document.createDocumentFragment();
-    var headingEl = document.createElement('h3');
-    var messageEl = document.createElement('p');
+    var headingEl = document.createElement("h3");
+    var messageEl = document.createElement("p");
 
-    messageEl.classList.add('plugin-space-message');
+    messageEl.classList.add("plugin-space-message");
     messageEl.textContent = config.message;
-    headingEl.classList.add('plugin-space-heading');
-    headingEl.textContent = 'Hello kintone plugin!';
+    headingEl.classList.add("plugin-space-heading");
+    headingEl.textContent = "Hello kintone plugin!";
 
     fragment.appendChild(headingEl);
     fragment.appendChild(messageEl);
     spaceElement.appendChild(fragment);
   });
-})(jQuery, kintone.$PLUGIN_ID);
+})(kintone.$PLUGIN_ID);

--- a/packages/create-plugin/templates/minimum/src/js/mobile.js
+++ b/packages/create-plugin/templates/minimum/src/js/mobile.js
@@ -2,23 +2,23 @@
   "use strict";
 
   kintone.events.on("mobile.app.record.index.show", function () {
-    var config = kintone.plugin.app.getConfig(PLUGIN_ID);
-
-    var spaceElement = kintone.mobile.app.getHeaderSpaceElement();
-    if (spaceElement === null) {
-      throw new Error("The header element is unavailable on this page");
+    let spaceEl = kintone.mobile.app.getHeaderSpaceElement();
+    if (spaceEl === null) {
+      throw new Error("The header element is unavailable on this page.");
     }
-    var fragment = document.createDocumentFragment();
-    var headingEl = document.createElement("h3");
-    var messageEl = document.createElement("p");
 
-    messageEl.classList.add("plugin-space-message");
+    let fragment = document.createDocumentFragment();
+    let headingEl = document.createElement("h3");
+    let messageEl = document.createElement("p");
+
+    const config = kintone.plugin.app.getConfig(PLUGIN_ID);
     messageEl.textContent = config.message;
-    headingEl.classList.add("plugin-space-heading");
+    messageEl.classList.add("plugin-space-message");
     headingEl.textContent = "Hello kintone plugin!";
+    headingEl.classList.add("plugin-space-heading");
 
     fragment.appendChild(headingEl);
     fragment.appendChild(messageEl);
-    spaceElement.appendChild(fragment);
+    spaceEl.appendChild(fragment);
   });
 })(kintone.$PLUGIN_ID);


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
- jQuery is the old technology, so we don't recommend using jQuery in new projects anymore.
- We will stop using jQuery in our minimum template.
<!-- Why do you want the feature and why does it make sense for the package? -->

## What
- Remove jQuery from the minimum template
<!-- What is a solution you want to add? -->

## How to test
- The create-plugin can generate a plugin project with an updated minimum template (without jQuery code inside)
<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
