### PR TITLE
fix: extend test timeouts for Windows CI on Node.js 24

### DIFF
--- a/packages/create-plugin/vitest.generator.config.ts
+++ b/packages/create-plugin/vitest.generator.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     include: ["src/__tests__/generator.test.ts"],
     environment: "node",
     testTimeout: 300000,
-    hookTimeout: 30000,
+    hookTimeout: 300000,
     globals: true,
   },
 });

--- a/packages/rest-api-client/src/__tests__/e2e.rollup.test.ts
+++ b/packages/rest-api-client/src/__tests__/e2e.rollup.test.ts
@@ -21,7 +21,7 @@ const tempDir = fs.mkdtempSync(
 
 const extensions = [".ts", ".js"];
 
-const TESTCASE_TIMEOUT = 30000;
+const TESTCASE_TIMEOUT = 300000;
 
 describe("Rollup Bundler tests", function () {
   let bundle: RollupBuild;

--- a/packages/rest-api-client/src/__tests__/e2e.vite.test.ts
+++ b/packages/rest-api-client/src/__tests__/e2e.vite.test.ts
@@ -9,7 +9,7 @@ const tempDir = fs.mkdtempSync(
 );
 
 describe("Vite CLI Bundler tests", function () {
-  it(`should be able to build with Vite successfully`, () => {
+  it(`should be able to build with Vite successfully`, { timeout: 300000 }, () => {
     const buildResult = spawnSync(
       "vite build",
       ["--config", "fixtures/vite.config.mjs"],

--- a/packages/rest-api-client/src/__tests__/e2e.vite.test.ts
+++ b/packages/rest-api-client/src/__tests__/e2e.vite.test.ts
@@ -9,22 +9,26 @@ const tempDir = fs.mkdtempSync(
 );
 
 describe("Vite CLI Bundler tests", function () {
-  it(`should be able to build with Vite successfully`, { timeout: 300000 }, () => {
-    const buildResult = spawnSync(
-      "vite build",
-      ["--config", "fixtures/vite.config.mjs"],
-      {
-        cwd: __dirname,
-        stdio: "inherit",
-        shell: true,
-        env: {
-          ...process.env,
-          TEMP_DIR: tempDir,
+  it(
+    `should be able to build with Vite successfully`,
+    { timeout: 300000 },
+    () => {
+      const buildResult = spawnSync(
+        "vite build",
+        ["--config", "fixtures/vite.config.mjs"],
+        {
+          cwd: __dirname,
+          stdio: "inherit",
+          shell: true,
+          env: {
+            ...process.env,
+            TEMP_DIR: tempDir,
+          },
         },
-      },
-    );
-    expect(buildResult.status).toBe(0);
-  });
+      );
+      expect(buildResult.status).toBe(0);
+    },
+  );
 
   afterAll(() => {
     rimrafSync(tempDir);

--- a/packages/webpack-plugin-kintone-plugin/src/__tests__/cli.test.ts
+++ b/packages/webpack-plugin-kintone-plugin/src/__tests__/cli.test.ts
@@ -29,7 +29,7 @@ describe("KintonePlugin", () => {
     }
     cleanupJsFiles();
   });
-  it("should be able to create a plugin zip", { timeout: 180000 }, () => {
+  it("should be able to create a plugin zip", { timeout: 300000 }, () => {
     const rs = runWebpack();
     expect(rs.error).toBeUndefined();
     verifyPluginZip(pluginZipPath);

--- a/packages/webpack-plugin-kintone-plugin/src/__tests__/cli.test.ts
+++ b/packages/webpack-plugin-kintone-plugin/src/__tests__/cli.test.ts
@@ -29,7 +29,7 @@ describe("KintonePlugin", () => {
     }
     cleanupJsFiles();
   });
-  it("should be able to create a plugin zip", () => {
+  it("should be able to create a plugin zip", { timeout: 180000 }, () => {
     const rs = runWebpack();
     expect(rs.error).toBeUndefined();
     verifyPluginZip(pluginZipPath);


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

CI の Windows ジョブで複数のテストがタイムアウトで失敗している。

- https://github.com/kintone/js-sdk/actions/runs/24387729257/job/71373524293?pr=3740

Node.js 24 の `DEP0190` 警告や Windows ランナーの負荷により、バンドラー（webpack, rollup, vite）を使うテストやファイル削除を行う hook の実行が遅くなっている。

## What

タイムアウトで失敗しているテストのタイムアウト値を延長した。

| パッケージ | ファイル | 変更内容 |
|---|---|---|
| `webpack-plugin-kintone-plugin` | `cli.test.ts` | テストタイムアウト 30秒 → 300秒 |
| `rest-api-client` | `e2e.rollup.test.ts` | テストタイムアウト 30秒 → 300秒 |
| `rest-api-client` | `e2e.vite.test.ts` | テストタイムアウト追加（デフォルト5秒 → 300秒） |
| `create-plugin` | `vitest.generator.config.ts` | hookTimeout 30秒 → 300秒 |

テストの実行内容自体は変更していない。

## How to test

- CI の Windows ジョブがタイムアウトせず通ることを確認
- 他のOS・Node.jsバージョンでもテストが引き続きパスすることを確認

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.



BEGIN_COMMIT_OVERRIDE
chore: extend test timeouts for Windows CI on Node.js 24
END_COMMIT_OVERRIDE