### PR TITLE
feat(rest-api-client): Add method for uninstall plugin

### DIFF
--- a/packages/rest-api-client/docs/plugin.md
+++ b/packages/rest-api-client/docs/plugin.md
@@ -5,6 +5,7 @@
 - [getApps](#getApps)
 - [updatePlugin](#updatePlugin)
 - [installPlugin](#installPlugin)
+- [uninstallPlugin](#uninstallPlugin)
 
 ## Overview
 
@@ -141,3 +142,21 @@ Install an imported plug-in in the Kintone environment.
 #### Reference
 
 - https://kintone.dev/en/docs/kintone/rest-api/plugins/install-plugin/
+
+### uninstallPlugin
+
+Uninstalls a plug-in from the Kintone environment.
+
+#### Parameters
+
+| Name |  Type  | Required | Description            |
+| ---- | :----: | :------: | ---------------------- |
+| id   | String |   Yes    | The ID of the plug-in. |
+
+#### Returns
+
+An empty object.
+
+#### Reference
+
+- https://kintone.dev/en/docs/kintone/rest-api/plugins/uninstall-plugin/

--- a/packages/rest-api-client/src/client/PluginClient.ts
+++ b/packages/rest-api-client/src/client/PluginClient.ts
@@ -10,6 +10,7 @@ import type {
   UpdatePluginForResponse,
   InstallPluginForRequest,
   InstallPluginForResponse,
+  UninstallPluginForRequest,
 } from "./types/plugin";
 
 export class PluginClient extends BaseClient {
@@ -44,5 +45,10 @@ export class PluginClient extends BaseClient {
   ): Promise<InstallPluginForResponse> {
     const path = this.buildPath({ endpointName: "plugin" });
     return this.client.post(path, params);
+  }
+
+  public uninstallPlugin(params: UninstallPluginForRequest): Promise<{}> {
+    const path = this.buildPath({ endpointName: "plugin" });
+    return this.client.delete(path, params);
   }
 }

--- a/packages/rest-api-client/src/client/__tests__/PluginClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/PluginClient.test.ts
@@ -114,4 +114,22 @@ describe("PluginClient", () => {
       expect(mockClient.getLogs()[0].params).toEqual(params);
     });
   });
+
+  describe("uninstallPlugin", () => {
+    const params = {
+      id: "pluginId",
+    };
+    beforeEach(async () => {
+      await pluginClient.uninstallPlugin(params);
+    });
+    it("should pass the path to the http client", () => {
+      expect(mockClient.getLogs()[0].path).toBe("/k/v1/plugin.json");
+    });
+    it("should send a DELETE request", () => {
+      expect(mockClient.getLogs()[0].method).toBe("delete");
+    });
+    it("should pass the param to the http client", () => {
+      expect(mockClient.getLogs()[0].params).toEqual(params);
+    });
+  });
 });

--- a/packages/rest-api-client/src/client/types/plugin/index.ts
+++ b/packages/rest-api-client/src/client/types/plugin/index.ts
@@ -55,3 +55,7 @@ export type InstallPluginForResponse = {
   id: PluginID;
   version: string;
 };
+
+export type UninstallPluginForRequest = {
+  id: PluginID;
+};


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

- Support plugin.uninstallPlugin method to be able to uninstalls a plug-in from the Kintone environment.

## What

<!-- What is a solution you want to add? -->

- Add a document for the new method.
- Add new unit tests.

## How to test

1. prepare a zip file for a plug-in.
2. run below code and check logs:
```ts
import {KintoneRestAPIClient} from '@kintone/rest-api-client';

const client = new KintoneRestAPIClient();

// Upload a file and attach it to a record
const resp = await client.file.uploadFile({
  file: {
    path: "./files/plugin.zip"
  }
});

const fileKey = resp.fileKey;
console.log(fileKey);

if (typeof fileKey == "string") {
  const pluginId = (await client.plugin.installPlugin({fileKey: fileKey})).id;
  console.log(pluginId);
  console.log(await client.plugin.getPlugins({}));

  await client.plugin.uninstallPlugin({id: pluginId});
  console.log(await client.plugin.getPlugins({}));
}
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.

