### PR TITLE
test(webpack-plugin-kintone-plugin): fix failed test on windows

### DIFF
--- a/packages/webpack-plugin-kintone-plugin/src/__tests__/cli.test.ts
+++ b/packages/webpack-plugin-kintone-plugin/src/__tests__/cli.test.ts
@@ -19,6 +19,7 @@ const runWebpack = (config = "webpack.config.js") => {
     ["--config", config, "--mode", "production"],
     {
       cwd: pluginDir,
+      shell: true,
     },
   );
 };

--- a/packages/webpack-plugin-kintone-plugin/src/__tests__/cli.test.ts
+++ b/packages/webpack-plugin-kintone-plugin/src/__tests__/cli.test.ts
@@ -13,14 +13,14 @@ const pluginJsOutputPaths = [
 ];
 
 const runWebpack = (config = "webpack.config.js") => {
-  const webpackCommand = `webpack${os.platform() === "win32" ? ".cmd" : ""}`;
-  const shell = os.platform() === "win32";
+  const isWindows = os.platform() === "win32";
+  const webpackCommand = `webpack${isWindows ? ".cmd" : ""}`;
   return spawnSync(
     webpackCommand,
     ["--config", config, "--mode", "production"],
     {
       cwd: pluginDir,
-      shell,
+      shell: isWindows,
     },
   );
 };

--- a/packages/webpack-plugin-kintone-plugin/src/__tests__/cli.test.ts
+++ b/packages/webpack-plugin-kintone-plugin/src/__tests__/cli.test.ts
@@ -14,12 +14,13 @@ const pluginJsOutputPaths = [
 
 const runWebpack = (config = "webpack.config.js") => {
   const webpackCommand = `webpack${os.platform() === "win32" ? ".cmd" : ""}`;
+  const shell = os.platform() === "win32";
   return spawnSync(
     webpackCommand,
     ["--config", config, "--mode", "production"],
     {
       cwd: pluginDir,
-      shell: true,
+      shell,
     },
   );
 };


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
- Fix fail test on Windows
- Following the 18.20.2/20.12.2 node.js releases, it is no longer valid to call child_process.spawn with a .cmd or .bat file without using the shell: true option.
Ref: https://nodejs.org/en/blog/release/v18.20.2
<!-- Why do you want the feature and why does it make sense for the package? -->

## What
- Add `shell: true` to `spawnSync` configuration if OS is Windows.
<!-- What is a solution you want to add? -->

## How to test
`pnpm test`
<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
