### PR TITLE
feat(plugin-manifest-validator): add sandbox manifest fields (sandbox / allowed_hosts / permissions)

### DIFF
--- a/packages/plugin-manifest-validator/manifest-schema.d.ts
+++ b/packages/plugin-manifest-validator/manifest-schema.d.ts
@@ -66,4 +66,10 @@ export interface KintonePluginManifestJson {
     css?: Resources;
     required_params?: string[];
   };
+  sandbox?: boolean;
+  allowed_hosts?: string[];
+  permissions?: {
+    js_api?: string[];
+    rest_api?: string[];
+  };
 }

--- a/packages/plugin-manifest-validator/manifest-schema.d.ts
+++ b/packages/plugin-manifest-validator/manifest-schema.d.ts
@@ -69,7 +69,7 @@ export interface KintonePluginManifestJson {
   sandbox?: boolean;
   allowed_hosts?: string[];
   /**
-   * Controls cross-domain access scope inside cybozu products (kintone.api / kintone.proxy). Defaults to "SELF" when omitted.
+   * Cross-domain access scope inside cybozu products. Defaults to "SELF".
    */
   allowed_domains?: "SELF" | "ANY";
   permissions?: {

--- a/packages/plugin-manifest-validator/manifest-schema.d.ts
+++ b/packages/plugin-manifest-validator/manifest-schema.d.ts
@@ -68,6 +68,10 @@ export interface KintonePluginManifestJson {
   };
   sandbox?: boolean;
   allowed_hosts?: string[];
+  /**
+   * Controls cross-domain access scope inside cybozu products (kintone.api / kintone.proxy). Defaults to "SELF" when omitted.
+   */
+  allowed_domains?: "SELF" | "ANY";
   permissions?: {
     js_api?: string[];
     rest_api?: string[];

--- a/packages/plugin-manifest-validator/manifest-schema.json
+++ b/packages/plugin-manifest-validator/manifest-schema.json
@@ -379,9 +379,57 @@
           }
         }
       }
+    },
+    "sandbox": {
+      "type": "boolean"
+    },
+    "allowed_hosts": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Either a bare \"*\" that matches any host, or a URI with a scheme (e.g. https://example.com). Domain-specific rules (IP literal rejection, cybozu domain exclusion, etc.) are enforced by kintone itself.",
+        "anyOf": [{ "const": "*" }, { "format": "uri" }]
+      }
+    },
+    "permissions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "js_api": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "rest_api": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
     }
   },
   "required": ["manifest_version", "version", "type", "name", "icon"],
+  "allOf": [
+    {
+      "if": {
+        "required": ["sandbox"],
+        "properties": {
+          "sandbox": { "const": true }
+        }
+      },
+      "then": {
+        "required": ["allowed_hosts", "permissions"]
+      }
+    }
+  ],
   "definitions": {
     "resources": {
       "$id": "#resources",

--- a/packages/plugin-manifest-validator/manifest-schema.json
+++ b/packages/plugin-manifest-validator/manifest-schema.json
@@ -389,13 +389,13 @@
       "items": {
         "type": "string",
         "minLength": 1,
-        "description": "Either a bare \"*\" that matches any host, or a URI with a scheme (e.g. https://example.com). Domain-specific rules (IP literal rejection, cybozu domain exclusion, etc.) are enforced by kintone itself.",
+        "description": "Either \"*\" or a URI with a scheme. Domain-level rules are enforced by kintone.",
         "anyOf": [{ "const": "*" }, { "format": "uri" }]
       }
     },
     "allowed_domains": {
       "type": "string",
-      "description": "Controls cross-domain access scope inside cybozu products (kintone.api / kintone.proxy). Defaults to \"SELF\" when omitted.",
+      "description": "Cross-domain access scope inside cybozu products. Defaults to \"SELF\".",
       "enum": ["SELF", "ANY"]
     },
     "permissions": {

--- a/packages/plugin-manifest-validator/manifest-schema.json
+++ b/packages/plugin-manifest-validator/manifest-schema.json
@@ -393,6 +393,11 @@
         "anyOf": [{ "const": "*" }, { "format": "uri" }]
       }
     },
