### PR TITLE
fix(dts-gen): Fix to not read eslint.config

### DIFF
--- a/packages/dts-gen/src/templates/template.test.ts
+++ b/packages/dts-gen/src/templates/template.test.ts
@@ -27,6 +27,7 @@ const writeAndLint = async (filepath: string, expression: string) => {
         ],
       },
     },
+    overrideConfigFile: true,
   });
   const eslintResult = (await eslint.lintFiles(filepath))[0];
   const eslintOutput = eslintResult.output;

--- a/packages/dts-gen/src/templates/template.ts
+++ b/packages/dts-gen/src/templates/template.ts
@@ -29,6 +29,7 @@ const renderAsFile = async (output: string, renderInput: RenderInput) => {
         ],
       },
     },
+    overrideConfigFile: true,
   });
   const eslintResult = (await eslint.lintText(tsExpression.tsExpression()))[0];
   if (eslintResult.fatalErrorCount > 0) {


### PR DESCRIPTION
ref. #3059

## Why
I installed and ran the package and got an error `Error: Could not find config file.`.

## What
I fixed to not read eslint.config, when using ESLint in running dts-gen, 

## How to test
```sh
js-sdk/packages/dts-gen$ pnpm build
js-sdk/packages/dts-gen$ rm eslint.config.mjs
js-sdk/packages/dts-gen$ rm ../../eslint.config.mjs
js-sdk/packages/dts-gen$ ls fields.d.ts 
ls: 'fields.d.ts' にアクセスできません: そのようなファイルやディレクトリはありません
js-sdk/packages/dts-gen$ direnv exec . node dist/index.js --app-id 4 --type-name App顧客リストFields
js-sdk/packages/dts-gen$ ls fields.d.ts 
fields.d.ts
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
