### PR TITLE
docs: clarify ACL methods only update pre-live settings

### DIFF
--- a/packages/rest-api-client/docs/app.md
+++ b/packages/rest-api-client/docs/app.md
@@ -704,6 +704,8 @@ Gets the app permissions of an app.
 
 Updates the app permissions of an app.
 
+> **Note:** This method only updates the pre-live settings. To deploy the changes to the live app, use the [`deployApp()`](#deployApp) method.
+
 #### Parameters
 
 | Name                      |       Type       |          Required           | Description                                                                                                                                                                                                                                                                                                                                                                                                    |
@@ -798,6 +800,8 @@ Gets the record permission settings of an app.
 
 Updates the record permission settings of an app.
 
+> **Note:** This method only updates the pre-live settings. To deploy the changes to the live app, use the [`deployApp()`](#deployApp) method.
+
 #### Parameters
 
 | Name                            |       Type       | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                               |
@@ -857,6 +861,8 @@ Gets the field permission settings of an app.
 ### updateFieldAcl
 
 Updates the field permission settings of an app.
+
+> **Note:** This method only updates the pre-live settings. To deploy the changes to the live app, use the [`deployApp()`](#deployApp) method.
 
 #### Parameters
 


### PR DESCRIPTION
  ## Why

  The three methods `updateAppAcl`, `updateRecordAcl`, and `updateFieldAcl` only update the pre-live environment and do not reflect changes to the live app. However, this behavior was not clearly documented.

  Users might misunderstand that these methods automatically deploy changes to the live app, so explicit documentation is needed.

  ## What

  Added notes to the following three methods in `packages/rest-api-client/docs/app.md`:
  - `updateAppAcl`
  - `updateRecordAcl`
  - `updateFieldAcl`

  Added note:
  > **Note:** This method only updates the pre-live settings. To deploy the changes to the live app, use the `deployApp()` method.

  ## How to test

  1. Open `packages/rest-api-client/docs/app.md`
  2. Verify that the note has been added to each section of `updateAppAcl`, `updateRecordAcl`, and `updateFieldAcl`
  3. Verify that the build succeeds: `npm run build`

  ## Checklist

  - [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
  - [x] Updated documentation if it is required.
  - [ ] Added tests if it is required. (Not required for documentation-only changes)
  - [ ] Passed `pnpm lint` and `pnpm test` on the root directory.