### PR TITLE
feat(rest-api-client): add `space.addThreadComment()` method

### DIFF
--- a/examples/rest-api-client-demo/src/space.ts
+++ b/examples/rest-api-client-demo/src/space.ts
@@ -33,4 +33,35 @@ export class Space {
       console.log(error);
     }
   }
+
+  public async addThreadComment() {
+    const params = {
+      space: "8",
+      thread: "1",
+      comment: {
+        text: "This is a comment",
+        files: [
+          {
+            fileKey: "file1",
+            width: 100,
+          },
+        ],
+        mentions: [
+          {
+            code: "user1",
+            type: "USER" as const,
+          },
+          {
+            code: "user2",
+            type: "USER" as const,
+          },
+        ],
+      },
+    };
+    try {
+      console.log(await this.client.space.addThreadComment(params));
+    } catch (error) {
+      console.log(error);
+    }
+  }
 }

--- a/packages/rest-api-client/docs/space.md
+++ b/packages/rest-api-client/docs/space.md
@@ -3,6 +3,7 @@
 - [getSpace](#getSpace)
 - [deleteSpace](#deleteSpace)
 - [updateSpaceBody](#updateSpaceBody)
+- [addThreadComment](#addThreadComment)
 
 ## Overview
 
@@ -116,3 +117,32 @@ An empty object.
 #### Reference
 
 - https://kintone.dev/en/docs/kintone/rest-api/spaces/update-space-body/
+
+### addThreadComment
+
+Adds a comment to a Thread of a Space.
+
+#### Parameters
+
+| Name                    |       Type       |          Required           | Description                                                                                                                                                                                                                                                                                                                                          |
+| ----------------------- | :--------------: | :-------------------------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| id                      | Number or String |             Yes             | The space ID.                                                                                                                                                                                                                                                                                                                                        |
+| thread                  | Number or String |             Yes             | The thread ID.                                                                                                                                                                                                                                                                                                                                       |
+| comment                 |      Object      |                             | An object including comment details.                                                                                                                                                                                                                                                                                                                 |
+| comment.text            |      String      | Conditionally<br />Required | The comment contents.<br />A line break can be specified by LF.<br />The maximum characters of the comment is 65535. Required, if comment.files is not set.                                                                                                                                                                                          |
+| comment.files           |      Array       | Conditionally<br />Required | An array including data of attachment files.<br />The maximum number of the files is 5.<br />Required, if comment.text is not set.                                                                                                                                                                                                                   |
+| comment.files[].fileKey |      String      |                             | The fileKey of the attachment file.<br />Use the fileKey that is responded from the [Upload File API](https://kintone.dev/en/docs/kintone/rest-api/files/upload-file/).                                                                                                                                                                              |
+| comment.files[].width   | Number or String |                             | A width can be specified if the attachment file is an image.<br />The minimum is 100, and the maximum is 750.<br />If this parameter is ignored, the original width will be set (this width is the same size as the size when "Original" is chosen when adding an image to a thread via GUI). This parameter is ignored if the file is not an image. |
+| comment.mentions        |      Array       |                             | An array including mentions, that notify other Kintone users.                                                                                                                                                                                                                                                                                        |
+| comment.mentions[].code |      String      |                             | The code of the user, group or department that will be mentioned.<br />The maximum number of mentions is 10.<br />The mentioned users will be placed in front of the comment text in the output.                                                                                                                                                     |
+| comment.mentions[].type |      String      |                             | The entity type of the mentioned target.<br><ul><li><strong>USER</strong>: User<li><strong>GROUP</strong>: Group<li><strong>ORGANIZATION</strong>: Department                                                                                                                                                                                        |
+
+#### Returns
+
+| Name |  Type  | Description                            |
+| ---- | :----: | -------------------------------------- |
+| id   | String | The comment ID of the created comment. |
+
+#### Reference
+
+- https://kintone.dev/en/docs/kintone/rest-api/spaces/add-thread-comment/

--- a/packages/rest-api-client/src/client/SpaceClient.ts
+++ b/packages/rest-api-client/src/client/SpaceClient.ts
@@ -1,4 +1,4 @@
-import type { SpaceID, Space } from "./types";
+import type { SpaceID, Space, ThreadComment } from "./types";
 import { BaseClient } from "./BaseClient";
 
 export class SpaceClient extends BaseClient {
@@ -21,5 +21,12 @@ export class SpaceClient extends BaseClient {
       endpointName: "space/body",
     });
     return this.client.put(path, params);
+  }
+
+  public addThreadComment(params: ThreadComment): Promise<{ id: string }> {
+    const path = this.buildPathWithGuestSpaceId({
+      endpointName: "space/thread/comment",
+    });
+    return this.client.post(path, params);
   }
 }

--- a/packages/rest-api-client/src/client/__tests__/SpaceClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/SpaceClient.test.ts
@@ -2,6 +2,7 @@ import type { MockClient } from "../../http/MockClient";
 import { buildMockClient } from "../../http/MockClient";
 import { SpaceClient } from "../SpaceClient";
 import { KintoneRequestConfigBuilder } from "../../KintoneRequestConfigBuilder";
+import type { ThreadComment } from "../types";
 
 const SPACE_ID = 1;
 
@@ -69,6 +70,36 @@ describe("SpaceClient", () => {
       expect(mockClient.getLogs()[0].method).toBe("put");
     });
     it("should pass id, body to the http client", () => {
+      expect(mockClient.getLogs()[0].params).toEqual(params);
+    });
+  });
+
+  describe("addThreadComment", () => {
+    const params: ThreadComment = {
+      space: "1",
+      thread: "2",
+      comment: {
+        text: "This is a comment",
+        mentions: [
+          {
+            code: "user1",
+            type: "USER",
+          },
+        ],
+      },
+    };
+    beforeEach(async () => {
+      await spaceClient.addThreadComment(params);
+    });
+    it("should pass the path to the http client", () => {
+      expect(mockClient.getLogs()[0].path).toBe(
+        "/k/v1/space/thread/comment.json",
+      );
+    });
+    it("should send a POST request", () => {
+      expect(mockClient.getLogs()[0].method).toBe("post");
+    });
+    it("should pass space, thread, comment to the http client", () => {
       expect(mockClient.getLogs()[0].params).toEqual(params);
     });
   });

--- a/packages/rest-api-client/src/client/types/index.ts
+++ b/packages/rest-api-client/src/client/types/index.ts
@@ -2,6 +2,7 @@ export type AppID = string | number;
 export type RecordID = string | number;
 export type Revision = string | number;
 export type SpaceID = string | number;
+export type ThreadID = string | number;
 
 export * from "./record";
 export * from "./app";

--- a/packages/rest-api-client/src/client/types/space/index.ts
+++ b/packages/rest-api-client/src/client/types/space/index.ts
@@ -32,21 +32,20 @@ export type Space = {
   fixedMember: boolean;
 };
 
+type FileComment = {
+  fileKey: string;
+  width?: string | number;
+};
+
 export type CommentWithText = {
   text: string;
-  files?: Array<{
-    fileKey: string;
-    width?: string | number;
-  }>;
+  files?: FileComment[];
   mentions?: Entity[];
 };
 
 export type CommentWithFiles = {
   text?: string;
-  files: Array<{
-    fileKey: string;
-    width?: string | number;
-  }>;
+  files: FileComment[];
   mentions?: Entity[];
 };
 

--- a/packages/rest-api-client/src/client/types/space/index.ts
+++ b/packages/rest-api-client/src/client/types/space/index.ts
@@ -1,4 +1,5 @@
 import type { App } from "../app";
+import type { Entity } from "../entity";
 
 type AttachedApp = Pick<
   App,
@@ -29,4 +30,28 @@ export type Space = {
   isGuest: boolean;
   attachedApps: AttachedApp[];
   fixedMember: boolean;
+};
+
+export type CommentWithText = {
+  text: string;
+  files?: Array<{
+    fileKey: string;
+    width?: string | number;
+  }>;
+  mentions?: Entity[];
+};
+
+export type CommentWithFiles = {
+  text?: string;
+  files: Array<{
+    fileKey: string;
+    width?: string | number;
+  }>;
+  mentions?: Entity[];
+};
+
+export type ThreadComment = {
+  space: string;
+  thread: string;
+  comment: CommentWithText | CommentWithFiles;
 };

--- a/packages/rest-api-client/src/client/types/space/index.ts
+++ b/packages/rest-api-client/src/client/types/space/index.ts
@@ -1,5 +1,6 @@
 import type { App } from "../app";
 import type { Entity } from "../entity";
+import type { SpaceID, ThreadID } from "../index";
 
 type AttachedApp = Pick<
   App,
@@ -50,7 +51,7 @@ export type CommentWithFiles = {
 };
 
 export type ThreadComment = {
-  space: string;
-  thread: string;
+  space: SpaceID;
+  thread: ThreadID;
   comment: CommentWithText | CommentWithFiles;
 };


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
- Support `addThreadComment` method to be able to add a comment to a thread of a space.
<!-- Why do you want the feature and why does it make sense for the package? -->

## What
- Add new method `addThreadComment`
- Add unit test
- Add demo script
<!-- What is a solution you want to add? -->

## How to test
- Check test spec
<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [X] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
