### PR TITLE
fix: bump axios and form-data npms for CVE-2025-7783

### DIFF
--- a/packages/dts-gen/package.json
+++ b/packages/dts-gen/package.json
@@ -29,10 +29,10 @@
   "license": "MIT",
   "dependencies": {
     "@cybozu/eslint-config": "^24.0.0",
-    "axios": "^1.8.4",
+    "axios": "^1.12.2",
     "commander": "^12.1.0",
     "eslint": "^9.20.1",
-    "form-data": "^4.0.1",
+    "form-data": "^4.0.4",
     "lodash": "^4.17.21",
     "prettier": "^3.4.2"
   },

--- a/packages/rest-api-client/package.json
+++ b/packages/rest-api-client/package.json
@@ -74,9 +74,9 @@
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {
-    "axios": "^1.8.4",
+    "axios": "^1.12.2",
     "core-js": "^3.40.0",
-    "form-data": "^4.0.1",
+    "form-data": "^4.0.4",
     "js-base64": "^3.7.8",
     "mime": "^3.0.0",
     "qs": "^6.14.0"

--- a/packages/rest-api-client/src/client/__tests__/File.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/File.test.ts
@@ -7,7 +7,11 @@ import * as browserDeps from "../../platform/browser";
 import * as nodeDeps from "../../platform/node";
 import { KintoneRequestConfigBuilder } from "../../KintoneRequestConfigBuilder";
 
-jest.mock("form-data");
+jest.mock("form-data", () => {
+  const MockFormData = jest.fn();
+  MockFormData.prototype.append = jest.fn();
+  return MockFormData;
+})
 
 describe("FileClient", () => {
   let mockClient: MockClient;

--- a/packages/rest-api-client/src/client/__tests__/File.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/File.test.ts
@@ -11,7 +11,7 @@ jest.mock("form-data", () => {
   const MockFormData = jest.fn();
   MockFormData.prototype.append = jest.fn();
   return MockFormData;
-})
+});
 
 describe("FileClient", () => {
   let mockClient: MockClient;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,8 +175,8 @@ importers:
         specifier: ^24.0.0
         version: 24.0.0(@types/eslint@9.6.1)(eslint@9.20.1)(prettier@3.4.2)(typescript@5.7.3)
       axios:
-        specifier: ^1.8.4
-        version: 1.8.4
+        specifier: ^1.12.2
+        version: 1.12.2
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -184,8 +184,8 @@ importers:
         specifier: ^9.20.1
         version: 9.20.1
       form-data:
-        specifier: ^4.0.1
-        version: 4.0.1
+        specifier: ^4.0.4
+        version: 4.0.4
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -493,14 +493,14 @@ importers:
   packages/rest-api-client:
     dependencies:
       axios:
-        specifier: ^1.8.4
-        version: 1.8.4
+        specifier: ^1.12.2
+        version: 1.12.2
       core-js:
         specifier: ^3.40.0
         version: 3.40.0
       form-data:
-        specifier: ^4.0.1
-        version: 4.0.1
+        specifier: ^4.0.4
+        version: 4.0.4
       js-base64:
         specifier: ^3.7.8
         version: 3.7.8
@@ -5006,11 +5006,11 @@ packages:
     resolution: {integrity: sha512-qPC9o+kD8Tir0lzNGLeghbOrWMr3ZJpaRlCIb6Uobt/7N4FiEDvqUMnxzCHRHmg8vOg14kr5gVNyScRmbMaJ9g==}
     engines: {node: '>=4'}
 
-  /axios@1.8.4:
-    resolution: {integrity: sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==}
+  /axios@1.12.2:
+    resolution: {integrity: sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==}
     dependencies:
       follow-redirects: 1.15.6(debug@4.4.1)
-      form-data: 4.0.1
+      form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -6585,7 +6585,7 @@ packages:
       es-define-property: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.0.0
-      es-set-tostringtag: 2.0.3
+      es-set-tostringtag: 2.1.0
       es-to-primitive: 1.2.1
       function.prototype.name: 1.1.6
       get-intrinsic: 1.2.7
@@ -6701,7 +6701,7 @@ packages:
       define-properties: 1.2.1
       es-abstract: 1.23.9
       es-errors: 1.3.0
-      es-set-tostringtag: 2.0.3
+      es-set-tostringtag: 2.1.0
       function-bind: 1.1.2
       get-intrinsic: 1.2.7
       globalthis: 1.0.4
@@ -6722,14 +6722,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       es-errors: 1.3.0
-
-  /es-set-tostringtag@2.0.3:
-    resolution: {integrity: sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      get-intrinsic: 1.2.7
-      has-tostringtag: 1.0.2
-      hasown: 2.0.2
 
   /es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
@@ -7673,12 +7665,14 @@ packages:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  /form-data@4.0.1:
-    resolution: {integrity: sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==}
+  /form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
       mime-types: 2.1.35
 
   /forwarded@0.2.0:
@@ -8426,7 +8420,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.7
-      has-tostringtag: 1.0.0
+      has-tostringtag: 1.0.2
 
   /is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
@@ -8468,7 +8462,7 @@ packages:
     resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      has-tostringtag: 1.0.0
+      has-tostringtag: 1.0.2
 
   /is-date-object@1.1.0:
     resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
@@ -8551,7 +8545,7 @@ packages:
     resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      has-tostringtag: 1.0.0
+      has-tostringtag: 1.0.2
 
   /is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
@@ -8606,7 +8600,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.7
-      has-tostringtag: 1.0.0
+      has-tostringtag: 1.0.2
 
   /is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -8641,7 +8635,7 @@ packages:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      has-tostringtag: 1.0.0
+      has-tostringtag: 1.0.2
 
   /is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
@@ -9347,7 +9341,7 @@ packages:
       decimal.js: 10.4.3
       domexception: 4.0.0
       escodegen: 2.1.0
-      form-data: 4.0.1
+      form-data: 4.0.4
       html-encoding-sniffer: 3.0.0
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
@@ -13381,7 +13375,7 @@ packages:
       '@types/node': 22.13.17
       esbuild: 0.21.5
       postcss: 8.5.6
-      rollup: 4.50.1
+      rollup: 4.39.0
     optionalDependencies:
       fsevents: 2.3.3
     dev: true


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

A critical security vulnerability (CVE-2025-7783) was discovered in the form-data npm package.

This vulnerability uses unsafe random number generation (Math.random()) for multipart form boundaries, which could allow attackers to predict boundaries and inject additional parameters into requests.
With a CVSS score of 9.4, this could potentially allow arbitrary requests to internal systems.

## What

<!-- What is a solution you want to add? -->

Updated both axios and form-data packages to their latest secure versions:
- axios: 1.8.4 → 1.12.2
- form-data: 4.0.1 → 4.0.4 (patched version for CVE-2025-7783)

These updates were applied to:
- packages/dts-gen/package.json
- packages/rest-api-client/package.json
- Updated test mocking in packages/rest-api-client/src/client/__tests__/File.test.ts for compatibility

## How to test

<!-- How can we test this pull request? -->

The unit tests are passing, but could you please run an actual API call to confirm it works, just to be sure?

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
