### PR TITLE
fix(rest-api-client-demo): add npm, pnpm support in rest-api-client-demo

### DIFF
--- a/examples/rest-api-client-demo/README.md
+++ b/examples/rest-api-client-demo/README.md
@@ -32,14 +32,42 @@ We have an app ID in `customize-manifest.json`, so you have to update the app ID
 
 ### Run a script with `ts-node`
 
+#### yarn
+
 ```
-% yarn run-script record getRecord
+% yarn run demo record getRecord
+```
+
+#### npm
+
+```
+% npm run demo record getRecord
+```
+
+#### pnpm
+
+```
+% pnpm run demo record getRecord
 ```
 
 ### Upload scripts to your Kintone environment
 
+#### yarn
+
 ```
-% yarn deploy
+% yarn run deploy
+```
+
+#### npm
+
+```
+% npm run deploy
+```
+
+#### pnpm
+
+```
+% pnpm run deploy
 ```
 
 ## License

--- a/examples/rest-api-client-demo/README.md
+++ b/examples/rest-api-client-demo/README.md
@@ -35,7 +35,7 @@ We have an app ID in `customize-manifest.json`, so you have to update the app ID
 #### yarn
 
 ```
-% yarn run demo record getRecord
+% yarn demo record getRecord
 ```
 
 #### npm
@@ -47,7 +47,7 @@ We have an app ID in `customize-manifest.json`, so you have to update the app ID
 #### pnpm
 
 ```
-% pnpm run demo record getRecord
+% pnpm demo record getRecord
 ```
 
 ### Upload scripts to your Kintone environment
@@ -55,7 +55,7 @@ We have an app ID in `customize-manifest.json`, so you have to update the app ID
 #### yarn
 
 ```
-% yarn run deploy
+% yarn deploy
 ```
 
 #### npm
@@ -67,7 +67,7 @@ We have an app ID in `customize-manifest.json`, so you have to update the app ID
 #### pnpm
 
 ```
-% pnpm run deploy
+% pnpm deploy
 ```
 
 ## License

--- a/examples/rest-api-client-demo/package.json
+++ b/examples/rest-api-client-demo/package.json
@@ -21,7 +21,7 @@
     "lint": "run-p -l lint:*",
     "deploy": "rimraf scripts/dist && run-s webpack upload",
     "upload": "kintone-customize-uploader customize-manifest.json",
-    "run-script": "ts-node src/run-node.ts",
+    "demo": "ts-node src/run-node.ts",
     "webpack": "webpack"
   },
   "bugs": {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
- Our tools need support most common package managers
<!-- Why do you want the feature and why does it make sense for the package? -->

## What
- Add npm, pnpm support in rest-api-client-demo
<!-- What is a solution you want to add? -->

## How to test
yarn
```
$ cd <path-to-rest-api-client-demo>
$ yarn demo space getSpace
$ yarn deploy
```

npm
```
$ cd <path-to-rest-api-client-demo>
$ npm run demo space getSpace
$ npm run deploy
```

pnpm
```
$ cd <path-to-rest-api-client-demo>
$ pnpm demo space getSpace
$ pnpm deploy
```
<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
