### PR TITLE
ci: resolve release-please-action warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,12 @@ jobs:
         id: release
         with:
           token: ${{ steps.create-iat.outputs.token }}
-          command: manifest
 
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
     needs: release
-    if: ${{ needs.release.outputs.releases_created }}
+    if: ${{ needs.release.outputs.releases_created == 'true' }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

1) release-please use a manifest configuration file by default. Therefore, we do not need to specify the `command` option.
2) The behavior of `releases_created` is changed from v3->v4, [ref](https://github.com/google-github-actions/release-please-action/issues/912)

## What

- Remove the `command` option.
- Update the condition of `releases_created`

## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
