### PR TITLE
feat(plugin-manifest-validator): add locales

### DIFF
--- a/packages/plugin-manifest-validator/README.md
+++ b/packages/plugin-manifest-validator/README.md
@@ -62,7 +62,7 @@ When you are configuring your project, you would better set the $schema property
 We recommend setting the $schema property to the following URI in your manifest.json:
 
 ```
-https://raw.githubusercontent.com/kintone/js-sdk/%40kintone/plugin-manifest-validator%4010.2.0/packages/plugin-manifest-validator/manifest-schema.json
+https://raw.githubusercontent.com/kintone/js-sdk/%40kintone/plugin-manifest-validator%4010.3.0/packages/plugin-manifest-validator/manifest-schema.json
 ```
 
 Note: Add or update the $schema property at the top of the manifest.json.

--- a/packages/plugin-manifest-validator/examples/manifest.json
+++ b/packages/plugin-manifest-validator/examples/manifest.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/kintone/js-sdk/%40kintone/plugin-manifest-validator%4010.2.0/packages/plugin-manifest-validator/manifest-schema.json",
+  "$schema": "https://raw.githubusercontent.com/kintone/js-sdk/%40kintone/plugin-manifest-validator%4010.3.0/packages/plugin-manifest-validator/manifest-schema.json",
   "manifest_version": 1,
   "version": 1,
   "type": "APP",
@@ -7,20 +7,29 @@
     "ja": "サンプルプラグイン",
     "en": "sample plugin",
     "zh": "插件的例子",
