### PR TITLE
chore(plugin-manifest-validator, create-plugin): update schema url in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,45 @@ jobs:
         with:
           token: ${{ steps.create-iat.outputs.token }}
 
+      # release-please's extra-files cannot replace a version substring inside
+      # a URL (jsonpath replaces the whole field), so patch the release PR
+      # directly whenever release-please creates/updates it.
+      - name: Resolve release PR branch
+        id: sync-prep
+        if: ${{ steps.release.outputs.pr }}
+        env:
+          PR_JSON: ${{ steps.release.outputs.pr }}
+        run: |
+          echo "branch=$(jq -r '.headBranchName' <<<"$PR_JSON")" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout release PR branch
+        if: ${{ steps.release.outputs.pr }}
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.sync-prep.outputs.branch }}
+          token: ${{ steps.create-iat.outputs.token }}
+          path: _sync
+
+      - name: Sync plugin-manifest-validator examples/manifest.json
+        if: ${{ steps.release.outputs.pr }}
+        working-directory: _sync
+        run: |
+          set -euo pipefail
+          target="packages/plugin-manifest-validator/examples/manifest.json"
+          new_version=$(jq -r '."packages/plugin-manifest-validator"' .release-please-manifest.json)
+
+          sed -i -E "s|(plugin-manifest-validator%40)[0-9]+\.[0-9]+\.[0-9]+|\1${new_version}|g" "$target"
+
+          if git diff --quiet -- "$target"; then
+            echo "URL already points to ${new_version}; nothing to sync"
+            exit 0
+          fi
+
+          git -c user.name="release-please-bot" \
+              -c user.email="release-please-bot@users.noreply.github.com" \
+              commit -am "chore: sync examples/manifest.json to @kintone/plugin-manifest-validator@${new_version}"
+          git push
+
   publish:
     name: Publish to npm
     permissions:

--- a/packages/create-plugin/src/__tests__/fixtures/manifest.json
+++ b/packages/create-plugin/src/__tests__/fixtures/manifest.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/kintone/js-sdk/%40kintone/plugin-manifest-validator%4010.2.0/packages/plugin-manifest-validator/manifest-schema.json",
+  "$schema": "https://raw.githubusercontent.com/kintone/js-sdk/%40kintone/plugin-manifest-validator%4011.1.1/packages/plugin-manifest-validator/manifest-schema.json",
   "manifest_version": 1,
   "version": 1,
   "type": "APP",

--- a/packages/create-plugin/src/manifest.ts
+++ b/packages/create-plugin/src/manifest.ts
@@ -5,7 +5,7 @@ import type { TemplateType } from "./template";
 
 const minimumManifest = {
   $schema:
-    "https://raw.githubusercontent.com/kintone/js-sdk/%40kintone/plugin-manifest-validator%4010.2.0/packages/plugin-manifest-validator/manifest-schema.json",
+    "https://raw.githubusercontent.com/kintone/js-sdk/%40kintone/plugin-manifest-validator%4011.1.1/packages/plugin-manifest-validator/manifest-schema.json",
   manifest_version: 1,
   version: 1,
   type: "APP",
@@ -24,7 +24,7 @@ const minimumManifest = {
 
 const modernManifest = {
   $schema:
-    "https://raw.githubusercontent.com/kintone/js-sdk/%40kintone/plugin-manifest-validator%4010.2.0/packages/plugin-manifest-validator/manifest-schema.json",
+    "https://raw.githubusercontent.com/kintone/js-sdk/%40kintone/plugin-manifest-validator%4011.1.1/packages/plugin-manifest-validator/manifest-schema.json",
   manifest_version: 1,
   version: 1,
   type: "APP",

--- a/packages/plugin-manifest-validator/README.md
+++ b/packages/plugin-manifest-validator/README.md
@@ -61,9 +61,13 @@ let manifest: KintonePluginManifestJson;
 When you are configuring your project, you would better set the $schema property. This property should point to a schema file that validates your manifest.
 We recommend setting the $schema property to the following URI in your manifest.json:
 
+<!-- x-release-please-start-version -->
+
 ```
 https://raw.githubusercontent.com/kintone/js-sdk/%40kintone/plugin-manifest-validator%4011.1.0/packages/plugin-manifest-validator/manifest-schema.json
 ```
+
+<!-- x-release-please-end -->
 
 Note: Add or update the $schema property at the top of the manifest.json.
 

--- a/packages/plugin-manifest-validator/README.md
+++ b/packages/plugin-manifest-validator/README.md
@@ -64,7 +64,7 @@ We recommend setting the $schema property to the following URI in your manifest.
 <!-- x-release-please-start-version -->
 
 ```
-https://raw.githubusercontent.com/kintone/js-sdk/%40kintone/plugin-manifest-validator%4011.1.0/packages/plugin-manifest-validator/manifest-schema.json
+https://raw.githubusercontent.com/kintone/js-sdk/%40kintone/plugin-manifest-validator%4011.1.1/packages/plugin-manifest-validator/manifest-schema.json
 ```
 
 <!-- x-release-please-end -->

--- a/packages/plugin-manifest-validator/examples/manifest.json
+++ b/packages/plugin-manifest-validator/examples/manifest.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/kintone/js-sdk/%40kintone/plugin-manifest-validator%4011.1.0/packages/plugin-manifest-validator/manifest-schema.json",
+  "$schema": "https://raw.githubusercontent.com/kintone/js-sdk/%40kintone/plugin-manifest-validator%4011.1.1/packages/plugin-manifest-validator/manifest-schema.json",
   "manifest_version": 1,
   "version": 1,
   "type": "APP",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -31,7 +31,8 @@
     },
     "packages/plugin-manifest-validator": {
       "package-name": "@kintone/plugin-manifest-validator",
-      "component": "@kintone/plugin-manifest-validator"
+      "component": "@kintone/plugin-manifest-validator",
+      "extra-files": ["README.md"]
     },
     "packages/plugin-packer": {
       "package-name": "@kintone/plugin-packer",

--- a/renovate.json5
+++ b/renovate.json5
@@ -39,7 +39,27 @@
       },
     ],
   },
