### PR TITLE
fix: remove param valiidation of getPlugins

### DIFF
--- a/packages/rest-api-client/src/client/PluginClient.ts
+++ b/packages/rest-api-client/src/client/PluginClient.ts
@@ -17,14 +17,6 @@ export class PluginClient extends BaseClient {
   public getPlugins(
     params: GetPluginsForRequest,
   ): Promise<GetPluginsForResponse> {
-    if (params.ids !== undefined) {
-      if (
-        !Array.isArray(params.ids) ||
-        !params.ids.every((id) => typeof id === "string")
-      ) {
-        throw new Error("the `ids` parameter must be an array of string.");
-      }
-    }
     const path = this.buildPath({ endpointName: "plugins" });
     return this.client.get(path, params);
   }

--- a/packages/rest-api-client/src/client/__tests__/PluginClient.test.ts
+++ b/packages/rest-api-client/src/client/__tests__/PluginClient.test.ts
@@ -58,65 +58,6 @@ describe("PluginClient", () => {
         expect(mockClient.getLogs()[0].params).toEqual(paramsWithIds);
       });
     });
-
-    describe("validation for ids parameter", () => {
-      it("should throw an error if ids is not an array", () => {
-        const invalidParams = {
-          offset: 0,
-          limit: 10,
-          ids: "not-an-array",
-        };
-        // @ts-expect-error Testing runtime validation
-        expect(() => pluginClient.getPlugins(invalidParams)).toThrow(
-          "the `ids` parameter must be an array of string.",
-        );
-      });
-
-      it("should throw an error if ids contains non-string values", () => {
-        const invalidParams = {
-          offset: 0,
-          limit: 10,
-          ids: ["plugin1", 123, "plugin3"],
-        };
-        // @ts-expect-error Testing runtime validation
-        expect(() => pluginClient.getPlugins(invalidParams)).toThrow(
-          "the `ids` parameter must be an array of string.",
-        );
-      });
-
-      it("should throw an error if ids contains object values", () => {
-        const invalidParams = {
-          offset: 0,
-          limit: 10,
-          ids: ["plugin1", { id: "plugin2" }, "plugin3"],
-        };
-        // @ts-expect-error Testing runtime validation
-        expect(() => pluginClient.getPlugins(invalidParams)).toThrow(
-          "the `ids` parameter must be an array of string.",
-        );
-      });
-
-      it("should not throw an error if ids is undefined", async () => {
-        const validParams = {
-          offset: 0,
-          limit: 10,
-        };
-        await expect(
-          pluginClient.getPlugins(validParams),
-        ).resolves.not.toThrow();
-      });
-
-      it("should not throw an error if ids is an empty array", async () => {
-        const validParams = {
-          offset: 0,
-          limit: 10,
-          ids: [],
-        };
-        await expect(
-          pluginClient.getPlugins(validParams),
-        ).resolves.not.toThrow();
-      });
-    });
   });
 
   describe("getRequiredPlugins", () => {


### PR DESCRIPTION
 <!-- Thank you for sending a pull request! -->

  ## Why

  Only the `PluginClient.getPlugins()` method performs runtime validation for the `ids` parameter, while other API methods (such as `AppClient.getApps()`, `PluginClient.getRequiredPlugins()`) do not implement similar validation. To maintain consistency across the API, we should remove the validation from `getPlugins()` and rely on TypeScript's type system like other methods.

  ## What

  - Removed runtime validation for the `ids` parameter from `PluginClient.getPlugins()` method
    - Removed validation: array type check, array element type check
  - Removed corresponding test cases (5 tests)
    - Tests that expected validation errors
  - Maintained normal case tests (`with ids parameter`)

  With this change, the `getPlugins()` method will rely solely on TypeScript's type checking, consistent with other methods.

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.