+    "allowed_domains": {
+      "type": "string",
+      "description": "Controls cross-domain access scope inside cybozu products (kintone.api / kintone.proxy). Defaults to \"SELF\" when omitted.",
+      "enum": ["SELF", "ANY"]
+    },
     "permissions": {
       "type": "object",
       "additionalProperties": false,

--- a/packages/plugin-manifest-validator/script/generate-dts.ts
+++ b/packages/plugin-manifest-validator/script/generate-dts.ts
@@ -2,9 +2,20 @@ import fs from "fs";
 import { compile } from "json-schema-to-typescript";
 import schema from "../manifest-schema.json";
 
-const schemaWithoutAnyOf = schema as any;
-delete schemaWithoutAnyOf.definitions.resources.items.anyOf;
+// json-schema-to-typescript expands `allOf` / `anyOf` into loose
+// `{ [k: string]: unknown }` index signatures; strip them from a clone so
+// the runtime validator still sees the original.
+const schemaForDts = structuredClone(schema) as any;
 
-compile(schemaWithoutAnyOf, "manifest-schema.json").then((dts) =>
+// `resources.items` uses anyOf to allow string-or-array forms.
+delete schemaForDts.definitions.resources.items.anyOf;
+
+// Top-level allOf encodes the `sandbox:true` → required(allowed_hosts, permissions) rule.
+delete schemaForDts.allOf;
+
+// `allowed_hosts.items` uses anyOf to allow `"*"` or a URI string.
+delete schemaForDts.properties.allowed_hosts.items.anyOf;
+
+compile(schemaForDts, "manifest-schema.json").then((dts) =>
   fs.writeFileSync("manifest-schema.d.ts", dts),
 );

--- a/packages/plugin-manifest-validator/src/__tests__/index.ts
+++ b/packages/plugin-manifest-validator/src/__tests__/index.ts
@@ -660,6 +660,51 @@ describe("validator", () => {
     });
   });
 
