### PR TITLE
feat(rest-api-client): add the method of plugin.getApps

### DIFF
--- a/packages/rest-api-client/docs/plugin.md
+++ b/packages/rest-api-client/docs/plugin.md
@@ -83,7 +83,7 @@ Gets Apps that have the specified plug-in added.
 | ------ | :----: | :------: | ------------------------------------------------------------------------------------------------------ |
 | id     | String |   Yes    | The ID of the plug-in.                                                                                 |
 | offset | Number |          | The number of apps to skip from the list of app.<br />If ignored, this value is 0.                     |
-| limit  | Number |          | The maximum number of apps to retrieve.<br />Must be between 1 and 100.The default<br />number is 100. |
+| limit  | Number |          | The maximum number of apps to retrieve.<br />Must be between 1 and 500.The default<br />number is 100. |
 
 #### Returns
 

--- a/packages/rest-api-client/docs/plugin.md
+++ b/packages/rest-api-client/docs/plugin.md
@@ -2,6 +2,7 @@
 
 - [getPlugins](#getPlugins)
 - [getRequiredPlugins](#getRequiredPlugins)
+- [getApps](#getApps)
 
 ## Overview
 
@@ -71,3 +72,27 @@ This can occur when a plug-in is installed, added to an App, and then proceeded 
 #### Reference
 
 - https://kintone.dev/en/docs/kintone/rest-api/plugins/get-required-plugins/
+
+### getApps
+
+Gets Apps that have the specified plug-in added.
+
+#### Parameters
+
+| Name   |  Type  | Required | Description                                                                                            |
+| ------ | :----: | :------: | ------------------------------------------------------------------------------------------------------ |
+| id     | String |   Yes    | The ID of the plug-in.                                                                                 |
+| offset | Number |          | The number of apps to skip from the list of app.<br />If ignored, this value is 0.                     |
+| limit  | Number |          | The maximum number of apps to retrieve.<br />Must be between 1 and 100.The default<br />number is 100. |
+
+#### Returns
+
+| Name        |  Type  | Description                                                                                                    |
+| ----------- | :----: | -------------------------------------------------------------------------------------------------------------- |
+| apps        | Array  | A list of objects containing the App ID and name.<br />Objects are listed in ascending order of their App IDs. |
+| apps[].id   | String | The App ID.                                                                                                    |
+| apps[].name | String | The name of the App.                                                                                           |
+
+#### Reference
+
+- https://kintone.dev/en/docs/kintone/rest-api/plugins/get-plugin-apps/

--- a/packages/rest-api-client/src/client/PluginClient.ts
+++ b/packages/rest-api-client/src/client/PluginClient.ts
@@ -1,5 +1,7 @@
 import { BaseClient } from "./BaseClient";
 import type {
+  GetAppsForRequest,
+  GetAppsForResponse,
   GetPluginsForRequest,
   GetPluginsForResponse,
   GetRequiredPluginsForRequest,
@@ -18,6 +20,11 @@ export class PluginClient extends BaseClient {
     params: GetRequiredPluginsForRequest,
   ): Promise<GetRequiredPluginsForResponse> {
     const path = this.buildPath({ endpointName: "plugins/required" });
+    return this.client.get(path, params);
+  }
+
+  public getApps(params: GetAppsForRequest): Promise<GetAppsForResponse> {
+    const path = this.buildPath({ endpointName: "plugin/apps" });
     return this.client.get(path, params);
   }
 }

--- a/packages/rest-api-client/src/client/__tests__/PluginClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/PluginClient.test.ts
@@ -57,4 +57,24 @@ describe("PluginClient", () => {
       expect(mockClient.getLogs()[0].params).toEqual(params);
     });
   });
+
+  describe("getApps", () => {
+    const params = {
+      id: "pluginId",
+      offset: 1,
+      limit: 2,
+    };
+    beforeEach(async () => {
+      await pluginClient.getApps(params);
+    });
+    it("should pass the path to the http client", () => {
+      expect(mockClient.getLogs()[0].path).toBe("/k/v1/plugin/apps.json");
+    });
+    it("should send a GET request", () => {
+      expect(mockClient.getLogs()[0].method).toBe("get");
+    });
+    it("should pass the param to the http client", () => {
+      expect(mockClient.getLogs()[0].params).toEqual(params);
+    });
+  });
 });

--- a/packages/rest-api-client/src/client/types/index.ts
+++ b/packages/rest-api-client/src/client/types/index.ts
@@ -5,6 +5,7 @@ export type SpaceID = string | number;
 export type SpaceTemplateID = string | number;
 export type GuestSpaceID = string | number;
 export type ThreadID = string | number;
+export type PluginID = string;
 
 export * from "./record";
 export * from "./app";

--- a/packages/rest-api-client/src/client/types/plugin/index.ts
+++ b/packages/rest-api-client/src/client/types/plugin/index.ts
@@ -1,3 +1,5 @@
+import type { PluginID } from "..";
+
 type Plugin = {
   id: string;
   name: string;
@@ -23,4 +25,14 @@ export type GetRequiredPluginsForRequest = {
 
 export type GetRequiredPluginsForResponse = {
   plugins: RequiredPlugin[];
+};
+
+export type GetAppsForRequest = {
+  id: PluginID;
+  offset?: number;
+  limit?: number;
+};
+
+export type GetAppsForResponse = {
+  apps: Array<{ id: string; name: string }>;
 };


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

- Support plugin.getApps method to be able to get the list of Apps  that have the specified plug-in added.


## What

<!-- What is a solution you want to add? -->

- Add a document for the new methods.
- Add new unit tests.
- Add type for the new method request and response.

## How to test

1. prepare installed plug-ins and add a plug-in to some apps.
2. run below code and check logs:
```ts
import {KintoneRestAPIClient} from '@kintone/rest-api-client';

const client = new KintoneRestAPIClient();

const pluginId = (await client.plugin.getPlugins({
  offset: 0,
  limit: 1
})).plugins[0].id;

console.log(await client.plugin.getApps({
  id: pluginId,
}));
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
