### PR TITLE
feat(rest-api-client): add filterCond to actions

### DIFF
--- a/packages/rest-api-client/src/client/__tests__/app/Actions.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/app/Actions.test.ts
@@ -82,6 +82,7 @@ describe("Actions", () => {
               code: "Administrator",
             },
           ],
+          filterCond: 'Status = "Active"',
         },
       },
     };

--- a/packages/rest-api-client/src/client/types/app/action.ts
+++ b/packages/rest-api-client/src/client/types/app/action.ts
@@ -19,6 +19,7 @@ type ActionPropertyForParameter = (
   name?: string;
   index: string | number;
   entities?: Entity[];
+  filterCond?: string;
 };
 
 type DestAppForParameter =
@@ -41,6 +42,7 @@ type ActionPropertyForResponse = {
   destApp: DestAppForResponse;
   mappings: Mapping[];
   entities: Entity[];
+  filterCond: string;
 };
 
 type DestAppForResponse = {


### PR DESCRIPTION

  <!-- Thank you for sending a pull request! -->

  ## Why

  This PR addresses the kintone API update from July 13, 2025, where new fields were added to the app action settings API endpoints.

  API Update: https://cybozu.dev/ja/kintone/news/api-updates/2025-07/

  ## What

  - Added `filterCond` field to action settings types
    - `ActionPropertyForResponse.filterCond: string` - The query string for conditions to execute the Action
    - `ActionPropertyForParameter.filterCond?: string` - Optional query string parameter
  - Added test case with `filterCond` field in Actions.test.ts

  ## How to test
```
  pnpm --filter @kintone/rest-api-client test
```


  ## Checklist

  - [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
  - [x] Updated documentation if it is required.
  - [x] Added tests if it is required.
  - [x] Passed `pnpm lint` and `pnpm test` on the root directory.