### PR TITLE
feat(rest): add HttpMethodOverrideMiddleware

### DIFF
--- a/packages/rest/src/client/Middlewares/HttpMethodOverrideMiddleware.ts
+++ b/packages/rest/src/client/Middlewares/HttpMethodOverrideMiddleware.ts
@@ -1,0 +1,27 @@
+import type { Middleware, MiddlewareCallbackParams } from "openapi-fetch";
+
+const THRESHOLD_AVOID_REQUEST_URL_TOO_LARGE = 4096;
+
+export const getHttpMethodOverrideMiddleware = (): Middleware => {
+  return {
+    async onRequest({ request, params }: MiddlewareCallbackParams) {
+      if (request.method !== "GET") {
+        return;
+      }
+      if (request.url.length <= THRESHOLD_AVOID_REQUEST_URL_TOO_LARGE) {
+        return;
+      }
+      const _url = new URL(request.url);
+      const body = params.query;
+      const newHeaders = new Headers(request.headers);
+      newHeaders.set("X-HTTP-Method-Override", "GET");
+      newHeaders.set("Content-Type", "application/json");
+
+      return new Request(_url.origin + _url.pathname, {
+        method: "POST",
+        headers: newHeaders,
+        body: JSON.stringify(body),
+      });
+    },
+  };
+};

--- a/packages/rest/src/client/Middlewares/HttpMethodOverrideMiddleware.ts
+++ b/packages/rest/src/client/Middlewares/HttpMethodOverrideMiddleware.ts
@@ -1,15 +1,16 @@
-import type { Middleware, MiddlewareCallbackParams } from "openapi-fetch";
+/* eslint-disable n/no-unsupported-features/node-builtins */
+import type { Middleware } from "openapi-fetch";
 
 const THRESHOLD_AVOID_REQUEST_URL_TOO_LARGE = 4096;
 
 export const getHttpMethodOverrideMiddleware = (): Middleware => {
   return {
-    async onRequest({ request, params }: MiddlewareCallbackParams) {
+    async onRequest({ request, params }) {
       if (request.method !== "GET") {
-        return;
+        return request;
       }
       if (request.url.length <= THRESHOLD_AVOID_REQUEST_URL_TOO_LARGE) {
-        return;
+        return request;
       }
       const _url = new URL(request.url);
       const body = params.query;

--- a/packages/rest/src/client/index.ts
+++ b/packages/rest/src/client/index.ts
@@ -10,6 +10,7 @@ import type { KintoneClient } from "./KintoneClient";
 import { buildNativeClientOptions } from "./KintoneClientOptions";
 import { getCsrfMiddleware } from "./Middlewares/CsrfMiddleware";
 import { isSessionAuth } from "./KintoneClientOptions/Auth";
+import { getHttpMethodOverrideMiddleware } from "./Middlewares/HttpMethodOverrideMiddleware";
 
 export const createClient = (clientOptions: KintoneClientOptions) => {
   return _createClient<paths>(clientOptions);
@@ -26,6 +27,7 @@ const _createClient = <Paths extends {}, Media extends MediaType = MediaType>(
   if (isSessionAuth(clientOptions.auth)) {
     client.use(getCsrfMiddleware());
   }
+  client.use(getHttpMethodOverrideMiddleware());
 
   const api: KintoneApiMethod<Paths, Media> = async (url, method, body) => {
     const _body =


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

`@kintone/rest-api-client` has the function to send a request with the `X-Http-Method-Override` header when the URL length is above 4096, but `@kintone/rest` doesn't yet have it.

## What

<!-- What is a solution you want to add? -->

Add a middleware for the same task.

## How to test

<!-- How can we test this pull request? -->

1. Set the `THRESHOLD_AVOID_REQUEST_URL_TOO_LARGE` value 1.
2. send GET request.
3. check headers and HTTP method.

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
