### PR TITLE
fix(create-plugin): exit-code should be non-zero when an error occurs

### DIFF
--- a/packages/create-plugin/__e2e__/e2e.test.ts
+++ b/packages/create-plugin/__e2e__/e2e.test.ts
@@ -23,6 +23,7 @@ import { pattern as emptyOutputDir } from "./fixtures/emptyOutputDir";
 import { pattern as pluginNameContain65Chars } from "./fixtures/pluginNameContain65Chars";
 import { pattern as pluginDescriptionContain201Chars } from "./fixtures/pluginDescriptionContain201Chars";
 import { pattern as existOutputDir } from "./fixtures/existOutputDir";
+import { pattern as forbiddenCharacters } from "./fixtures/forbiddenCharacters";
 import { pattern as createKintonePluginCommand } from "./fixtures/createKintonePluginCommand";
 
 export type TestPattern = {
@@ -62,6 +63,7 @@ describe("create-plugin", function () {
     existOutputDir,
     pluginNameContain65Chars,
     pluginDescriptionContain201Chars,
+    forbiddenCharacters,
     createKintonePluginCommand,
   ];
 
@@ -106,69 +108,6 @@ describe("create-plugin", function () {
           new RegExp(expected.failure.stderr),
         );
       }
-    }
-  });
-
-  it("#JsSdkTest-11 Should throw an error when the output directory contains forbidden characters", async () => {
-    const m = getBoundMessage("en");
-    let outputDir: string;
-    const isWindows = process.platform === "win32";
-    if (isWindows) {
-      outputDir = ":";
-    } else {
-      outputDir = "/";
-    }
-
-    const questionsInput: QuestionInput[] = [
-      {
-        question: m("Q_NameEn"),
-        answer: "test11-name",
-      },
-      {
-        question: m("Q_DescriptionEn"),
-        answer: "test11-description",
-      },
-      {
-        question: m("Q_SupportJa"),
-        answer: DEFAULT_ANSWER,
-      },
-      {
-        question: m("Q_SupportZh"),
-        answer: DEFAULT_ANSWER,
-      },
-      {
-        question: m("Q_WebsiteUrlEn"),
-        answer: DEFAULT_ANSWER,
-      },
-      {
-        question: m("Q_MobileSupport"),
-        answer: ANSWER_NO,
-      },
-      {
-        question: m("Q_EnablePluginUploader"),
-        answer: ANSWER_NO,
-      },
-    ];
-
-    const response = await executeCommandWithInteractiveInput({
-      command: CREATE_PLUGIN_COMMAND,
-      workingDir,
-      outputDir,
-      questionsInput,
-    });
-
-    if (isWindows) {
-      assert.equal(response.status, 0);
-      assert.match(
-        response.stderr.toString().trim(),
-        /Could not create a plug-in project. Error:\nEINVAL: invalid argument, mkdir '.*:'/,
-      );
-    } else {
-      assert.notEqual(response.status, 0);
-      assert.match(
-        response.stderr.toString().trim(),
-        /Error: \/ already exists. Choose a different directory/,
-      );
     }
   });
 

