### PR TITLE
fix(rest): Separate titleField type between GET and UPDATE

### DIFF
--- a/packages/rest-api-client/src/client/types/app/setting.ts
+++ b/packages/rest-api-client/src/client/types/app/setting.ts
@@ -11,15 +11,6 @@ type Theme =
   | "YELLOW"
   | "BLACK";
 
-type TitleField =
-  | {
-      selectionMode: "AUTO";
-    }
-  | {
-      selectionMode: "MANUAL";
-      code: string;
-    };
-
 export type GetAppSettingsForRequest = {
   app: AppID;
   lang?: AppLang;
@@ -41,7 +32,10 @@ export type GetAppSettingsForResponse = {
       }
     | { type: "PRESET"; key: string };
   theme: Theme;
-  titleField: TitleField;
+  titleField: {
+    selectionMode: "AUTO" | "MANUAL";
+    code: string;
+  };
   enableThumbnails: boolean;
   enableBulkDeletion: boolean;
   enableComments: boolean;
@@ -68,7 +62,9 @@ export type UpdateAppSettingsForRequest = {
       }
     | { type: "PRESET"; key: string };
   theme?: Theme;
-  titleField?: TitleField;
+  titleField?:
+    | { selectionMode: "AUTO" }
+    | { selectionMode: "MANUAL"; code: string };
   enableThumbnails?: boolean;
   enableBulkDeletion?: boolean;
   enableComments?: boolean;


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

Revise the `titleField` type definition to ensure it correctly accommodates both selection modes, enhancing type safety in the application settings.

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
