### PR TITLE
fix(rest-api-client): rename moveToSpace method to move

### DIFF
--- a/examples/rest-api-client-demo/src/app.ts
+++ b/examples/rest-api-client-demo/src/app.ts
@@ -765,11 +765,9 @@ export class App {
     }
   }
 
-  public async moveToSpace() {
+  public async move() {
     try {
-      console.log(
-        await this.client.app.moveToSpace({ app: APP_ID, space: SPACE_ID }),
-      );
+      console.log(await this.client.app.move({ app: APP_ID, space: SPACE_ID }));
     } catch (error) {
       console.log(error);
     }

--- a/packages/rest-api-client/docs/app.md
+++ b/packages/rest-api-client/docs/app.md
@@ -36,7 +36,7 @@
 - [updateReports](#updateReports)
 - [getAppActions](#getAppActions)
 - [updateAppActions](#updateAppActions)
-- [moveToSpace](#moveToSpace)
+- [move](#move)
 - [getPlugins](#getPlugins)
 
 ## Overview
@@ -1356,7 +1356,7 @@ Updates the [Action](https://get.kintone.help/k/en/user/app_settings/appaction/s
 
 - https://kintone.dev/en/docs/kintone/rest-api/apps/update-action-settings/
 
-### moveToSpace
+### move
 
 Changes the Space to which an App belongs.
 

--- a/packages/rest-api-client/src/client/AppClient.ts
+++ b/packages/rest-api-client/src/client/AppClient.ts
@@ -620,10 +620,7 @@ export class AppClient extends BaseClient {
     return this.client.put(path, params);
   }
 
-  public moveToSpace(params: {
-    app: AppID;
-    space: SpaceID | null;
-  }): Promise<{}> {
+  public move(params: { app: AppID; space: SpaceID | null }): Promise<{}> {
     const path = this.buildPath({
       endpointName: "app/move",
     });

--- a/packages/rest-api-client/src/client/__tests__/AppClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/AppClient.test.ts
@@ -1312,7 +1312,7 @@ describe("AppClient", () => {
   });
 });
 
-describe("AppClient: moveToSpace", () => {
+describe("AppClient: move", () => {
   let mockClient: MockClient;
   let appClient: AppClient;
 
@@ -1324,10 +1324,10 @@ describe("AppClient: moveToSpace", () => {
     mockClient = buildMockClient(requestConfigBuilder);
     appClient = new AppClient(mockClient);
   });
-  describe("moveToSpace", () => {
+  describe("move", () => {
     const params = { app: APP_ID, space: 1 } as const;
     beforeEach(async () => {
-      await appClient.moveToSpace(params);
+      await appClient.move(params);
     });
     it("should pass the path to the http client", () => {
       expect(mockClient.getLogs()[0].path).toBe("/k/v1/app/move.json");


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

The method name moveToSpace can be misleading.
In fact, it not only changes the space, but also removes the space.

## What

<!-- What is a solution you want to add? -->

- change the `moveToSpace` method name to `move`

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
