### PR TITLE
feat(dts-gen): Characters check for typename compliant with ECMA262.

### DIFF
--- a/packages/dts-gen/docs/field-type-definition-guide.md
+++ b/packages/dts-gen/docs/field-type-definition-guide.md
@@ -18,10 +18,3 @@ Additional to fields of `com.cybozu.kintone.AwesomeFields`,
 this type includes `$id`, `$revision`, create time, creator, update time and update time fields.
 
 This fields will be included when you refer to a saved record.
-
-## Notes
-
-`namespace` and `type-name` convention:
-
-- Starts with a letter (`a-z` or `A-Z`), underscore (`_`), or dollar sign (`$`).
-- Can be followed by any alphanumeric, underscores, or dollar signs.

--- a/packages/dts-gen/src/validators/__tests__/args.test.ts
+++ b/packages/dts-gen/src/validators/__tests__/args.test.ts
@@ -1,8 +1,6 @@
 import { validateArgs } from "../args";
 
-const identifierConventionMsg = `The namespace and type-name convention:
-- Starts with a letter (\`a-z\` or \`A-Z\`), underscore (\`_\`), or dollar sign (\`$\`).
-- Can be followed by any alphanumeric, underscores, or dollar signs.`;
+const identifierConventionMsg = `In the ECMA262 specification, this is an invalid string as IdentifierName.`;
 const invalidNamespaceMessage = `Invalid namespace option!\n${identifierConventionMsg}`;
 const invalidTypeNameMessage = `Invalid type-name option!\n${identifierConventionMsg}`;
 const baseInput = {
@@ -76,6 +74,35 @@ const patterns = [
   {
     description: "should error when type-name contains invalid characters",
     input: { ...baseInput, typeName: "te-st" },
+    expected: {
+      failure: {
+        errorMessage: invalidTypeNameMessage,
+      },
+    },
+  },
+  {
+    description: "should not error when type-name contains japanese characters",
+    input: {
+      ...baseInput,
+      typeName: "案件管理",
+    },
+    expected: {
+      failure: undefined,
+    },
+  },
+  {
+    description: "should not error when type-name is only symbols",
+    input: {
+      ...baseInput,
+      typeName: "$$$",
+    },
+    expected: {
+      failure: undefined,
+    },
+  },
+  {
+    description: "should error when type-name starts with a space",
+    input: { ...baseInput, typeName: " test" },
     expected: {
       failure: {
         errorMessage: invalidTypeNameMessage,

--- a/packages/dts-gen/src/validators/args.ts
+++ b/packages/dts-gen/src/validators/args.ts
@@ -5,9 +5,7 @@ export const validateArgs = (args: ParsedArgs) => {
     throw new Error("--base-url (KINTONE_BASE_URL) must be specified");
   }
 
-  const identifierConventionMsg = `The namespace and type-name convention:
-- Starts with a letter (\`a-z\` or \`A-Z\`), underscore (\`_\`), or dollar sign (\`$\`).
-- Can be followed by any alphanumeric, underscores, or dollar signs.`;
+  const identifierConventionMsg = `In the ECMA262 specification, this is an invalid string as IdentifierName.`;
 
   if (args.namespace && !isValidIdentifier(args.namespace)) {
     throw new Error(`Invalid namespace option!\n${identifierConventionMsg}`);
@@ -19,11 +17,11 @@ export const validateArgs = (args: ParsedArgs) => {
 };
 
 /**
- * https://developer.mozilla.org/en-US/docs/Glossary/Identifier
+ * https://262.ecma-international.org/14.0/index.html#prod-IdentifierName
  * @param targetIdentifier
  */
 const isValidIdentifier = (targetIdentifier: string): boolean => {
   const identifiers = targetIdentifier.split(".");
-  const identifierRegex = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
+  const identifierRegex = /^[\p{ID_Start}_$][\p{ID_Continue}$\u200C\u200D]*$/u;
   return identifiers.every((identifier) => identifierRegex.test(identifier));
 };


### PR DESCRIPTION
ref. #3035

## Why
Supported to use Japanese in version 5, but error in version 8.
```sh
# success
$ npx -p @kintone/dts-gen@5 kintone-dts-gen --app-id 12 --type-name 'App取引先Fields'
```
```sh
$ npx -p @kintone/dts-gen@8 kintone-dts-gen --app-id 12 --type-name 'App取引先Fields'
Invalid type-name option!
The namespace and type-name convention:
- Starts with a letter (`a-z` or `A-Z`), underscore (`_`), or dollar sign (`$`).
- Can be followed by any alphanumeric, underscores, or dollar signs.
```

## What
This pull request will enable the use of Japanese in `typename`.

## How to test
Look at diff in args.test.ts.

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