+  describe("allowed_domains", () => {
+    it.each(["SELF", "ANY"])("accepts enum value: %s", (value) => {
+      assert.deepStrictEqual(validator(json({ allowed_domains: value })), {
+        valid: true,
+        errors: null,
+        warnings: null,
+      });
+    });
+
+    it("rejects unknown enum value", () => {
+      const actual = validator(json({ allowed_domains: "OTHERS" }));
+      assert(actual.valid === false);
+      assert(
+        actual.errors?.some(
+          (e) => e.keyword === "enum" && e.instancePath === "/allowed_domains",
+        ),
+      );
+    });
+
+    it("rejects non-string", () => {
+      const actual = validator(
+        json({ allowed_domains: 1 } as Record<string, any>),
+      );
+      assert(actual.valid === false);
+      assert(
+        actual.errors?.some(
+          (e) => e.keyword === "type" && e.instancePath === "/allowed_domains",
+        ),
+      );
+    });
+
+    it("does not require allowed_domains when sandbox is true", () => {
+      assert.deepStrictEqual(
+        validator(
+          json({
+            sandbox: true,
+            allowed_hosts: [],
+            permissions: {},
+          }),
+        ),
+        { valid: true, errors: null, warnings: null },
+      );
+    });
+  });
+
   describe("permissions", () => {
     it("accepts js_api and rest_api arrays", () => {
       assert.deepStrictEqual(

--- a/packages/plugin-manifest-validator/src/__tests__/index.ts
+++ b/packages/plugin-manifest-validator/src/__tests__/index.ts
@@ -553,6 +553,163 @@ describe("validator", () => {
     );
   });
 
+  describe("sandbox", () => {
+    it("accepts boolean false", () => {
+      assert.deepStrictEqual(validator(json({ sandbox: false })), {
+        valid: true,
+        errors: null,
+        warnings: null,
+      });
+    });
+
+    it("rejects non-boolean", () => {
+      const actual = validator(json({ sandbox: "yes" }));
+      assert(actual.valid === false);
+      assert(actual.errors?.length === 1);
+      assert.strictEqual(actual.errors[0].instancePath, "/sandbox");
+      assert.strictEqual(actual.errors[0].keyword, "type");
+    });
+
+    it("requires allowed_hosts and permissions when sandbox is true", () => {
+      const actual = validator(json({ sandbox: true }));
+      assert(actual.valid === false);
+      const missing = (actual.errors ?? [])
+        .filter((e) => e.keyword === "required")
+        .map((e) => (e.params as { missingProperty?: string }).missingProperty);
+      assert(missing.includes("allowed_hosts"));
+      assert(missing.includes("permissions"));
+    });
+
+    it("accepts sandbox:true with allowed_hosts and permissions present", () => {
+      assert.deepStrictEqual(
+        validator(
+          json({
+            sandbox: true,
+            allowed_hosts: [],
+            permissions: {},
+          }),
+        ),
+        { valid: true, errors: null, warnings: null },
+      );
+    });
+
+    it("does not require allowed_hosts/permissions when sandbox is false", () => {
+      assert.deepStrictEqual(validator(json({ sandbox: false })), {
+        valid: true,
+        errors: null,
+        warnings: null,
+      });
+    });
+  });
+
+  describe("allowed_hosts", () => {
+    // Validator only enforces "structure / type / length / simple format".
+    // Domain-specific URL rules (IP literal rejection, trailing-slash-only
+    // rejection, cybozu domain exclusion, etc.) are kintone's job.
+    it("accepts empty array", () => {
+      assert.deepStrictEqual(validator(json({ allowed_hosts: [] })), {
+        valid: true,
+        errors: null,
+        warnings: null,
+      });
+    });
+
+    it("accepts wildcard", () => {
+      assert.deepStrictEqual(validator(json({ allowed_hosts: ["*"] })), {
+        valid: true,
+        errors: null,
+        warnings: null,
+      });
+    });
+
+    it.each([
+      "https://example.com",
+      "https://example.com/api/*",
+      "https://example.com/file.html",
+      "wss://example.com",
+      "https://192.168.0.1",
+      "https://example.com/",
+      "ftp://example.com",
+    ])("accepts URI-form host: %s", (host) => {
+      assert.deepStrictEqual(validator(json({ allowed_hosts: [host] })), {
+        valid: true,
+        errors: null,
+        warnings: null,
+      });
+    });
+
+    it.each([
+      ["missing scheme", "example.com"],
+      ["empty string", ""],
+    ])("rejects non-URI host (%s): %s", (_desc, host) => {
+      const actual = validator(json({ allowed_hosts: [host] }));
+      assert(actual.valid === false);
+      assert(actual.errors !== null);
+    });
+
+    it("rejects non-string entries", () => {
+      const actual = validator(
+        json({ allowed_hosts: [123] } as Record<string, any>),
+      );
+      assert(actual.valid === false);
+      assert(
+        actual.errors?.some(
+          (e) => e.keyword === "type" && e.instancePath === "/allowed_hosts/0",
+        ),
+      );
+    });
+  });
+
+  describe("permissions", () => {
+    it("accepts js_api and rest_api arrays", () => {
+      assert.deepStrictEqual(
+        validator(
+          json({
+            permissions: {
+              js_api: ["app:read", "network:connect"],
+              rest_api: ["app_record:read", "file:write"],
+            },
+          }),
+        ),
+        { valid: true, errors: null, warnings: null },
+      );
+    });
+
+    it("accepts empty arrays", () => {
+      assert.deepStrictEqual(
+        validator(json({ permissions: { js_api: [], rest_api: [] } })),
+        { valid: true, errors: null, warnings: null },
+      );
+    });
+
+    it("rejects unknown property", () => {
+      const actual = validator(
+        json({ permissions: { unknown: [] } } as Record<string, any>),
+      );
+      assert(actual.valid === false);
+      assert(
+        actual.errors?.some(
+          (e) =>
+            e.keyword === "additionalProperties" &&
+            e.instancePath === "/permissions",
+        ),
+      );
+    });
+
+    it("rejects non-string entries", () => {
+      const actual = validator(
+        json({ permissions: { js_api: [123] } } as Record<string, any>),
+      );
+      assert(actual.valid === false);
+      assert(
+        actual.errors?.some(
+          (e) =>
+            e.keyword === "type" && e.instancePath === "/permissions/js_api/0",
+        ),
+      );
+    });
+  });
+
   describe("validate required properties", () => {
     it.each`
       languageCode | name

--- a/packages/plugin-manifest-validator/src/__tests__/index.ts
+++ b/packages/plugin-manifest-validator/src/__tests__/index.ts
@@ -593,8 +593,8 @@ describe("validator", () => {
       );
     });
 
-    it("does not require allowed_hosts/permissions when sandbox is false", () => {
-      assert.deepStrictEqual(validator(json({ sandbox: false })), {
+    it("does not require allowed_hosts/permissions when sandbox is omitted", () => {
+      assert.deepStrictEqual(validator(json({})), {
         valid: true,
         errors: null,
         warnings: null,
@@ -655,6 +655,21 @@ describe("validator", () => {
       assert(
         actual.errors?.some(
           (e) => e.keyword === "type" && e.instancePath === "/allowed_hosts/0",
+        ),
+      );
+    });
+
+    it("rejects duplicated entries", () => {
+      const actual = validator(
+        json({
+          allowed_hosts: ["https://example.com", "https://example.com"],
+        }),
+      );
+      assert(actual.valid === false);
+      assert(
+        actual.errors?.some(
+          (e) =>
+            e.keyword === "uniqueItems" && e.instancePath === "/allowed_hosts",
         ),
       );
     });
@@ -753,6 +768,23 @@ describe("validator", () => {
         ),
       );
     });
+
+    it.each(["js_api", "rest_api"] as const)(
+      "rejects duplicated entries in %s",
+      (key) => {
+        const actual = validator(
+          json({ permissions: { [key]: ["app:read", "app:read"] } }),
+        );
+        assert(actual.valid === false);
+        assert(
+          actual.errors?.some(
+            (e) =>
+              e.keyword === "uniqueItems" &&
+              e.instancePath === `/permissions/${key}`,
+          ),
+        );
+      },
+    );
   });
 
   describe("validate required properties", () => {

--- a/packages/plugin-manifest-validator/src/index.ts
+++ b/packages/plugin-manifest-validator/src/index.ts
@@ -73,6 +73,9 @@ export default (
       "relative-path": relativePath,
     },
   });
+  // ajv-formats "fast" mode is intentional: allowed_hosts only enforces a
+  // structural URI shape. Stricter URL validity, IP-literal rejection, etc.
+  // are handled by kintone at runtime, not by this validator.
   addFormats(ajv, { mode: "fast", formats: ["uri"] });
 
   const validateMaxFileSize: SchemaValidateFunction = (


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

Add three optional manifest fields (`sandbox`, `allowed_hosts`, `permissions`) to Manifest v1 so that the validator recognizes sandbox-aware plugin manifests.

## What

- `manifest-schema.json`: add three optional properties to Manifest v1:
  - `sandbox: boolean`
  - `allowed_hosts: string[]` — each item is either `"*"` or a URI (AJV stock `format: "uri"`)
  - `permissions: { js_api?: string[]; rest_api?: string[] }`
- Make `allowed_hosts` and `permissions` required when `sandbox: true` via a top-level `allOf` + `if/then`.
- `script/generate-dts.ts`: deep-clone the schema with `structuredClone` before stripping `allOf` / `anyOf` so that the imported schema object is not mutated and the runtime validator still sees the original schema. Strip the two new `anyOf` / `allOf` sites so the generated `.d.ts` does not degrade to `{ [k: string]: unknown }` index-signature types.
- `manifest-schema.d.ts`: regenerated.
- Tests: add cases for `sandbox` (type / required branch), `allowed_hosts` (empty / wildcard / URI / non-URI / non-string), and `permissions` (arrays / empty / unknown key / non-string entries).

## How to test

- `pnpm build`
- `pnpm test` (108 passed)
- `pnpm lint`
- `pnpm prettier --check`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.