### PR TITLE
fix(dts-gen): fix error when running dts-gen globally

### DIFF
--- a/packages/dts-gen/src/templates/template.ts
+++ b/packages/dts-gen/src/templates/template.ts
@@ -17,6 +17,7 @@ export interface RenderInput {
 const renderAsFile = async (output: string, renderInput: RenderInput) => {
   const tsExpression = convertToTsExpression(renderInput);
   const eslint = new ESLint({
+    cwd: path.resolve(__dirname, "..", ".."),
     fix: true,
     useEslintrc: false,
     baseConfig: {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
- Fix error when running dts-gen globally
<!-- Why do you want the feature and why does it make sense for the package? -->

## What
- Set current working directory to Eslint
<!-- What is a solution you want to add? -->

## How to test
`kintone-dts-gen --base-url <domain-name> -u <username> -p <password> --app-id <app-id> --type-name SampleFields --namespace abc.types -o sample-fields.d.ts`
Check command running locally and globally successful.
<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
