### PR TITLE
fix: make app.getStatistics params to required

### DIFF
--- a/packages/rest-api-client/src/client/AppClient.ts
+++ b/packages/rest-api-client/src/client/AppClient.ts
@@ -639,11 +639,11 @@ export class AppClient extends BaseClient {
   }
 
   public getStatistics(
-    params?: GetStatisticsRequest,
+    params: GetStatisticsRequest,
   ): Promise<GetStatisticsResponse> {
     const path = this.buildPath({
       endpointName: "apps/statistics",
     });
-    return this.client.get(path, params ?? {});
+    return this.client.get(path, params);
   }
 }

--- a/packages/rest-api-client/src/client/__tests__/app/App.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/app/App.test.ts
@@ -132,9 +132,9 @@ describe("App Test", () => {
   });
 
   describe("getStatistics", () => {
-    describe("without params", () => {
+    describe("with empty params", () => {
       beforeEach(async () => {
-        await appClient.getStatistics();
+        await appClient.getStatistics({});
       });
       it("should pass the path to the http client", () => {
         expect(mockClient.getLogs()[0].path).toBe("/k/v1/apps/statistics.json");


### PR DESCRIPTION
  <!-- Thank you for sending a pull request! -->

  ## Why

  <!-- Why do you want the feature and why does it make sense for the package? -->

  Make the params object required for `app.getStatistics()` method to improve type safety. The current implementation allows params to be
  optional, but requiring an explicit empty object `{}` ensures API consistency.

  ## What

  <!-- What is a solution you want to add? -->

  - Changed `AppClient.getStatistics()` params from `params?: GetStatisticsRequest` to `params: GetStatisticsRequest`
  - Removed unnecessary nullish coalescing `params ?? {}` and use `params` directly
  - Updated test: `getStatistics()` → `getStatistics({})`
  - Updated test description from "without params" to "with empty params" for better accuracy

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.
