### PR TITLE
feat(rest-api-client): add the method of app.addPlugins

### DIFF
--- a/packages/rest-api-client/docs/app.md
+++ b/packages/rest-api-client/docs/app.md
@@ -40,6 +40,7 @@
 - [updateAdminNotes](#updateAdminNotes)
 - [move](#move)
 - [getPlugins](#getPlugins)
+- [addPlugins](#addPlugins)
 
 ## Overview
 
@@ -1445,3 +1446,25 @@ Gets the list of Plug-ins added to an App.
 #### Reference
 
 - https://kintone.dev/en/docs/kintone/rest-api/apps/get-app-plugins/
+
+### addPlugins
+
+Adds Plug-ins to an App.
+
+#### Parameters
+
+| Name     |       Type       | Required | Description                                                                                                                                                                                                                                      |
+| -------- | :--------------: | :------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| app      | Number or String |   Yes    | The App ID.                                                                                                                                                                                                                                      |
+| ids      | Array of String  |   Yes    | The Plug-in IDs that will be added to the App.                                                                                                                                                                                                   |
+| revision | Number or String |          | Specify the revision number of the settings that will be deployed.<br />The request will fail if the stated revision number is not the latest revision.<br />The revision will not be checked if this parameter is ignored or `-1` is specified. |
+
+#### Returns
+
+| Name     |  Type  | Description                              |
+| -------- | :----: | ---------------------------------------- |
+| revision | String | The revision number of the App settings. |
+
+#### Reference
+
+- https://kintone.dev/en/docs/kintone/rest-api/apps/add-plugins/

--- a/packages/rest-api-client/src/client/AppClient.ts
+++ b/packages/rest-api-client/src/client/AppClient.ts
@@ -667,4 +667,16 @@ export class AppClient extends BaseClient {
     });
     return this.client.get(path, rest);
   }
+
+  public addPlugins(params: {
+    app: AppID;
+    ids: string[];
+    revision?: Revision;
+  }): Promise<{ revision: string }> {
+    const path = this.buildPathWithGuestSpaceId({
+      endpointName: "app/plugins",
+      preview: true,
+    });
+    return this.client.post(path, params);
+  }
 }

--- a/packages/rest-api-client/src/client/__tests__/app/Plugins.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/app/Plugins.test.ts
@@ -49,4 +49,22 @@ describe("AppClient: plugins", () => {
       });
     });
   });
+
+  describe("addPlugins", () => {
+    const params = { app: APP_ID, ids: ["abc", "xyz"], revision: 1 };
+    beforeEach(async () => {
+      await appClient.addPlugins(params);
+    });
+    it("should pass the path to the http client", () => {
+      expect(mockClient.getLogs()[0].path).toBe(
+        "/k/v1/preview/app/plugins.json",
+      );
+    });
+    it("should send a post request", () => {
+      expect(mockClient.getLogs()[0].method).toBe("post");
+    });
+    it("should pass the param to the http client", () => {
+      expect(mockClient.getLogs()[0].params).toEqual(params);
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

- Support app.addPlugins method to be able to add Plug-ins to an App.

## What

<!-- What is a solution you want to add? -->

- Add a document for the new methods.
- Add new unit tests.

## How to test

1. prepare installed plug-ins and apps in Kintone.
2. run below code and check logs:
```ts
import {KintoneRestAPIClient} from '@kintone/rest-api-client';

const client = new KintoneRestAPIClient();

const pluginId = (await client.app.getPlugins({app: 1})).plugins[0].id;

console.log(await client.app.getPlugins({app: 2, preview: true}));
console.log(await client.app.addPlugins({app: 2, ids: [pluginId]}));
console.log(await client.app.getPlugins({app: 2, preview: true}));
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.

