### PR TITLE
ci: remove PAT

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -34,7 +34,6 @@ jobs:
           repository: kintone/rest-api-spec
           ref: main
           path: rest-api-spec
-          token: ${{ secrets.REST_API_SPEC_READ_TOKEN }}
 
       - name: Start mock server
         shell: bash


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

In #3324, the clone of the rest-api-spec repository failed.
At the time, rest-api-spec was a private repository, so a PAT was set, but now that it is an open repository, a PAT is not necessary.

## What

<!-- What is a solution you want to add? -->

PAT deleted.

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.
