### PR TITLE
feat(plugin-packer): print warning messages

### DIFF
--- a/packages/plugin-packer/package.json
+++ b/packages/plugin-packer/package.json
@@ -39,7 +39,7 @@
     "start": "npm-run-all -l -s clean build -p build:dev site:dev"
   },
   "dependencies": {
-    "@kintone/plugin-manifest-validator": "^10.1.0",
+    "@kintone/plugin-manifest-validator": "^10.2.0",
     "chokidar": "^3.6.0",
     "debug": "^4.3.4",
     "denodeify": "^1.2.1",

--- a/packages/plugin-packer/src/cli.ts
+++ b/packages/plugin-packer/src/cli.ts
@@ -118,6 +118,12 @@ const throwIfInvalidManifest = (manifest: any, pluginDir: string) => {
   });
   debug(result);
 
+  if (result.warnings && result.warnings.length > 0) {
+    result.warnings.forEach((warning) => {
+      console.warn(`WARN: ${warning.message}`);
+    });
+  }
+
   if (!result.valid) {
     const msgs = generateErrorMessages(result.errors ?? []);
     console.error("Invalid manifest.json:");

--- a/packages/plugin-packer/src/console.ts
+++ b/packages/plugin-packer/src/console.ts
@@ -1,4 +1,5 @@
 export = {
   log: console.log,
   error: console.error,
+  warn: console.warn,
 };

--- a/packages/plugin-packer/test/cli.spec.ts
+++ b/packages/plugin-packer/test/cli.spec.ts
@@ -17,15 +17,18 @@ const PLUGIN_BUFFER = Buffer.from("foo");
 describe("cli", () => {
   const consoleLog = console.log;
   const consoleError = console.error;
+  const consoleWarn = console.warn;
   beforeEach(() => {
     /* eslint-disable @typescript-eslint/no-empty-function -- This is mock functions */
     console.log = () => {};
     console.error = () => {};
+    console.warn = () => {};
     /* eslint-enable @typescript-eslint/no-empty-function */
   });
   afterEach(() => {
     console.log = consoleLog;
     console.error = consoleError;
+    console.warn = consoleWarn;
   });
 
   it("is a function", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,7 +252,7 @@ importers:
   packages/plugin-packer:
     dependencies:
       '@kintone/plugin-manifest-validator':
-        specifier: ^10.1.0
+        specifier: ^10.2.0
         version: link:../plugin-manifest-validator
       chokidar:
         specifier: ^3.6.0


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

Now, `plugin-manifest-validator` returns warnings if any. They should be printed on the console.

## What

- Prints warning messages that are returned from `plugin-manifest-validator`.

## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
