### PR TITLE
chore(plugin-packer): move browserify-sign to pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
   "packageManager": "pnpm@8.14.3",
   "pnpm": {
     "overrides": {
-      "follow-redirects@<1.15.4": ">=1.15.4"
+      "follow-redirects@<1.15.4": ">=1.15.4",
+      "browserify-sign@<4.2.2": ">=4.2.2"
     }
   }
 }

--- a/packages/plugin-packer/package.json
+++ b/packages/plugin-packer/package.json
@@ -61,7 +61,6 @@
     "array-flatten": "^3.0.0",
     "assert": "^2.1.0",
     "babel-plugin-replace-ts-export-assignment": "^0.0.2",
-    "browserify-sign": "^4.2.2",
     "browserify-zlib": "^0.2.0",
     "buffer": "^6.0.3",
     "constants-browserify": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   follow-redirects@<1.15.4: '>=1.15.4'
+  browserify-sign@<4.2.2: '>=4.2.2'
 
 importers:
 
@@ -305,9 +306,6 @@ importers:
       babel-plugin-replace-ts-export-assignment:
         specifier: ^0.0.2
         version: 0.0.2
-      browserify-sign:
-        specifier: ^4.2.2
-        version: 4.2.2
       browserify-zlib:
         specifier: ^0.2.0
         version: 0.2.0


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

`browserify-sign` is added to plugin-packer as devDependencies. But, we don't use it directly.

## What

- Remove the devDependencies `browserify-sign`
- Add it to `pnpm.overrides` property.

## How to test

```
pnpm audit
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
