### PR TITLE
build: fix running pnpm postbuild on Windows

### DIFF
--- a/packages/dts-gen/bin/npm-build.js
+++ b/packages/dts-gen/bin/npm-build.js
@@ -1,0 +1,18 @@
+const fs = require("fs");
+const path = require("path");
+
+const sourceFile = path.join(__dirname, "..", "dist", "index.js");
+const shebangFile = path.join(__dirname, "..", "resources", "shebang.txt");
+const tmpFile = path.join(__dirname, "..", "dist", "index.js.tmp");
+
+// Read the shebang
+const shebangContent = fs.readFileSync(shebangFile, "utf8");
+
+// Read the original dist/index.js
+const originalContent = fs.readFileSync(sourceFile, "utf8");
+
+// Concatenate and write to temp file
+fs.writeFileSync(tmpFile, shebangContent + originalContent);
+
+// Replace original file with temp file
+fs.renameSync(tmpFile, sourceFile);

--- a/packages/dts-gen/bin/npm-build.sh
+++ b/packages/dts-gen/bin/npm-build.sh
@@ -1,4 +1,0 @@
-#!/bin/sh -ex
-
-cat resources/shebang.txt dist/index.js > dist/index.js.tmp
-mv dist/index.js.tmp dist/index.js

--- a/packages/dts-gen/package.json
+++ b/packages/dts-gen/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prebuild": "pnpm clean",
     "build": "tsc --build --force",
-    "postbuild": "bash bin/npm-build.sh && pnpm build:integration",
+    "postbuild": "node bin/npm-build.js && pnpm build:integration",
     "clean": "rimraf dist",
     "fix:eslint": "pnpm lint:eslint --fix",
     "fix:prettier": "prettier --parser typescript --write \"src/**/*.{ts,tsx}\" ./kintone.d.ts",


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
- Fixing `pnpm postbuild` failed on Windows developing environment
<!-- Why do you want the feature and why does it make sense for the package? -->

## What
- Change sh script to js script in adding shebang in index.js
<!-- What is a solution you want to add? -->

## How to test
`pnpm postbuild`
<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
