### PR TITLE
debug(create-plugin): handle timeout error and reduce execution time

### DIFF
--- a/packages/create-plugin/__e2e__/utils/executeCommand.ts
+++ b/packages/create-plugin/__e2e__/utils/executeCommand.ts
@@ -10,7 +10,10 @@ export const execCommand = (
 ) => {
   return spawn(command, parseArgs(args, options?.env), {
     stdio: ["pipe", "pipe", "pipe"],
-    env: options?.env ?? process.env,
+    env: {
+      ...process.env,
+      ...options.env,
+    },
     cwd: options?.cwd ?? process.cwd(),
     shell: true,
   });


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

- The test cannot exit when it exceeds the Jest timeout due to the spawn process.
- The execution time is too high.

## What

- Teardown spawn process when a test case is finished
- Reduce the execution time

## How to test

```
pnpm test:e2e
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
