### PR TITLE
fix(create-plugin): use correct @cybozu/eslint-config flat config API

### DIFF
--- a/packages/create-plugin/package.json
+++ b/packages/create-plugin/package.json
@@ -35,7 +35,7 @@
     "start": "pnpm build --watch",
     "test": "jest --testPathIgnorePatterns=/__tests__/generator\\.test\\.ts$",
     "test:all": "run-p test test:generator test:e2e",
-    "test:ci": "pnpm test test:generator",
+    "test:ci": "pnpm test && pnpm test:generator",
     "test:e2e": "cross-env NODE_ENV=e2e jest --config=jest.e2e.config.js",
     "test:generator": "cross-env NODE_ENV=e2e jest --testPathPattern=/__tests__/generator\\.test\\.ts$"
   },

--- a/packages/create-plugin/templates/minimum/eslint.config.mjs
+++ b/packages/create-plugin/templates/minimum/eslint.config.mjs
@@ -1,19 +1,13 @@
-import kintoneGlobalConfig from "@cybozu/eslint-config/flat/globals/kintone.js";
-import baseConfig from "@cybozu/eslint-config/flat/lib/base.js";
-import kintoneConfig from "@cybozu/eslint-config/flat/lib/kintone.js";
-import prettierConfig from "@cybozu/eslint-config/flat/lib/prettier.js";
+import kintone from '@cybozu/eslint-config/flat/lib/kintone.js';
+import prettier from '@cybozu/eslint-config/flat/lib/prettier.js';
 
 /** @type {import("eslint").Linter.Config[]} */
 export default [
-  ...kintoneGlobalConfig,
-  ...baseConfig,
-  ...kintoneConfig,
-  ...prettierConfig,
+  ...kintone(),
+  ...prettier(),
   {
     rules: {
-      "prettier/prettier": ["error", { singleQuote: true }],
-      "space-before-function-paren": 0,
-      "object-curly-spacing": 0,
+      'prettier/prettier': ['error', { singleQuote: true }],
     },
   },
 ];

--- a/packages/create-plugin/templates/modern/eslint.config.mjs
+++ b/packages/create-plugin/templates/modern/eslint.config.mjs
@@ -1,4 +1,4 @@
-import presetsPrettier from "@cybozu/eslint-config/flat/presets/prettier.js";
+import kintoneCustomizePrettier from "@cybozu/eslint-config/flat/presets/kintone-customize-prettier.js";
 
 /** @type {import("eslint").Linter.Config[]} */
-export default [...presetsPrettier];
+export default [...kintoneCustomizePrettier];


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

The ESLint configuration in `create-plugin` templates was not using the `@cybozu/eslint-config` flat config API correctly, causing `npm run lint` to fail in generated plugin projects.

Specific issues:
- `minimum` template: Attempted to spread `kintone()`, `prettier()`, etc. directly without calling them as functions
- `modern` template: Used `presets/prettier` which does not include kintone globals, resulting in `kintone is not defined` errors

## What

<!-- What is a solution you want to add? -->

- **minimum template**: Fixed to call `kintone()` and `prettier()` as functions
- **modern template**: Changed from `presets/prettier` to `presets/kintone-customize-prettier` (includes kintone globals)
- **test:ci**: Fixed `pnpm test test:generator` to `pnpm test && pnpm test:generator` to ensure generator tests run correctly

## How to test

<!-- How can we test this pull request? -->

```bash
pnpm --filter @kintone/create-plugin test:generator
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
