### PR TITLE
fix(dts-gen): remove unavailable property

### DIFF
--- a/packages/dts-gen/kintone.d.ts
+++ b/packages/dts-gen/kintone.d.ts
@@ -379,19 +379,16 @@ declare namespace kintone {
     interface RecordNumber {
       type: "RECORD_NUMBER";
       value: string;
-      error?: string | null;
     }
 
     interface UpdatedTime {
       type: "UPDATED_TIME";
       value: string;
-      error?: string | null;
     }
 
     interface CreatedTime {
       type: "CREATED_TIME";
       value: string;
-      error?: string | null;
     }
   }
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

The `error` property is not available on the below fields ([ref](https://kintone.dev/en/docs/kintone/js-api/events/event-object-actions/)).
- Record number
- Created datetime
- Updated datetime

## What

- The `error` property is removed for the below fields
  - Record number
  - Created datetime
  - Updated datetime


## How to test

<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
