### PR TITLE
feat(rest-api-client): add app.getPlugins method

### DIFF
--- a/examples/rest-api-client-demo/src/app.ts
+++ b/examples/rest-api-client-demo/src/app.ts
@@ -764,4 +764,12 @@ export class App {
       console.log(error);
     }
   }
+
+  public async getPlugins() {
+    try {
+      console.log(await this.client.app.getPlugins({ app: APP_ID }));
+    } catch (error) {
+      console.log(error);
+    }
+  }
 }

--- a/examples/rest-api-client-demo/src/app.ts
+++ b/examples/rest-api-client-demo/src/app.ts
@@ -767,7 +767,9 @@ export class App {
 
   public async getPlugins() {
     try {
-      console.log(await this.client.app.getPlugins({ app: APP_ID }));
+      console.log(
+        await this.client.app.getPlugins({ app: APP_ID, lang: "en" }),
+      );
     } catch (error) {
       console.log(error);
     }

--- a/packages/rest-api-client/docs/app.md
+++ b/packages/rest-api-client/docs/app.md
@@ -36,6 +36,7 @@
 - [updateReports](#updateReports)
 - [getAppActions](#getAppActions)
 - [updateAppActions](#updateAppActions)
+- [getPlugins](#getPlugins)
 
 ## Overview
 
@@ -1353,3 +1354,26 @@ Updates the [Action](https://get.kintone.help/k/en/user/app_settings/appaction/s
 #### Reference
 
 - https://kintone.dev/en/docs/kintone/rest-api/apps/update-action-settings/
+
+### getPlugins
+
+Gets the list of Plug-ins added to an App.
+
+#### Parameters
+
+| Name    |       Type       | Required | Description                                                                                                                                                                                                                                                                |
+| ------- | :--------------: | :------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| app     | Number or String |   Yes    | The App ID.                                                                                                                                                                                                                                                                |
+| lang    |      String      |          | The localized language to retrieve the data in: <ul> <li>`en`: retrieves the localized English names</li> <li>`zh`: retrieves the localized Chinese names</li> <li>`ja`: retrieves the localized Japanese names</li> </ul>If ignored, the default names will be retrieved. |
+| preview |     Boolean      |          | A flag whether to get the app actions for pre-live environment                                                                                                                                                                                                             |
+
+#### Returns
+
+| Name     |  Type  | Description                                                                                                                                                                                 |
+| -------- | :----: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| revision | String | The revision number of the App settings.                                                                                                                                                    |
+| plugins  | Object | An object listing Plug-ins. <br/>For each property of this object, see “Response Parameters” section of [the reference](https://kintone.dev/en/docs/kintone/rest-api/apps/get-app-plugins/) |
+
+#### Reference
+
+- https://kintone.dev/en/docs/kintone/rest-api/apps/get-app-plugins/

--- a/packages/rest-api-client/docs/app.md
+++ b/packages/rest-api-client/docs/app.md
@@ -1321,10 +1321,10 @@ Get the [Action](https://get.kintone.help/k/en/user/app_settings/appaction/set_a
 
 #### Returns
 
-| Name     |  Type  | Description                                                                                                                                                                                                                               |
-| -------- | :----: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| revision | String | The revision number of the App settings.                                                                                                                                                                                                  |
-| actions  | Object | An object listing Action settings. An object listing Action settings. <br/>For each property of this object, see “Response Parameters” section of [the reference](https://kintone.dev/en/docs/kintone/rest-api/apps/get-action-settings/) |
+| Name     |  Type  | Description                                                                                                                                                                                            |
+| -------- | :----: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| revision | String | The revision number of the App settings.                                                                                                                                                               |
+| actions  | Object | An object listing Action settings. <br/>For each property of this object, see “Response Parameters” section of [the reference](https://kintone.dev/en/docs/kintone/rest-api/apps/get-action-settings/) |
 
 #### Reference
 

--- a/packages/rest-api-client/src/client/AppClient.ts
+++ b/packages/rest-api-client/src/client/AppClient.ts
@@ -35,6 +35,7 @@ import type {
   AppActionsForResponse,
 } from "./types";
 import { BaseClient } from "./BaseClient";
+import type { AppPlugin } from "./types/app/plugin";
 type RowLayoutForParameter = {
   type: "ROW";
   fields: Array<{ [key: string]: unknown }>;
@@ -615,5 +616,21 @@ export class AppClient extends BaseClient {
       preview: true,
     });
     return this.client.put(path, params);
+  }
+
+  public getPlugins(params: {
+    app: AppID;
+    lang?: Lang;
+    preview?: boolean;
+  }): Promise<{
+    plugins: AppPlugin[];
+    revision: string;
+  }> {
+    const { preview, ...rest } = params;
+    const path = this.buildPathWithGuestSpaceId({
+      endpointName: "app/plugins",
+      preview,
+    });
+    return this.client.get(path, rest);
   }
 }

--- a/packages/rest-api-client/src/client/AppClient.ts
+++ b/packages/rest-api-client/src/client/AppClient.ts
@@ -3,7 +3,7 @@ import type {
   RecordID,
   Revision,
   Properties,
-  Lang,
+  AppLang,
   Layout,
   ViewForResponse,
   ViewForParameter,
@@ -33,6 +33,7 @@ import type {
   ReportForResponse,
   AppActionsForParameter,
   AppActionsForResponse,
+  PluginLocale,
 } from "./types";
 import { BaseClient } from "./BaseClient";
 import type { AppPlugin } from "./types/app/plugin";
@@ -69,7 +70,7 @@ type SpaceResponseParameters = {
 export class AppClient extends BaseClient {
   public getFormFields<T extends Properties>(params: {
     app: AppID;
-    lang?: Lang;
+    lang?: AppLang;
     preview?: boolean;
   }): Promise<{ properties: T; revision: string }> {
     const { preview, ...rest } = params;
@@ -142,7 +143,7 @@ export class AppClient extends BaseClient {
 
   public getViews(params: {
     app: AppID;
-    lang?: Lang;
+    lang?: AppLang;
     preview?: boolean;
   }): Promise<{
     views: { [viewName: string]: ViewForResponse };
@@ -222,7 +223,7 @@ export class AppClient extends BaseClient {
 
   public getAppSettings(params: {
     app: AppID;
-    lang?: Lang;
+    lang?: AppLang;
     preview?: boolean;
   }): Promise<{
     name: string;
@@ -293,7 +294,7 @@ export class AppClient extends BaseClient {
 
   public getProcessManagement(params: {
     app: AppID;
-    lang?: Lang;
+    lang?: AppLang;
     preview?: boolean;
   }): Promise<{
     enable: boolean;
@@ -414,7 +415,7 @@ export class AppClient extends BaseClient {
 
   public getRecordAcl(params: {
     app: AppID;
-    lang?: Lang;
+    lang?: AppLang;
     preview?: boolean;
   }): Promise<{ rights: RecordRightForResponse[]; revision: string }> {
     const { preview, ...rest } = params;
@@ -500,7 +501,7 @@ export class AppClient extends BaseClient {
 
   public getPerRecordNotifications(params: {
     app: AppID;
-    lang?: Lang;
+    lang?: AppLang;
     preview?: boolean;
   }): Promise<{
     notifications: PerRecordNotificationForResponse[];
@@ -528,7 +529,7 @@ export class AppClient extends BaseClient {
 
   public getReminderNotifications(params: {
     app: AppID;
-    lang?: Lang;
+    lang?: AppLang;
     preview?: boolean;
   }): Promise<{
     notifications: ReminderNotificationForResponse[];
@@ -558,7 +559,7 @@ export class AppClient extends BaseClient {
 
   public getReports(params: {
     app: AppID;
-    lang?: Lang;
+    lang?: AppLang;
     preview?: boolean;
   }): Promise<{
     reports: { [reportName: string]: ReportForResponse };
@@ -589,7 +590,7 @@ export class AppClient extends BaseClient {
 
   public getAppActions(params: {
     app: AppID;
-    lang?: Lang;
+    lang?: AppLang;
     preview?: boolean;
   }): Promise<{
     actions: AppActionsForResponse;
@@ -620,7 +621,7 @@ export class AppClient extends BaseClient {
 
   public getPlugins(params: {
     app: AppID;
-    lang?: Exclude<Lang, "default" | "user">;
+    lang?: PluginLocale;
     preview?: boolean;
   }): Promise<{
     plugins: AppPlugin[];

--- a/packages/rest-api-client/src/client/AppClient.ts
+++ b/packages/rest-api-client/src/client/AppClient.ts
@@ -620,7 +620,7 @@ export class AppClient extends BaseClient {
 
   public getPlugins(params: {
     app: AppID;
-    lang?: Lang;
+    lang?: Exclude<Lang, "default" | "user">;
     preview?: boolean;
   }): Promise<{
     plugins: AppPlugin[];

--- a/packages/rest-api-client/src/client/__tests__/AppClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/AppClient.test.ts
@@ -1312,6 +1312,56 @@ describe("AppClient", () => {
   });
 });
 
+describe("AppClient: plugins", () => {
+  let mockClient: MockClient;
+  let appClient: AppClient;
+
+  beforeEach(() => {
+    const requestConfigBuilder = new KintoneRequestConfigBuilder({
+      baseUrl: "https://example.cybozu.com",
+      auth: { type: "apiToken", apiToken: "foo" },
+    });
+    mockClient = buildMockClient(requestConfigBuilder);
+    appClient = new AppClient(mockClient);
+  });
+  describe("getPlugins", () => {
+    const params = { app: APP_ID } as const;
+    describe("without preview", () => {
+      beforeEach(async () => {
+        await appClient.getPlugins(params);
+      });
+      it("should pass the path to the http client", () => {
+        expect(mockClient.getLogs()[0].path).toBe("/k/v1/app/plugins.json");
+      });
+      it("should send a get request", () => {
+        expect(mockClient.getLogs()[0].method).toBe("get");
+      });
+      it("should pass app and lang as a param to the http client", () => {
+        expect(mockClient.getLogs()[0].params).toEqual(params);
+      });
+    });
+    describe("preview: true", () => {
+      beforeEach(async () => {
+        await appClient.getPlugins({
+          ...params,
+          preview: true,
+        });
+      });
+      it("should pass the path to the http client", () => {
+        expect(mockClient.getLogs()[0].path).toBe(
+          "/k/v1/preview/app/plugins.json",
+        );
+      });
+      it("should send a get request", () => {
+        expect(mockClient.getLogs()[0].method).toBe("get");
+      });
+      it("should pass app and lang as a param to the http client", () => {
+        expect(mockClient.getLogs()[0].params).toEqual(params);
+      });
+    });
+  });
+});
+
 describe("AppClient with guestSpaceId", () => {
   it("should pass the path to the http client", async () => {
     const GUEST_SPACE_ID = 2;

--- a/packages/rest-api-client/src/client/__tests__/AppClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/AppClient.test.ts
@@ -1325,7 +1325,7 @@ describe("AppClient: plugins", () => {
     appClient = new AppClient(mockClient);
   });
   describe("getPlugins", () => {
-    const params = { app: APP_ID } as const;
+    const params = { app: APP_ID, lang: "en" } as const;
     describe("without preview", () => {
       beforeEach(async () => {
         await appClient.getPlugins(params);

--- a/packages/rest-api-client/src/client/types/app/index.ts
+++ b/packages/rest-api-client/src/client/types/app/index.ts
@@ -1,4 +1,6 @@
-export type Lang = "ja" | "en" | "zh" | "user" | "default";
+type Lang = "ja" | "en" | "zh";
+export type AppLang = Lang | "default" | "user";
+export type PluginLocale = Lang;
 export type DeployStatus = "PROCESSING" | "SUCCESS" | "FAIL" | "CANCEL";
 
 export type App = {

--- a/packages/rest-api-client/src/client/types/app/plugin.ts
+++ b/packages/rest-api-client/src/client/types/app/plugin.ts
@@ -1,0 +1,5 @@
+export type AppPlugin = {
+  id: string;
+  name: string;
+  enabled: boolean;
+};


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Support app.getPlugins method to be able to get the list of Plug-ins added to an App.

## What

<!-- What is a solution you want to add? -->

- Add new methods, app.getPlugins
- Add unit test
  - When I run pnpm fix, I faced the warning as below in AppClientTest:
    `Arrow function has too many statements (41). Maximum allowed is 40  max-statements`
    So I implemented the new unit tests separately from the existing root description method.
- Add demo script
- Add type for AppPlugin
- Add and Fix doc
  - I found a minor writing error in the doc of the getActions method, so I fixed it together.　 c4d753892db71e7a4c21077ed65e49c528b535d6
- The Lang type split into AppLang and PluginLocale because they are different.


## How to test

<!-- How can we test this pull request? -->

Check test spec.

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
