### PR TITLE
ci: fix flaky E2E test workflow

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Start mock server
         shell: bash
         run: |
-          npx @stoplight/prism-cli@5.12.0 mock rest-api-spec/kintone/$(ls rest-api-spec/kintone | sort | tail -n 1)/openapi.yaml &
-          npx wait-on -t 180s tcp:127.0.0.1:4010
+          pnpm dlx @stoplight/prism-cli@5.12.0 mock rest-api-spec/kintone/$(ls rest-api-spec/kintone | sort | tail -n 1)/openapi.yaml &
+          pnpm dlx wait-on -t 180s tcp:127.0.0.1:4010
 
       - run: pnpm install --fetch-timeout 900000 --frozen-lockfile
       - run: pnpm build


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

The E2E tests for rest.js have been frequently failing.

- https://github.com/kintone/js-sdk/actions/runs/18485716355/job/52668779897
- https://github.com/kintone/js-sdk/actions/runs/18521110235/job/52781050389
- https://github.com/kintone/js-sdk/actions/runs/18971291288/job/54179430710
- https://github.com/kintone/js-sdk/actions/runs/18971301963/job/54179467647
- https://github.com/kintone/js-sdk/actions/runs/18971331622/job/54179564514
- https://github.com/kintone/js-sdk/actions/runs/18971429305/job/54179874057

```log
npm warn exec The following package was not found and will be installed: wait-on@9.0.1
npm warn exec The following package was not found and will be installed: @stoplight/prism-cli@5.12.0
npm error code ECOMPROMISED
npm error Lock compromised
npm error A complete log of this run can be found in: C:\npm\cache\_logs\2025-10-31T11_39_42_566Z-debug-0.log
Error: Timed out waiting for: tcp:127.0.0.1:4010
```

It appears that on Windows with Node v24, running 'npx' often causes an 'ECOMPROMISED' error.
Since npx doesn’t guarantee fixed package versions and can be a security risk, we will use `pnpm dlx` instead.

## What

<!-- What is a solution you want to add? -->

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.
