### PR TITLE
test(create-plugin): optimizing e2e test

### DIFF
--- a/packages/create-plugin/__e2e__/utils/CreatePlugin.ts
+++ b/packages/create-plugin/__e2e__/utils/CreatePlugin.ts
@@ -25,7 +25,7 @@ export class CreatePlugin {
   private currentStep: number = 0;
   private stdout: string = "";
   private stderr: string = "";
-  private processExited: boolean = false;
+  private hasProcessExited: boolean = false;
 
   constructor(options: {
     command: string;
@@ -70,7 +70,7 @@ export class CreatePlugin {
 
     const cliExitPromise = new Promise<Response>((resolve, reject) => {
       this.childProcess.on("exit", (code: number, signal) => {
-        this.processExited = true;
+        this.hasProcessExited = true;
         if (this._isProcessTimedOut(code, signal)) {
           reject(new Error(`Process timed out!`));
           return;
@@ -127,7 +127,7 @@ export class CreatePlugin {
       }
 
       this.childProcess.on("exit", () => {
-        this.processExited = true;
+        this.hasProcessExited = true;
         resolve();
       });
       this.finishProcess();
@@ -135,7 +135,9 @@ export class CreatePlugin {
   }
 
   private finishProcess() {
-    this.childProcess.stdin.end();
+    if (this.childProcess.stdin) {
+      this.childProcess.stdin.end();
+    }
   }
 
   private _getCommands = (): { [key: string]: string } => {
@@ -185,7 +187,7 @@ export class CreatePlugin {
   }
 
   private _isProcessExited() {
-    return this.childProcess.exitCode !== null || this.processExited;
+    return this.childProcess.exitCode !== null || this.hasProcessExited;
   }
 
   private _isProcessTimedOut(

--- a/packages/create-plugin/__e2e__/utils/executeCommand.ts
+++ b/packages/create-plugin/__e2e__/utils/executeCommand.ts
@@ -10,7 +10,10 @@ export const execCommand = (
 ) => {
   return spawn(command, parseArgs(args, options?.env), {
     stdio: ["pipe", "pipe", "pipe"],
-    env: options?.env ?? process.env,
+    env: {
+      ...process.env,
+      ...options.env,
+    },
     cwd: options?.cwd ?? process.cwd(),
     shell: true,
   });


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

- The test cannot exit when exceeds the Jest timeout due to the spawn process.
- The execution time is too high.

## What

- Teardown spawn process when a test case is finished
- Reduce the execution time

## How to test

```
pnpm test:e2e
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
