### PR TITLE
fix(webpack-plugin-kintone-plugin): fix Windows CI timeout on Node.js 24

### DIFF
--- a/packages/webpack-plugin-kintone-plugin/src/__tests__/cli.test.ts
+++ b/packages/webpack-plugin-kintone-plugin/src/__tests__/cli.test.ts
@@ -1,20 +1,17 @@
 import { spawnSync } from "child_process";
 import fs from "fs";
-import os from "os";
 import path from "path";
 import { verifyPluginZip, fixtureDir, cleanupJsFiles } from "./helpers";
 
 const pluginZipPath = path.resolve(fixtureDir, "dist", "plugin.zip");
 
 const runWebpack = (config = "webpack.config.js") => {
-  const isWindows = os.platform() === "win32";
-  // Use npx to ensure webpack-cli is found in PATH
+  const webpackBin = require.resolve("webpack-cli/bin/cli.js");
   return spawnSync(
-    isWindows ? "npx.cmd" : "npx",
-    ["webpack", "--config", config, "--mode", "production"],
+    process.execPath,
+    [webpackBin, "--config", config, "--mode", "production"],
     {
       cwd: fixtureDir,
-      shell: isWindows,
     },
   );
 };


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

CI の `Node.js windows-latest 24.x` ジョブで `cli.test.ts` の `should be able to create a plugin zip` が30秒タイムアウトで失敗している。

- https://github.com/kintone/js-sdk/actions/runs/24387729257/job/71373524293?pr=3740

原因は `spawnSync` で `shell: true` + 引数付きの子プロセスを起動しており、Node.js 24 の `DEP0190` 警告の影響で Windows 上の実行が極端に遅くなっている。

## What

`cli.test.ts` の `runWebpack()` を変更し、`npx` / `npx.cmd` 経由の起動をやめて `require.resolve("webpack-cli/bin/cli.js")` + `process.execPath` で直接実行するようにした。

- `shell: true` が不要になり、DEP0190 警告とタイムアウトの両方が解消される
- `os` の import も不要になるので削除
- `webpack-cli` は既に devDependencies にある (`"webpack-cli": "6.0.1"`) ので追加のインストールは不要

### テストへの影響について

このテストの目的は「webpack プラグイン (`webpack-plugin-kintone-plugin`) が正しく動作し、期待する構造の plugin.zip を生成できること」の検証であり、npx 自体の動作を検証するものではない。`npx webpack` も `node webpack-cli/bin/cli.js` も最終的に同じ webpack-cli のエントリポイントを実行するため、起動方法の変更はテストで検証したい内容に影響しない。

## How to test

- CI の `Node.js windows-latest 24.x` ジョブがタイムアウトせず通ることを確認
- 他のOS・Node.jsバージョンでもテストが引き続きパスすることを確認

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.