### PR TITLE
ci: check conventional commits

### DIFF
--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -1,0 +1,21 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Currently, all commits in the PR branch cannot be merged unless they follow Conventional Commits.
However, since we are using Squash Merge, it is sufficient if the PR title is a Conventional Commit, so the current rule is excessive.

## What

<!-- What is a solution you want to add? -->

Added GitHub Action to check PR Title.
see: https://github.com/amannn/action-semantic-pull-request

The following settings are required.

> Setting > General > Pull Requests
- Allow squash merging のみチェックする
- Default commit messageをPull Request Titleに変更

> Setting > Rules > Rulesets
- Targetsをinclude default branch
- Require status checks to passを有効にし、Validate PR Titleを追加する

## How to test

<!-- How can we test this pull request? -->

https://github.com/user-attachments/assets/b8027ea1-7c46-40b7-a90a-a0d43632a7a2


## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