+  customManagers: [
+    {
+      // track plugin-manifest-validator version embedded in $schema URLs
+      customType: "regex",
+      fileMatch: [
+        "^packages/create-plugin/src/manifest\\.ts$",
+      ],
+      matchStrings: [
+        "plugin-manifest-validator%40(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)",
+      ],
+      depNameTemplate: "@kintone/plugin-manifest-validator",
+      datasourceTemplate: "npm",
+    },
+  ],
   "packageRules": [
+    {
+      // URL-embedded validator version bumps are chore: (don't trigger release-please)
+      matchPackageNames: ["@kintone/plugin-manifest-validator"],
+      matchManagers: ["custom.regex"],
+      semanticCommitType: "chore",
+    },
     {
       // runtime dependencies use bump strategy (update pinned versions)
       matchDepTypes: ["dependencies"],


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

release-please manages versions in `package.json` but cannot fully update version strings embedded in URLs (e.g. the `$schema` URL of the plugin manifest). As a result, URL references have drifted out of sync: while `plugin-manifest-validator` is at 11.1.1, the README / examples / create-plugin references still point to `11.1.0` / `10.2.0`. This PR automates the catch-up so the URLs always track the current version on future releases.

## What

<!-- What is a solution you want to add? -->

- `plugin-manifest-validator/README.md`: wrap the `$schema` URL code block with `x-release-please-start-version` / `x-release-please-end` markers and add `README.md` to the validator's `extra-files` in `release-please-config.json` so release-please rewrites the embedded version on bump.
- `.github/workflows/release.yml`: whenever release-please creates or updates the release PR, run a 3-step sync (resolve PR branch → checkout → sed + `chore:` commit + push) that patches the `$schema` URL in `packages/plugin-manifest-validator/examples/manifest.json` to the new validator version. This is needed because release-please's `extra-files` cannot replace a version substring inside a JSON URL value.
- `renovate.json5`: add a `customManagers` regex entry that tracks the URL-embedded `@kintone/plugin-manifest-validator` version in `packages/create-plugin/src/manifest.ts` against the npm datasource, plus a `packageRules` entry that forces the update PR to use a `chore:` prefix so release-please does not bump in response.
- Manually update four files that were pinned to stale versions to `11.1.1` (the validator's README and examples, and create-plugin's `src/manifest.ts` and `src/__tests__/fixtures/manifest.json`).

## How to test

<!-- How can we test this pull request? -->

- release.yml sync step runs only when release-please creates/updates the release PR. Verify on the next release PR that `$schema` in `packages/plugin-manifest-validator/examples/manifest.json` matches the released validator version.
- renovate customManager: dry-run from the Renovate dashboard against this branch to confirm the URL-embedded version in `create-plugin/src/manifest.ts` is detected.
- README marker: run release-please in dry-run mode to confirm the URL version is rewritten on bump.

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory. (`pnpm lint` fails in `packages/rest` because of missing build artifacts — unrelated to these changes.)
