### PR TITLE
build(rest): enable SSR build to correct import target

### DIFF
--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -71,7 +71,6 @@
   },
   "devDependencies": {
     "vite": "^5.4.15",
-    "vite-plugin-cjs-interop": "^2.2.0",
     "vite-plugin-dts": "^4.5.3",
     "vite-plugin-license": "^0.0.1",
     "vite-plugin-static-copy": "^2.3.1",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -71,6 +71,7 @@
   },
   "devDependencies": {
     "vite": "^5.4.15",
+    "vite-plugin-cjs-interop": "^2.2.0",
     "vite-plugin-dts": "^4.5.3",
     "vite-plugin-license": "^0.0.1",
     "vite-plugin-static-copy": "^2.3.1",

--- a/packages/rest/vite.config.ts
+++ b/packages/rest/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig(({ mode }) => {
         formats: ["es", "cjs"],
         fileName: "[format]/[name]",
       },
+      ssr: true,
       sourcemap: isProd ? false : "inline",
       outDir: outDir,
       rollupOptions: {

--- a/packages/rest/vite.config.ts
+++ b/packages/rest/vite.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from "vite";
 import path from "node:path";
 import dts from "vite-plugin-dts";
 import { viteStaticCopy } from "vite-plugin-static-copy";
-import { cjsInterop } from "vite-plugin-cjs-interop";
 
 const outDir = "lib";
 
@@ -24,6 +23,8 @@ export default defineConfig(({ mode }) => {
       outDir: outDir,
       rollupOptions: {
         output: {
+          // ref. https://github.com/vitejs/vite/discussions/16201
+          interop: "auto",
           exports: "named",
           // ref. https://zenn.dev/nissy_dev/articles/how-to-make-tree-shakeable-libraries
           preserveModules: true,
@@ -34,7 +35,6 @@ export default defineConfig(({ mode }) => {
       },
     },
     plugins: [
-      cjsInterop({ dependencies: ["*"] }),
       dts({
         outDir: [path.join(outDir, "es"), path.join(outDir, "cjs")],
         exclude: ["**/__tests__/*", "**/*.test.ts"],

--- a/packages/rest/vite.config.ts
+++ b/packages/rest/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import path from "node:path";
 import dts from "vite-plugin-dts";
 import { viteStaticCopy } from "vite-plugin-static-copy";
+import { cjsInterop } from "vite-plugin-cjs-interop";
 
 const outDir = "lib";
 
@@ -33,6 +34,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     plugins: [
+      cjsInterop({ dependencies: ["*"] }),
       dts({
         outDir: [path.join(outDir, "es"), path.join(outDir, "cjs")],
         exclude: ["**/__tests__/*", "**/*.test.ts"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -474,6 +474,9 @@ importers:
       vite:
         specifier: ^5.4.15
         version: 5.4.16(@types/node@18.19.86)
+      vite-plugin-cjs-interop:
+        specifier: ^2.2.0
+        version: 2.2.0(vite@5.4.16)
       vite-plugin-dts:
         specifier: ^4.5.3
         version: 4.5.3(@types/node@18.19.86)(rollup@4.40.0)(typescript@5.8.2)(vite@5.4.16)
@@ -2920,6 +2923,74 @@ packages:
       '@octokit/openapi-types': 23.0.1
     dev: true
 
+  /@oxc-parser/binding-darwin-arm64@0.36.0:
+    resolution: {integrity: sha512-i49m1L++ZAeAjNob5qho2ir3nflhIzgQl9hsFvmMBzG+we4OKseGlUAd/nEXJ2XnNvu1TEi/EocsE9XgWM5xlg==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@oxc-parser/binding-darwin-x64@0.36.0:
+    resolution: {integrity: sha512-+UYnDyItrh76gp7JNiTwCYyipwD1f1GkXlVkFt7L4y8GI2nMkTsvS1kUrYVsZTi33GHq4d7janrEN9HUTHqfGg==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@oxc-parser/binding-linux-arm64-gnu@0.36.0:
+    resolution: {integrity: sha512-ZZXcl9FD77EbAENTpYXCYr/zZS1Ab+qomiKIhXVRC1PXIP8qqcYpFl2NtrJHKy0ScIqNHYjzB2F9pj84howN3w==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@oxc-parser/binding-linux-arm64-musl@0.36.0:
+    resolution: {integrity: sha512-2PqTw3uiazv4vp8pGSNWDAp8DSHAxFPh3rIub5colRlu4lLGZJNXm9fgFIp0fS5Z6BFYyhnYzWNZm8bc0q2tYA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@oxc-parser/binding-linux-x64-gnu@0.36.0:
+    resolution: {integrity: sha512-kmRgQj/48VaBf4R9P0ccZdpgepz4F2k7nJgg5L+oPenrJhnZeD9eUzImBlN27XcpBZhDxsvj7jOTp5xSVZ7E/Q==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@oxc-parser/binding-linux-x64-musl@0.36.0:
+    resolution: {integrity: sha512-hxpR0DdK2Zm6Gt3m/bqVLw4nZJdzkr5SsPc6sv0rPtsABx8Q6zxAf300+9mWxUm/Bf4hGHoWsCWFgWN0n87dBA==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@oxc-parser/binding-win32-arm64-msvc@0.36.0:
+    resolution: {integrity: sha512-IsarNWJhsbtARGa/7L2X2FfJt3mdQVH/CASWv99SowVaO62kLZ1lYHtU2Ps0F8dzfCwQUsWo5XnDtmfhd5nAkw==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@oxc-parser/binding-win32-x64-msvc@0.36.0:
+    resolution: {integrity: sha512-NSlWyqWtmWA78nPWRWWzc4W6A8zY0YdX2yjbGg5PnEMiTXrW7NdVTyXdffX59ERDxtC3BT6E78e/sKS9u983pQ==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@oxc-project/types@0.36.0:
+    resolution: {integrity: sha512-VAv7ANBGE6glvOX5PEhGcca8hqBeGGDXt3xfPApZg7GhkrvbI8YCf01HojlpdIewixN2rnNpfO6cFgHS6Ixe5A==}
+    dev: true
+
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -3049,7 +3120,7 @@ packages:
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.40.0)
       estree-walker: 2.0.2
-      magic-string: 0.30.14
+      magic-string: 0.30.17
       rollup: 4.40.0
     dev: true
 
@@ -3107,7 +3178,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 4.40.0
@@ -4190,8 +4261,8 @@ packages:
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
-      magic-string: 0.30.14
-      vite: 5.4.16(@types/node@22.13.17)
+      magic-string: 0.30.17
+      vite: 5.4.16(@types/node@18.19.86)
     dev: true
 
   /@vitest/pretty-format@2.1.9:
@@ -4211,7 +4282,7 @@ packages:
     resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
     dependencies:
       '@vitest/pretty-format': 2.1.9
-      magic-string: 0.30.14
+      magic-string: 0.30.17
       pathe: 1.1.2
     dev: true
 
@@ -8412,7 +8483,7 @@ packages:
   /is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
     dev: true
 
   /is-regex@1.1.4:
@@ -10031,6 +10102,21 @@ packages:
       get-intrinsic: 1.2.7
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
+
+  /oxc-parser@0.36.0:
+    resolution: {integrity: sha512-dcjn+8WvWVbIO0Bb0qAJcfq8JwdkbPflYyFBg3rcDb83awlXAQLnhZuheGUxuWEh18oQFAcxkgdUdObS6DvA7A==}
+    dependencies:
+      '@oxc-project/types': 0.36.0
+    optionalDependencies:
+      '@oxc-parser/binding-darwin-arm64': 0.36.0
+      '@oxc-parser/binding-darwin-x64': 0.36.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.36.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.36.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.36.0
+      '@oxc-parser/binding-linux-x64-musl': 0.36.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.36.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.36.0
+    dev: true
 
   /p-defer@1.0.0:
     resolution: {integrity: sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==}
@@ -12947,6 +13033,18 @@ packages:
       - terser
     dev: true
 
+  /vite-plugin-cjs-interop@2.2.0(vite@5.4.16):
+    resolution: {integrity: sha512-6r7AZMpz2kstspRiK78+4xPvK9GyiGau1uT4GOgxrdzmFFgwLTj/sF9tZiB1VyN24nHGO96wicsRoROEfPGOQg==}
+    peerDependencies:
+      vite: 4 || 5 || 6
+    dependencies:
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+      minimatch: 10.0.1
+      oxc-parser: 0.36.0
+      vite: 5.4.16(@types/node@18.19.86)
+    dev: true
+
   /vite-plugin-dts@4.5.3(@types/node@18.19.86)(rollup@4.40.0)(typescript@5.8.2)(vite@5.4.16):
     resolution: {integrity: sha512-P64VnD00dR+e8S26ESoFELqc17+w7pKkwlBpgXteOljFyT0zDwD8hH4zXp49M/kciy//7ZbVXIwQCekBJjfWzA==}
     peerDependencies:
@@ -13072,7 +13170,7 @@ packages:
       '@types/node': 22.13.17
       esbuild: 0.21.5
       postcss: 8.5.3
-      rollup: 4.40.0
+      rollup: 4.39.0
     optionalDependencies:
       fsevents: 2.3.3
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -474,9 +474,6 @@ importers:
       vite:
         specifier: ^5.4.15
         version: 5.4.16(@types/node@18.19.86)
-      vite-plugin-cjs-interop:
-        specifier: ^2.2.0
-        version: 2.2.0(vite@5.4.16)
       vite-plugin-dts:
         specifier: ^4.5.3
         version: 4.5.3(@types/node@18.19.86)(rollup@4.40.0)(typescript@5.8.2)(vite@5.4.16)
@@ -2923,74 +2920,6 @@ packages:
       '@octokit/openapi-types': 23.0.1
     dev: true
 
-  /@oxc-parser/binding-darwin-arm64@0.36.0:
-    resolution: {integrity: sha512-i49m1L++ZAeAjNob5qho2ir3nflhIzgQl9hsFvmMBzG+we4OKseGlUAd/nEXJ2XnNvu1TEi/EocsE9XgWM5xlg==}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@oxc-parser/binding-darwin-x64@0.36.0:
-    resolution: {integrity: sha512-+UYnDyItrh76gp7JNiTwCYyipwD1f1GkXlVkFt7L4y8GI2nMkTsvS1kUrYVsZTi33GHq4d7janrEN9HUTHqfGg==}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@oxc-parser/binding-linux-arm64-gnu@0.36.0:
-    resolution: {integrity: sha512-ZZXcl9FD77EbAENTpYXCYr/zZS1Ab+qomiKIhXVRC1PXIP8qqcYpFl2NtrJHKy0ScIqNHYjzB2F9pj84howN3w==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@oxc-parser/binding-linux-arm64-musl@0.36.0:
-    resolution: {integrity: sha512-2PqTw3uiazv4vp8pGSNWDAp8DSHAxFPh3rIub5colRlu4lLGZJNXm9fgFIp0fS5Z6BFYyhnYzWNZm8bc0q2tYA==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@oxc-parser/binding-linux-x64-gnu@0.36.0:
-    resolution: {integrity: sha512-kmRgQj/48VaBf4R9P0ccZdpgepz4F2k7nJgg5L+oPenrJhnZeD9eUzImBlN27XcpBZhDxsvj7jOTp5xSVZ7E/Q==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@oxc-parser/binding-linux-x64-musl@0.36.0:
-    resolution: {integrity: sha512-hxpR0DdK2Zm6Gt3m/bqVLw4nZJdzkr5SsPc6sv0rPtsABx8Q6zxAf300+9mWxUm/Bf4hGHoWsCWFgWN0n87dBA==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@oxc-parser/binding-win32-arm64-msvc@0.36.0:
-    resolution: {integrity: sha512-IsarNWJhsbtARGa/7L2X2FfJt3mdQVH/CASWv99SowVaO62kLZ1lYHtU2Ps0F8dzfCwQUsWo5XnDtmfhd5nAkw==}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@oxc-parser/binding-win32-x64-msvc@0.36.0:
-    resolution: {integrity: sha512-NSlWyqWtmWA78nPWRWWzc4W6A8zY0YdX2yjbGg5PnEMiTXrW7NdVTyXdffX59ERDxtC3BT6E78e/sKS9u983pQ==}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@oxc-project/types@0.36.0:
-    resolution: {integrity: sha512-VAv7ANBGE6glvOX5PEhGcca8hqBeGGDXt3xfPApZg7GhkrvbI8YCf01HojlpdIewixN2rnNpfO6cFgHS6Ixe5A==}
-    dev: true
-
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -4262,7 +4191,7 @@ packages:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.17
-      vite: 5.4.16(@types/node@18.19.86)
+      vite: 5.4.16(@types/node@22.13.17)
     dev: true
 
   /@vitest/pretty-format@2.1.9:
@@ -10103,21 +10032,6 @@ packages:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  /oxc-parser@0.36.0:
-    resolution: {integrity: sha512-dcjn+8WvWVbIO0Bb0qAJcfq8JwdkbPflYyFBg3rcDb83awlXAQLnhZuheGUxuWEh18oQFAcxkgdUdObS6DvA7A==}
-    dependencies:
-      '@oxc-project/types': 0.36.0
-    optionalDependencies:
-      '@oxc-parser/binding-darwin-arm64': 0.36.0
-      '@oxc-parser/binding-darwin-x64': 0.36.0
-      '@oxc-parser/binding-linux-arm64-gnu': 0.36.0
-      '@oxc-parser/binding-linux-arm64-musl': 0.36.0
-      '@oxc-parser/binding-linux-x64-gnu': 0.36.0
-      '@oxc-parser/binding-linux-x64-musl': 0.36.0
-      '@oxc-parser/binding-win32-arm64-msvc': 0.36.0
-      '@oxc-parser/binding-win32-x64-msvc': 0.36.0
-    dev: true
-
   /p-defer@1.0.0:
     resolution: {integrity: sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==}
     engines: {node: '>=4'}
@@ -13031,18 +12945,6 @@ packages:
       - sugarss
       - supports-color
       - terser
-    dev: true
-
-  /vite-plugin-cjs-interop@2.2.0(vite@5.4.16):
-    resolution: {integrity: sha512-6r7AZMpz2kstspRiK78+4xPvK9GyiGau1uT4GOgxrdzmFFgwLTj/sF9tZiB1VyN24nHGO96wicsRoROEfPGOQg==}
-    peerDependencies:
-      vite: 4 || 5 || 6
-    dependencies:
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-      minimatch: 10.0.1
-      oxc-parser: 0.36.0
-      vite: 5.4.16(@types/node@18.19.86)
     dev: true
 
   /vite-plugin-dts@4.5.3(@types/node@18.19.86)(rollup@4.40.0)(typescript@5.8.2)(vite@5.4.16):


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->


The import/require target was incorrectly transformed on Vite output.

The output results are as follows.

```js
require(“/Users/tasshi/git/cybozu/js-sdk/node_modules/.pnpm/undici@7.4.0/node_modules/undici/index.js”)
```

- The local absolute path is specified.
- The entry point on the ESM side is specified

This is because Vite builds code for the browser.
(Browsers cannot import with the package name like `undici`, so Vite replaces it with the absolute path.)

By enabling SSR build, the build target is switched to Node.js, and the npm package name is retained.

```js
require(“undici”);
```

## What

<!-- What is a solution you want to add? -->

- enable SSR build for ESM/CJS build

ref. https://vite.dev/config/build-options.html#build-ssr

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.