--- a/packages/create-plugin/__e2e__/e2e.test.ts
+++ b/packages/create-plugin/__e2e__/e2e.test.ts
@@ -171,7 +171,7 @@ describe("create-plugin", function () {
     const response = await createPlugin.executeCommand();
 
     if (isWindows) {
-      assert.equal(response.status, 0);
+      assert.equal(response.status, 1);
       assert.match(
         response.stderr.trim(),
         /Could not create a plug-in project. Error:\nEINVAL: invalid argument, mkdir '.*:'/,

--- a/packages/create-plugin/__e2e__/fixtures/forbiddenCharacters.ts
+++ b/packages/create-plugin/__e2e__/fixtures/forbiddenCharacters.ts
@@ -1,0 +1,63 @@
+import type { TestPattern } from "../e2e.test";
+import {
+  ANSWER_NO,
+  CREATE_PLUGIN_COMMAND,
+  DEFAULT_ANSWER,
+} from "../utils/constants";
+import { getBoundMessage } from "../../src/messages";
+
+const m = getBoundMessage("en");
+let outputDir: string;
+let expectedStderr: string;
+const isWindows = process.platform === "win32";
+if (isWindows) {
+  outputDir = ":";
+  expectedStderr = `Could not create a plug-in project. Error:\\nEINVAL: invalid argument, mkdir '.*:'`;
+} else {
+  outputDir = "/";
+  expectedStderr = `Error: ${outputDir} already exists. Choose a different directory`;
+}
+
+export const pattern: TestPattern = {
+  description:
+    "#JsSdkTest-11 Should throw an error when the output directory contains forbidden characters",
+  input: {
+    command: CREATE_PLUGIN_COMMAND,
+    outputDir: outputDir,
+    questionsInput: [
+      {
+        question: m("Q_NameEn"),
+        answer: "test11-name",
+      },
+      {
+        question: m("Q_DescriptionEn"),
+        answer: "test11-description",
+      },
+      {
+        question: m("Q_SupportJa"),
+        answer: DEFAULT_ANSWER,
+      },
+      {
+        question: m("Q_SupportZh"),
+        answer: DEFAULT_ANSWER,
+      },
+      {
+        question: m("Q_WebsiteUrlEn"),
+        answer: DEFAULT_ANSWER,
+      },
+      {
+        question: m("Q_MobileSupport"),
+        answer: ANSWER_NO,
+      },
+      {
+        question: m("Q_EnablePluginUploader"),
+        answer: ANSWER_NO,
+      },
+    ],
+  },
+  expected: {
+    failure: {
+      stderr: expectedStderr,
+    },
+  },
+};

--- a/packages/create-plugin/src/index.ts
+++ b/packages/create-plugin/src/index.ts
@@ -83,9 +83,14 @@ ${m("developerSite")}
       `);
     })
     .catch((error: Error) => {
-      rimraf(outputDir, { glob: true }).then(() => {
-        printError(m("Error_cannotCreatePlugin"), error.message);
-      });
+      rimraf(outputDir, { glob: true })
+        .then(() => {
+          printError(m("Error_cannotCreatePlugin"), error.message);
+        })
+        .finally(() => {
+          // eslint-disable-next-line no-process-exit
+          process.exit(1);
+        });
     });
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,120 +147,6 @@ importers:
         specifier: ^29.7.0
         version: 29.7.0
 
-  'packages/create-plugin/:':
-    devDependencies:
-      '@cybozu/eslint-config':
-        specifier: ^23.0.0
-        version: 23.0.0(@types/eslint@8.56.10)(eslint@8.57.0)(prettier@3.2.5)(typescript@5.4.5)
-      '@kintone/plugin-packer':
-        specifier: ^8.0.6
-        version: link:../../plugin-packer
-      '@kintone/plugin-uploader':
-        specifier: ^9.1.0
-        version: link:../../plugin-uploader
-      eslint:
-        specifier: ^8.57.0
-        version: 8.57.0
-      npm-run-all:
-        specifier: ^4.1.5
-        version: 4.1.5
-
-  packages/create-plugin/xx:
-    devDependencies:
-      '@cybozu/eslint-config':
-        specifier: ^23.0.0
-        version: 23.0.0(@types/eslint@8.56.10)(eslint@8.57.0)(prettier@3.2.5)(typescript@5.4.5)
-      '@kintone/plugin-packer':
-        specifier: ^8.0.6
-        version: link:../../plugin-packer
-      '@kintone/plugin-uploader':
-        specifier: ^9.1.0
-        version: link:../../plugin-uploader
-      eslint:
-        specifier: ^8.57.0
-        version: 8.57.0
-      npm-run-all:
-        specifier: ^4.1.5
-        version: 4.1.5
-
-  packages/create-plugin/xxx:
-    devDependencies:
-      '@cybozu/eslint-config':
-        specifier: ^23.0.0
-        version: 23.0.0(@types/eslint@8.56.10)(eslint@8.57.0)(prettier@3.2.5)(typescript@5.4.5)
-      '@kintone/plugin-packer':
-        specifier: ^8.0.6
-        version: link:../../plugin-packer
-      '@kintone/plugin-uploader':
-        specifier: ^9.1.0
-        version: link:../../plugin-uploader
-      eslint:
-        specifier: ^8.57.0
-        version: 8.57.0
-      npm-run-all:
-        specifier: ^4.1.5
-        version: 4.1.5
-
-  packages/create-plugin/xxxxxx:
-    devDependencies:
-      '@cybozu/eslint-config':
-        specifier: ^23.0.0
-        version: 23.0.0(@types/eslint@8.56.10)(eslint@8.57.0)(prettier@3.2.5)(typescript@5.4.5)
-      '@kintone/plugin-packer':
-        specifier: ^8.0.6
-        version: link:../../plugin-packer
-      '@kintone/plugin-uploader':
-        specifier: ^9.1.0
-        version: link:../../plugin-uploader
-      eslint:
-        specifier: ^8.57.0
-        version: 8.57.0
-      npm-run-all:
-        specifier: ^4.1.5
-        version: 4.1.5
-
-  packages/create-plugin/xxxxxxx:
-    devDependencies:
-      '@cybozu/eslint-config':
-        specifier: ^23.0.0
-        version: 23.0.0(@types/eslint@8.56.10)(eslint@8.57.0)(prettier@3.2.5)(typescript@5.4.5)
-      '@kintone/plugin-packer':
-        specifier: ^8.0.6
-        version: link:../../plugin-packer
-      eslint:
-        specifier: ^8.57.0
-        version: 8.57.0
-
-  packages/create-plugin/xxxxxxxx:
-    devDependencies:
-      '@cybozu/eslint-config':
-        specifier: ^23.0.0
-        version: 23.0.0(@types/eslint@8.56.10)(eslint@8.57.0)(prettier@3.2.5)(typescript@5.4.5)
-      '@kintone/plugin-packer':
-        specifier: ^8.0.6
-        version: link:../../plugin-packer
-      eslint:
-        specifier: ^8.57.0
-        version: 8.57.0
-
-  packages/create-plugin/xxxxxxxxxx:
-    devDependencies:
-      '@cybozu/eslint-config':
-        specifier: ^23.0.0
-        version: 23.0.0(@types/eslint@8.56.10)(eslint@8.57.0)(prettier@3.2.5)(typescript@5.4.5)
-      '@kintone/plugin-packer':
-        specifier: ^8.0.6
-        version: link:../../plugin-packer
-      '@kintone/plugin-uploader':
-        specifier: ^9.1.0
-        version: link:../../plugin-uploader
-      eslint:
-        specifier: ^8.57.0
-        version: 8.57.0
-      npm-run-all:
-        specifier: ^4.1.5
-        version: 4.1.5
-
   packages/customize-uploader:
     dependencies:
       '@kintone/rest-api-client':
@@ -3886,7 +3772,7 @@ packages:
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
-      es-abstract: 1.23.3
+      es-abstract: 1.22.1
       get-intrinsic: 1.2.4
       is-string: 1.0.7
 
@@ -3915,8 +3801,8 @@ packages:
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
-      es-abstract: 1.23.3
-      es-shim-unscopables: 1.0.2
+      es-abstract: 1.22.1
+      es-shim-unscopables: 1.0.0
       get-intrinsic: 1.2.4
 
   /array.prototype.flat@1.3.2:
@@ -3925,8 +3811,8 @@ packages:
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
-      es-abstract: 1.23.3
-      es-shim-unscopables: 1.0.2
+      es-abstract: 1.22.1
+      es-shim-unscopables: 1.0.0
 
   /array.prototype.flatmap@1.3.2:
     resolution: {integrity: sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==}
@@ -3934,8 +3820,8 @@ packages:
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
-      es-abstract: 1.23.3
-      es-shim-unscopables: 1.0.2
+      es-abstract: 1.22.1
+      es-shim-unscopables: 1.0.0
 
   /array.prototype.toreversed@1.1.2:
     resolution: {integrity: sha512-wwDCoT4Ck4Cz7sLtgUmzR5UV3YF5mFHUlbChCzZBQZ+0m2cl/DH3tKgvphv1nKgFsJ48oCSg6p91q2Vm0I/ZMA==}
@@ -4017,6 +3903,11 @@ packages:
     dependencies:
       tslib: 2.6.2
     dev: false
+
+  /asynciterator.prototype@1.0.0:
+    resolution: {integrity: sha512-wwHYEIS0Q80f5mosx3L/dfG5t5rjEa9Ft51GTaNt862EnpyGHpgz2RkZvLPp1oF5TnAiTohkEKVEu8pQPJI7Vg==}
+    dependencies:
+      has-symbols: 1.0.3
 
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -5152,7 +5043,7 @@ packages:
       is-regex: 1.1.4
       object-is: 1.1.5
       object-keys: 1.1.1
-      regexp.prototype.flags: 1.5.2
+      regexp.prototype.flags: 1.5.0
     dev: true
 
   /deep-is@0.1.4:
@@ -5593,6 +5484,24 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  /es-iterator-helpers@1.0.15:
+    resolution: {integrity: sha512-GhoY8uYqd6iwUl2kgjTm4CZAf6oo5mHK7BPqx3rKgx893YSsy0LGHV6gfqqQvZt/8xM8xeOnfXBCfqclMKkJ5g==}
+    dependencies:
+      asynciterator.prototype: 1.0.0
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-abstract: 1.22.1
+      es-set-tostringtag: 2.0.1
+      function-bind: 1.1.2
+      get-intrinsic: 1.2.4
+      globalthis: 1.0.3
+      has-property-descriptors: 1.0.2
+      has-proto: 1.0.1
+      has-symbols: 1.0.3
+      internal-slot: 1.0.5
+      iterator.prototype: 1.1.2
+      safe-array-concat: 1.0.1
+
   /es-iterator-helpers@1.0.18:
     resolution: {integrity: sha512-scxAJaewsahbqTYrGKJihhViaM6DDZDDoucfvzNbK0pOren1g/daDQ3IAhzn+1G14rBG7w+i5N+qul60++zlKA==}
     engines: {node: '>= 0.4'}
@@ -5646,7 +5555,7 @@ packages:
   /es-shim-unscopables@1.0.2:
     resolution: {integrity: sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==}
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.0
 
   /es-to-primitive@1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
@@ -5881,7 +5790,7 @@ packages:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.4.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
-      hasown: 2.0.2
+      hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
       minimatch: 3.1.2
@@ -5910,9 +5819,9 @@ packages:
       axobject-query: 3.2.1
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      es-iterator-helpers: 1.0.18
+      es-iterator-helpers: 1.0.15
       eslint: 8.57.0
-      hasown: 2.0.2
+      hasown: 2.0.0
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
       minimatch: 3.1.2
@@ -6586,7 +6495,7 @@ packages:
       function-bind: 1.1.2
       has-proto: 1.0.1
       has-symbols: 1.0.3
-      hasown: 2.0.2
+      hasown: 2.0.0
 
   /get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
@@ -6848,6 +6757,12 @@ packages:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
     dev: true
+
+  /hasown@2.0.0:
+    resolution: {integrity: sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      function-bind: 1.1.2
 
   /hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -7116,7 +7031,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       es-errors: 1.3.0
-      hasown: 2.0.2
+      hasown: 2.0.0
       side-channel: 1.0.6
 
   /interpret@3.1.1:
@@ -7216,7 +7131,7 @@ packages:
   /is-core-module@2.13.1:
     resolution: {integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==}
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.0
 
   /is-data-view@1.0.1:
     resolution: {integrity: sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==}
@@ -7530,7 +7445,7 @@ packages:
       get-intrinsic: 1.2.4
       has-symbols: 1.0.3
       reflect.getprototypeof: 1.0.4
-      set-function-name: 2.0.2
+      set-function-name: 2.0.1
 
   /jackspeak@2.3.6:
     resolution: {integrity: sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==}
@@ -8132,7 +8047,7 @@ packages:
     dependencies:
       array-includes: 3.1.7
       array.prototype.flat: 1.3.2
-      object.assign: 4.1.5
+      object.assign: 4.1.4
       object.values: 1.1.7
 
   /kind-of@6.0.3:
@@ -8749,7 +8664,7 @@ packages:
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
-      es-abstract: 1.23.3
+      es-abstract: 1.22.1
       get-intrinsic: 1.2.4
 
   /object.hasown@1.1.4:
@@ -9903,7 +9818,7 @@ packages:
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
-      es-abstract: 1.23.3
+      es-abstract: 1.22.1
       get-intrinsic: 1.2.4
       globalthis: 1.0.3
       which-builtin-type: 1.1.3
@@ -10345,6 +10260,14 @@ packages:
       function-bind: 1.1.2
       get-intrinsic: 1.2.4
       gopd: 1.0.1
+      has-property-descriptors: 1.0.2
+
+  /set-function-name@2.0.1:
+    resolution: {integrity: sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      define-data-property: 1.1.4
+      functions-have-names: 1.2.3
       has-property-descriptors: 1.0.2
 
   /set-function-name@2.0.2:
@@ -11720,8 +11643,8 @@ packages:
     resolution: {integrity: sha512-YmjsSMDBYsM1CaFiayOVT06+KJeXf0o5M/CAd4o1lTadFAtacTUM49zoYxr/oroopFDfhvN6iEcBxUyc3gvKmw==}
     engines: {node: '>= 0.4'}
     dependencies:
-      function.prototype.name: 1.1.6
-      has-tostringtag: 1.0.2
+      function.prototype.name: 1.1.5
+      has-tostringtag: 1.0.0
       is-async-function: 2.0.0
       is-date-object: 1.0.5
       is-finalizationregistry: 1.0.2
@@ -11731,7 +11654,7 @@ packages:
       isarray: 2.0.5
       which-boxed-primitive: 1.0.2
       which-collection: 1.0.1
-      which-typed-array: 1.1.15
+      which-typed-array: 1.1.11
 
   /which-collection@1.0.1:
     resolution: {integrity: sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==}


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

When an error occurs, the exit code is returned as zero.
It's difficult to know whether the command is successful or not.

## What

- The `exit-code` should be non-zero when an error occurs.

## How to test

```
pnpm build
pnpm test:e2e
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
