### PR TITLE
feat(rest-api-client): add method of plugin.installPlugin

### DIFF
--- a/packages/rest-api-client/docs/plugin.md
+++ b/packages/rest-api-client/docs/plugin.md
@@ -4,6 +4,7 @@
 - [getRequiredPlugins](#getRequiredPlugins)
 - [getApps](#getApps)
 - [updatePlugin](#updatePlugin)
+- [installPlugin](#installPlugin)
 
 ## Overview
 
@@ -119,3 +120,24 @@ Updates an imported plug-in in the Kintone environment.
 #### Reference
 
 - https://kintone.dev/en/docs/kintone/rest-api/plugins/update-plugin/
+
+### installPlugin
+
+Install an imported plug-in in the Kintone environment.
+
+#### Parameters
+
+| Name    |  Type  | Required | Description                                                                                                                                                                                       |
+| ------- | :----: | :------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| fileKey | String |   Yes    | The fileKey representing an uploaded file.<br />Use the following API to upload the file and retrieve the fileKey: [Upload File](https://kintone.dev/en/docs/kintone/rest-api/files/upload-file/) |
+
+#### Returns
+
+| Name    |  Type  | Description                        |
+| ------- | :----: | ---------------------------------- |
+| id      | String | The installed plug-in ID.          |
+| version | String | The version number of the plug-in. |
+
+#### Reference
+
+- https://kintone.dev/en/docs/kintone/rest-api/plugins/install-plugin/

--- a/packages/rest-api-client/src/client/PluginClient.ts
+++ b/packages/rest-api-client/src/client/PluginClient.ts
@@ -8,6 +8,8 @@ import type {
   GetRequiredPluginsForResponse,
   UpdatePluginForRequest,
   UpdatePluginForResponse,
+  InstallPluginForRequest,
+  InstallPluginForResponse,
 } from "./types/plugin";
 
 export class PluginClient extends BaseClient {
@@ -35,5 +37,12 @@ export class PluginClient extends BaseClient {
   ): Promise<UpdatePluginForResponse> {
     const path = this.buildPath({ endpointName: "plugin" });
     return this.client.put(path, params);
+  }
+
+  public installPlugin(
+    params: InstallPluginForRequest,
+  ): Promise<InstallPluginForResponse> {
+    const path = this.buildPath({ endpointName: "plugin" });
+    return this.client.post(path, params);
   }
 }

--- a/packages/rest-api-client/src/client/__tests__/PluginClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/PluginClient.test.ts
@@ -96,4 +96,22 @@ describe("PluginClient", () => {
       expect(mockClient.getLogs()[0].params).toEqual(params);
     });
   });
+
+  describe("installPlugin", () => {
+    const params = {
+      fileKey: "fileKey",
+    };
+    beforeEach(async () => {
+      await pluginClient.installPlugin(params);
+    });
+    it("should pass the path to the http client", () => {
+      expect(mockClient.getLogs()[0].path).toBe("/k/v1/plugin.json");
+    });
+    it("should send a POST request", () => {
+      expect(mockClient.getLogs()[0].method).toBe("post");
+    });
+    it("should pass the param to the http client", () => {
+      expect(mockClient.getLogs()[0].params).toEqual(params);
+    });
+  });
 });

--- a/packages/rest-api-client/src/client/types/plugin/index.ts
+++ b/packages/rest-api-client/src/client/types/plugin/index.ts
@@ -46,3 +46,12 @@ export type UpdatePluginForResponse = {
   id: PluginID;
   version: string;
 };
+
+export type InstallPluginForRequest = {
+  fileKey: string;
+};
+
+export type InstallPluginForResponse = {
+  id: PluginID;
+  version: string;
+};


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

- Support plugin.installPlugin method to be able to install an imported plug-in in the Kintone environment.

## What

<!-- What is a solution you want to add? -->

- Add a document for the new method.
- Add new unit tests.

## How to test

1. prepare a zip file for a plug-in and upload it in Kintone.
2. run below code and check logs:
```ts
import {KintoneRestAPIClient} from '@kintone/rest-api-client';

const client = new KintoneRestAPIClient();

const fileKey = (await client.file.uploadFile({
  file: {
    path: "./files/plugin.zip"
  }
})).fileKey;

if (typeof fileKey == "string") {
  console.log(await client.plugin.installPlugin({fileKey: fileKey}));
}
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.

