### PR TITLE
feat(rest-api-client): add method of plugin.updatePlugin

### DIFF
--- a/packages/rest-api-client/docs/plugin.md
+++ b/packages/rest-api-client/docs/plugin.md
@@ -3,6 +3,7 @@
 - [getPlugins](#getPlugins)
 - [getRequiredPlugins](#getRequiredPlugins)
 - [getApps](#getApps)
+- [updatePlugin](#updatePlugin)
 
 ## Overview
 
@@ -96,3 +97,25 @@ Gets Apps that have the specified plug-in added.
 #### Reference
 
 - https://kintone.dev/en/docs/kintone/rest-api/plugins/get-plugin-apps/
+
+### updatePlugin
+
+Updates an imported plug-in in the Kintone environment.
+
+#### Parameters
+
+| Name    |  Type  | Required | Description                                                                                                                                                                                       |
+| ------- | :----: | :------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| id      | String |   Yes    | The ID of the plug-in to be updated.                                                                                                                                                              |
+| fileKey | String |   Yes    | The fileKey representing an uploaded file.<br />Use the following API to upload the file and retrieve the fileKey: [Upload File](https://kintone.dev/en/docs/kintone/rest-api/files/upload-file/) |
+
+#### Returns
+
+| Name    |  Type  | Description                            |
+| ------- | :----: | -------------------------------------- |
+| id      | String | The plug-in ID of the updated plug-in. |
+| version | String | The version number of the plug-in      |
+
+#### Reference
+
+- https://kintone.dev/en/docs/kintone/rest-api/plugins/update-plugin/

--- a/packages/rest-api-client/src/client/PluginClient.ts
+++ b/packages/rest-api-client/src/client/PluginClient.ts
@@ -6,6 +6,8 @@ import type {
   GetPluginsForResponse,
   GetRequiredPluginsForRequest,
   GetRequiredPluginsForResponse,
+  UpdatePluginForRequest,
+  UpdatePluginForResponse,
 } from "./types/plugin";
 
 export class PluginClient extends BaseClient {
@@ -26,5 +28,12 @@ export class PluginClient extends BaseClient {
   public getApps(params: GetAppsForRequest): Promise<GetAppsForResponse> {
     const path = this.buildPath({ endpointName: "plugin/apps" });
     return this.client.get(path, params);
+  }
+
+  public updatePlugin(
+    params: UpdatePluginForRequest,
+  ): Promise<UpdatePluginForResponse> {
+    const path = this.buildPath({ endpointName: "plugin" });
+    return this.client.put(path, params);
   }
 }

--- a/packages/rest-api-client/src/client/__tests__/PluginClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/PluginClient.test.ts
@@ -77,4 +77,23 @@ describe("PluginClient", () => {
       expect(mockClient.getLogs()[0].params).toEqual(params);
     });
   });
+
+  describe("updatePlugin", () => {
+    const params = {
+      id: "pluginId",
+      fileKey: "fileKey",
+    };
+    beforeEach(async () => {
+      await pluginClient.updatePlugin(params);
+    });
+    it("should pass the path to the http client", () => {
+      expect(mockClient.getLogs()[0].path).toBe("/k/v1/plugin.json");
+    });
+    it("should send a PUT request", () => {
+      expect(mockClient.getLogs()[0].method).toBe("put");
+    });
+    it("should pass the param to the http client", () => {
+      expect(mockClient.getLogs()[0].params).toEqual(params);
+    });
+  });
 });

--- a/packages/rest-api-client/src/client/types/plugin/index.ts
+++ b/packages/rest-api-client/src/client/types/plugin/index.ts
@@ -36,3 +36,13 @@ export type GetAppsForRequest = {
 export type GetAppsForResponse = {
   apps: Array<{ id: string; name: string }>;
 };
+
+export type UpdatePluginForRequest = {
+  id: PluginID;
+  fileKey: string;
+};
+
+export type UpdatePluginForResponse = {
+  id: PluginID;
+  version: string;
+};


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

- Support plugin.updatePlugin method to be able to update an imported plug-in in the Kintone environment.

## What

<!-- What is a solution you want to add? -->

- Add a document for the new method.
- Add new unit tests.

## How to test

1. prepare a zip file for a plug-in and installe it in Kintone.
2. run below code and check logs:
```ts
import {KintoneRestAPIClient} from '@kintone/rest-api-client';

const client = new KintoneRestAPIClient();

const fileKey = (await client.file.uploadFile({
  file: {
    path: "./files/plugin.zip"
  }
})).fileKey;

if (typeof fileKey == "string") {
  const pluginId = (await client.app.getPlugins({app: 42})).plugins[0].id;
  console.log(await client.plugin.updatePlugin({id: pluginId, fileKey: fileKey}));
  console.log(await client.app.getPlugins({app: 42, preview: true}));
}
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.

