### PR TITLE
feat(rest-api-client): add space.addThread() method

### DIFF
--- a/examples/rest-api-client-demo/src/space.ts
+++ b/examples/rest-api-client-demo/src/space.ts
@@ -83,6 +83,15 @@ export class Space {
     }
   }
 
+  public async addThread() {
+    const name = "Added Thread Name";
+    try {
+      console.log(await this.client.space.addThread({ space: SPACE_ID, name }));
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
   public async updateThread() {
     const body = "<b>This is an updated thread body</b>";
     const name = "Updated Thread Name";

--- a/examples/rest-api-client-demo/src/space.ts
+++ b/examples/rest-api-client-demo/src/space.ts
@@ -84,7 +84,7 @@ export class Space {
   }
 
   public async addThread() {
-    const name = "Added Thread Name";
+    const name = "The thread added via rest-api-client";
     try {
       console.log(await this.client.space.addThread({ space: SPACE_ID, name }));
     } catch (error) {

--- a/packages/rest-api-client/docs/space.md
+++ b/packages/rest-api-client/docs/space.md
@@ -190,7 +190,9 @@ The Enable multiple threads option must be enabled in the space settings.
 
 #### Returns
 
-An empty object.
+| Name |  Type  | Description                          |
+| ---- | :----: | ------------------------------------ |
+| id   | String | The thread ID of the created Thread. |
 
 #### Reference
 

--- a/packages/rest-api-client/docs/space.md
+++ b/packages/rest-api-client/docs/space.md
@@ -5,6 +5,7 @@
 - [updateSpaceBody](#updateSpaceBody)
 - [getSpaceMembers](#getSpaceMembers)
 - [updateSpaceMembers](#updateSpaceMembers)
+- [addThread](#addThread)
 - [updateThread](#updateThread)
 - [addThreadComment](#addThreadComment)
 - [addGuests](#addGuests)
@@ -174,6 +175,26 @@ An empty object.
 #### Reference
 
 - https://kintone.dev/en/docs/kintone/rest-api/spaces/update-space-members/
+
+### addThread
+
+Adds a Thread of a Space.<br />
+The Enable multiple threads option must be enabled in the space settings.
+
+#### Parameters
+
+| Name  |       Type       | Required | Description                                                          |
+| ----- | :--------------: | :------: | -------------------------------------------------------------------- |
+| space | Number or String |   Yes    | The space ID.                                                        |
+| name  |      String      |   Yes    | The new name of the Thread.<br />Must be between 1 - 128 characters. |
+
+#### Returns
+
+An empty object.
+
+#### Reference
+
+- https://kintone.dev/en/docs/kintone/rest-api/spaces/add-thread/
 
 ### updateThread
 

--- a/packages/rest-api-client/src/client/SpaceClient.ts
+++ b/packages/rest-api-client/src/client/SpaceClient.ts
@@ -52,6 +52,16 @@ export class SpaceClient extends BaseClient {
     return this.client.put(path, params);
   }
 
+  public addThread(params: {
+    space: SpaceID;
+    name: string;
+  }): Promise<{ id: string }> {
+    const path = this.buildPathWithGuestSpaceId({
+      endpointName: "space/thread",
+    });
+    return this.client.post(path, params);
+  }
+
   public updateThread(params: {
     id: ThreadID;
     name?: string;

--- a/packages/rest-api-client/src/client/__tests__/SpaceClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/SpaceClient.test.ts
@@ -136,6 +136,25 @@ describe("SpaceClient", () => {
     });
   });
 
+  describe("addThread", () => {
+    const params = {
+      space: SPACE_ID,
+      name: "Added Thread Name",
+    };
+    beforeEach(async () => {
+      await spaceClient.addThread(params);
+    });
+    it("should pass the path to the http client", () => {
+      expect(mockClient.getLogs()[0].path).toBe("/k/v1/space/thread.json");
+    });
+    it("should send a POST request", () => {
+      expect(mockClient.getLogs()[0].method).toBe("post");
+    });
+    it("should pass space, name to the http client", () => {
+      expect(mockClient.getLogs()[0].params).toEqual(params);
+    });
+  });
+
   describe("updateThread", () => {
     const params = {
       id: THREAD_ID,


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
Support addThread method to be able to add a tread to a space.

## What

<!-- What is a solution you want to add? -->
- Add new method addThread
- Add unit test
- Add demo script

## How to test

<!-- How can we test this pull request? -->
Check test spec

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
