### PR TITLE
fix: update plugin `manifest-schema.json` URL

### DIFF
--- a/packages/create-plugin/src/__tests__/fixtures/manifest.json
+++ b/packages/create-plugin/src/__tests__/fixtures/manifest.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/kintone/js-sdk/main/packages/plugin-manifest-validator/manifest-schema.json",
+  "$schema": "https://raw.githubusercontent.com/kintone/js-sdk/%40kintone/plugin-manifest-validator%4010.2.0/packages/plugin-manifest-validator/manifest-schema.json",
   "manifest_version": 1,
   "version": 1,
   "type": "APP",

--- a/packages/create-plugin/src/manifest.ts
+++ b/packages/create-plugin/src/manifest.ts
@@ -5,7 +5,7 @@ import type { TemplateType } from "./template";
 
 const minimumManifest = {
   $schema:
-    "https://raw.githubusercontent.com/kintone/js-sdk/main/packages/plugin-manifest-validator/manifest-schema.json",
+    "https://raw.githubusercontent.com/kintone/js-sdk/%40kintone/plugin-manifest-validator%4010.2.0/packages/plugin-manifest-validator/manifest-schema.json",
   manifest_version: 1,
   version: 1,
   type: "APP",
@@ -24,7 +24,7 @@ const minimumManifest = {
 
 const modernManifest = {
   $schema:
-    "https://raw.githubusercontent.com/kintone/js-sdk/main/packages/plugin-manifest-validator/manifest-schema.json",
+    "https://raw.githubusercontent.com/kintone/js-sdk/%40kintone/plugin-manifest-validator%4010.2.0/packages/plugin-manifest-validator/manifest-schema.json",
   manifest_version: 1,
   version: 1,
   type: "APP",

--- a/packages/plugin-manifest-validator/README.md
+++ b/packages/plugin-manifest-validator/README.md
@@ -62,7 +62,7 @@ When you are configuring your project, you would better set the $schema property
 We recommend setting the $schema property to the following URI in your manifest.json:
 
 ```
-https://raw.githubusercontent.com/kintone/js-sdk/main/packages/plugin-manifest-validator/manifest-schema.json
+https://raw.githubusercontent.com/kintone/js-sdk/%40kintone/plugin-manifest-validator%4010.2.0/packages/plugin-manifest-validator/manifest-schema.json
 ```
 
 Note: Add or update the $schema property at the top of the manifest.json.

--- a/packages/plugin-manifest-validator/examples/manifest.json
+++ b/packages/plugin-manifest-validator/examples/manifest.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/kintone/js-sdk/main/packages/plugin-manifest-validator/manifest-schema.json",
+  "$schema": "https://raw.githubusercontent.com/kintone/js-sdk/%40kintone/plugin-manifest-validator%4010.2.0/packages/plugin-manifest-validator/manifest-schema.json",
   "manifest_version": 1,
   "version": 1,
   "type": "APP",


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

In https://github.com/kintone/js-sdk/pull/2781 and https://github.com/kintone/js-sdk/pull/2782, we added the recommended URL to the JSON Schema file for the plugin manifest file.

That URL points to the `main` branch of this repository and potentially becomes a broken link if we change the directory structure. In this PR, we update the URL to point to the specific tag on this repo to make the URL more stable.

NOTE: We also plan to host schema files on the stable website.

## What

<!-- What is a solution you want to add? -->

- updated the URL

## How to test

<!-- How can we test this pull request? -->

Check CI

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
