### PR TITLE
fix(plugin-uploader): System ENV value check

### DIFF
--- a/packages/plugin-uploader/src/params.ts
+++ b/packages/plugin-uploader/src/params.ts
@@ -7,9 +7,9 @@ import {
 } from "./prompts/params";
 
 interface Params {
-  username?: string;
-  password?: string;
-  baseUrl?: string;
+  username: string;
+  password: string;
+  baseUrl: string;
   lang: Lang;
 }
 

--- a/packages/plugin-uploader/src/params.ts
+++ b/packages/plugin-uploader/src/params.ts
@@ -13,7 +13,7 @@ interface Params {
   lang: Lang;
 }
 
-const isSet = (v: string | null | undefined) => typeof v === "string";
+const isSet = (v: string | null | undefined) => typeof v === "string" && v;
 
 export const inquireParams = async ({
   username,


### PR DESCRIPTION
env variable should not be empty.

<!-- Thank you for sending a pull request! -->

## Why

The isSet function check to see if the env value is a type string; however, in the cli flags for the env are all defined as type string defeating the purpose of the isSet function. This results in not prompting the user to fill out the necessary values to run the kintone plugin uploader. The code will throw an error. This is a bug.

## What

I have updated the code to also check the value of the env. If the value is an empty string, isSet will return false.

## How to test

Run the kintone plugin uploader without initializing env variables. Then see if the code will prompt the user.

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