-    "es": "complemento de muestra"
+    "zh-TW": "插件的例子",
+    "es": "complemento de muestra",
+    "pt-BR": "complemento de amostra",
+    "th": "ปลั๊กอินตัวอย่าง"
   },
   "description": {
     "ja": "これはサンプルプラグインです。",
     "en": "This is sample plugin.",
     "zh": "这是插件的例子",
-    "es": "Este es un complemento de muestra."
+    "zh-TW": "這是插件的例子",
+    "es": "Este es un complemento de muestra.",
+    "pt-BR": "Este é um complemento de amostra.",
+    "th": "นี่คือปลั๊กอินตัวอย่าง"
   },
   "icon": "image/icon.png",
   "homepage_url": {
     "ja": "http://sample_cybozu.jp",
     "en": "http://sample_cybozu.com",
     "zh": "http://sample_cybozu.cn",
-    "es": "http://sample_cybozu.es"
+    "zh-TW": "http://sample_cybozu.tw",
+    "es": "http://sample_cybozu.es",
+    "pt-BR": "http://sample_cybozu.br",
+    "th": "http://sample_cybozu.th"
   },
   "desktop": {
     "js": ["js/customize.js", "https://example.com/js/customize.js"],

--- a/packages/plugin-manifest-validator/manifest-schema.d.ts
+++ b/packages/plugin-manifest-validator/manifest-schema.d.ts
@@ -19,13 +19,19 @@ export interface KintonePluginManifestJson {
     ja?: string;
     en: string;
     zh?: string;
+    "zh-TW"?: string;
     es?: string;
+    th?: string;
+    "pt-BR"?: string;
   };
   description?: {
     ja?: string;
     en: string;
     zh?: string;
+    "zh-TW"?: string;
     es?: string;
+    th?: string;
+    "pt-BR"?: string;
   };
   /**
    * internal only
@@ -35,7 +41,10 @@ export interface KintonePluginManifestJson {
     ja?: string;
     en?: string;
     zh?: string;
+    "zh-TW"?: string;
     es?: string;
+    th?: string;
+    "pt-BR"?: string;
   };
   desktop?: {
     js?: Resources;

--- a/packages/plugin-manifest-validator/manifest-schema.json
+++ b/packages/plugin-manifest-validator/manifest-schema.json
@@ -77,6 +77,21 @@
             "warn": true
           }
         },
+        "zh-TW": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "requiredProperties": {
+            "items": [
+              {
+                "homepage_url": {
+                  "properties": ["zh-TW"]
+                }
+              }
+            ],
+            "warn": true
+          }
+        },
         "es": {
           "type": "string",
           "minLength": 1,
@@ -86,6 +101,36 @@
               {
                 "homepage_url": {
                   "properties": ["es"]
+                }
+              }
+            ],
+            "warn": true
+          }
+        },
+        "th": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "requiredProperties": {
+            "items": [
+              {
+                "homepage_url": {
+                  "properties": ["th"]
+                }
+              }
+            ],
+            "warn": true
+          }
+        },
+        "pt-BR": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "requiredProperties": {
+            "items": [
+              {
+                "homepage_url": {
+                  "properties": ["pt-BR"]
                 }
               }
             ],
@@ -114,7 +159,22 @@
           "minLength": 1,
           "maxLength": 200
         },
+        "zh-TW": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
         "es": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "th": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "pt-BR": {
           "type": "string",
           "minLength": 1,
           "maxLength": 200
@@ -176,6 +236,20 @@
             ]
           }
         },
+        "zh-TW": {
+          "type": "string",
+          "minLength": 1,
+          "format": "http-url",
+          "requiredProperties": {
+            "items": [
+              {
+                "name": {
+                  "properties": ["zh-TW"]
+                }
+              }
+            ]
+          }
+        },
         "es": {
           "type": "string",
           "minLength": 1,
@@ -185,6 +259,34 @@
               {
                 "name": {
                   "properties": ["es"]
+                }
+              }
+            ]
+          }
+        },
+        "th": {
+          "type": "string",
+          "minLength": 1,
+          "format": "http-url",
+          "requiredProperties": {
+            "items": [
+              {
+                "name": {
+                  "properties": ["th"]
+                }
+              }
+            ]
+          }
+        },
+        "pt-BR": {
+          "type": "string",
+          "minLength": 1,
+          "format": "http-url",
+          "requiredProperties": {
+            "items": [
+              {
+                "name": {
+                  "properties": ["pt-BR"]
                 }
               }
             ]

--- a/packages/plugin-manifest-validator/src/__tests__/index.ts
+++ b/packages/plugin-manifest-validator/src/__tests__/index.ts
@@ -519,7 +519,7 @@ describe("validator", () => {
       ${"ja"}      | ${"名前"}   | ${"説明"}      | ${"https://example.com/ja"}
       ${"en"}      | ${"name"}   | ${"desc"}      | ${"https://example.com/en"}
       ${"zh"}      | ${"名称"}   | ${"描述"}      | ${"https://example.com/zh"}
-      ${"zh-TW"}   | ${"名称"}   | ${"描述"}      | ${"https://example.com/zh-TW"}
+      ${"zh-TW"}   | ${"名稱"}   | ${"描述"}      | ${"https://example.com/zh-TW"}
       ${"es"}      | ${"nombre"} | ${"desc"}      | ${"https://example.com/es"}
       ${"th"}      | ${"ชื่อ"}   | ${"คำอธิบาย"}  | ${"https://example.com/th"}
       ${"pt-BR"}   | ${"nome"}   | ${"descrição"} | ${"https://example.com/pt-BR"}
@@ -558,7 +558,7 @@ describe("validator", () => {
       ${"ja"}      | ${"名前"}
       ${"en"}      | ${"name"}
       ${"zh"}      | ${"名称"}
-      ${"zh-TW"}   | ${"名称"}
+      ${"zh-TW"}   | ${"名稱"}
       ${"es"}      | ${"nombre"}
       ${"th"}      | ${"ชื่อ"}
       ${"pt-BR"}   | ${"nome"}

--- a/packages/plugin-manifest-validator/src/__tests__/index.ts
+++ b/packages/plugin-manifest-validator/src/__tests__/index.ts
@@ -515,11 +515,14 @@ describe("validator", () => {
 
   describe("supported language", () => {
     it.each`
-      languageCode | name        | description | homepage_url
-      ${"ja"}      | ${"名前"}   | ${"説明"}   | ${"https://example.com/ja"}
-      ${"en"}      | ${"name"}   | ${"desc"}   | ${"https://example.com/en"}
-      ${"zh"}      | ${"名称"}   | ${"描述"}   | ${"https://example.com/zh"}
-      ${"es"}      | ${"nombre"} | ${"desc"}   | ${"https://example.com/es"}
+      languageCode | name        | description    | homepage_url
+      ${"ja"}      | ${"名前"}   | ${"説明"}      | ${"https://example.com/ja"}
+      ${"en"}      | ${"name"}   | ${"desc"}      | ${"https://example.com/en"}
+      ${"zh"}      | ${"名称"}   | ${"描述"}      | ${"https://example.com/zh"}
+      ${"zh-TW"}   | ${"名称"}   | ${"描述"}      | ${"https://example.com/zh-TW"}
+      ${"es"}      | ${"nombre"} | ${"desc"}      | ${"https://example.com/es"}
+      ${"th"}      | ${"ชื่อ"}   | ${"คำอธิบาย"}  | ${"https://example.com/th"}
+      ${"pt-BR"}   | ${"nome"}   | ${"descrição"} | ${"https://example.com/pt-BR"}
     `(
       `should return no error when the supported language is specified: $languageCode`,
       ({ languageCode, name, description, homepage_url }) => {
@@ -555,7 +558,10 @@ describe("validator", () => {
       ${"ja"}      | ${"名前"}
       ${"en"}      | ${"name"}
       ${"zh"}      | ${"名称"}
+      ${"zh-TW"}   | ${"名称"}
       ${"es"}      | ${"nombre"}
+      ${"th"}      | ${"ชื่อ"}
+      ${"pt-BR"}   | ${"nome"}
     `(
       `should return warnings when the name of the language "$languageCode" is specified and homepage_url is missing`,
       ({ languageCode, name }) => {
@@ -587,7 +593,10 @@ describe("validator", () => {
       languageCode | homepage_url
       ${"ja"}      | ${"https://example.com/ja"}
       ${"zh"}      | ${"https://example.com/zh"}
+      ${"zh-TW"}   | ${"https://example.com/zh-TW"}
       ${"es"}      | ${"https://example.com/es"}
+      ${"th"}      | ${"https://example.com/th"}
+      ${"pt-BR"}   | ${"https://example.com/pt-BR"}
     `(
       `should return errors when the homepage_url of the language "$languageCode" is specified and name is missing`,
       ({ languageCode, homepage_url }) => {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

## What

<!-- What is a solution you want to add? -->
- Added zh-TW, pt-BR, and th to the supported locales

## How to test

<!-- How can we test this pull request? -->

link `@kintone/plugin-manifest-validator`
```
# plugin-manifest-validatorのディレクトリでpnpm linkする
$ cd packages/plugin-manifest-validator
$ pnpm link --global

$ cd /path/to/test  # サンプルコードを実行するディレクトリで以下を実行
$ pnpm init
$ pnpm link --global @kintone/plugin-manifest-validator
```

Create a manifest that includes zh-TW, pt-BR, and th, and check that it passes validation.

```
const validator = require("@kintone/plugin-manifest-validator");

const manifest = {
  manifest_version: 1,
  version: 1,
  type: "APP",
  name: {
    ja: "サンプルプラグイン",
    en: "sample plugin",
    zh: "插件的例子",
    "zh-TW": "插件的例子",
    es: "complemento de muestra",
    "pt-BR": "complemento de amostra",
    th: "ปลั๊กอินตัวอย่าง",
  },
  description: {
    ja: "これはサンプルプラグインです。",
    en: "This is sample plugin.",
    zh: "这是插件的例子",
    "zh-TW": "這是插件的例子",
    es: "Este es un complemento de muestra.",
    "pt-BR": "Este é um complemento de amostra.",
    th: "นี่คือปลั๊กอินตัวอย่าง",
  },
  icon: "image/icon.png",
  homepage_url: {
    ja: "http://sample_cybozu.jp",
    en: "http://sample_cybozu.com",
    zh: "http://sample_cybozu.cn",
    "zh-TW": "http://sample_cybozu.tw",
    es: "http://sample_cybozu.es",
    "pt-BR": "http://sample_cybozu.br",
    th: "http://sample_cybozu.th",
  },
};

const result = validator.default(manifest);
console.log(result.valid);
// -> true
```

Confirm that it is reflected in the json schema
```
const manifestJsonSchema = require("@kintone/plugin-manifest-validator/manifest-schema.json");
console.log(manifestJsonSchema.properties.name.properties);
// -> zh-TW, pt-BR, th have been added.
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
