### PR TITLE
fix: update action type definition

### DIFF
--- a/packages/rest-api-client/src/client/types/app/processManagement.ts
+++ b/packages/rest-api-client/src/client/types/app/processManagement.ts
@@ -67,26 +67,36 @@ export type StateForParameter = {
   };
 };
 
-type ActionType = "PRIMARY" | "SECONDARY";
-
 export type ActionForResponse = {
   name: string;
   from: string;
   to: string;
   filterCond: string;
-  type: ActionType;
-  executableUser?: {
-    entities: ExecutableUserEntityForResponse[];
-  };
-};
+} & (
+  | {
+      type: "PRIMARY";
+    }
+  | {
+      type: "SECONDARY";
+      executableUser: {
+        entities: ExecutableUserEntityForResponse[];
+      };
+    }
+);
 
 export type ActionForParameter = {
   name: string;
   from: string;
   to: string;
   filterCond?: string;
-  type?: ActionType;
-  executableUser?: {
-    entities: ExecutableUserEntityForParameter[];
-  };
-};
+} & (
+  | {
+      type?: "PRIMARY";
+    }
+  | {
+      type: "SECONDARY";
+      executableUser: {
+        entities: ExecutableUserEntityForParameter[];
+      };
+    }
+);


### PR DESCRIPTION
  <!-- Thank you for sending a pull request! -->

  ## Why

  <!-- Why do you want the feature and why does it make sense for the package? -->

  The dependency relationship between `actions[].type` and `actions[].executableUser` was not expressed in
   the type system.

  In kintone's process management API, `actions[].executableUser` is required in requests and included in
  responses only when `actions[].type` is `"SECONDARY"`. By expressing this dependency relationship as
  type information, we can reduce runtime errors and improve the developer experience.

  ## What

  <!-- What is a solution you want to add? -->

  - Changed `ActionForResponse` type to a discriminated union, adding a type constraint that makes
  `executableUser` required only when `type="SECONDARY"`
  - Changed `ActionForParameter` type to a discriminated union, adding a type constraint that makes
  `executableUser` required only when `type="SECONDARY"`
  - Removed unused `ActionType` type

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.
