### PR TITLE
ci: Use googleapis/release-please-action instead of google-github-actions/release-please-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_GITHUB_APP_ID}}
           private-key: ${{ secrets.RELEASE_GITHUB_APP_KEY }}
-      - uses: google-github-actions/release-please-action@a37ac6e4f6449ce8b3f7607e4d97d0146028dc0b # v4
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           token: ${{ steps.create-iat.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_GITHUB_APP_ID}}
           private-key: ${{ secrets.RELEASE_GITHUB_APP_KEY }}
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@f3969c04a4ec81d7a9aa4010d84ae6a7602f86a7 # v4
         id: release
         with:
           token: ${{ steps.create-iat.outputs.token }}


### PR DESCRIPTION

<!-- Thank you for sending a pull request! -->

## Why
- The google-github-actions/release-please-action repo has been transferred to googleapis/release-please-action
https://github.com/googleapis/release-please-action/issues/980
<!-- Why do you want the feature and why does it make sense for the package? -->

## What
- Use googleapis/release-please-action instead of google-github-actions/release-please-action
<!-- What is a solution you want to add? -->

## How to test
- Check release PR is created by the action
<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
