### PR TITLE
chore(ci): remove unused id-token: write and pnpm cache from release

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
       - uses: Kesin11/actions-timeline@da70beff098ff89b15d279e8bf2f60519a8dadd7 # v2
       - name: Check out repository

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
       - uses: Kesin11/actions-timeline@da70beff098ff89b15d279e8bf2f60519a8dadd7 # v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,12 +90,6 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-        # To avoid setup-node cache failure.
-        # ref. https://github.com/actions/setup-node/issues/1137
-      - name: create pnpm cache directory
-        shell: bash
-        run: mkdir -vp $(pnpm store path --silent)
 
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
-      id-token: write
 
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
-      id-token: write
 
     strategy:
       matrix:


### PR DESCRIPTION
## 概要

[TanStack の npm サプライチェーン侵害事案（2026-05-11）](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem) と同型の攻撃ベクトルを緩和する予防的なハードニング。本リポジトリで侵害痕跡（IOC）は検出されていない。

TanStack 事案は以下3つの脆弱性を連鎖させた攻撃だった:
1. `pull_request_target` ワークフローで fork のコードが実行される（Pwn Request）
2. **PR ↔ release ワークフロー間で GitHub Actions キャッシュが汚染される**
3. **`id-token: write` を持つランナーから OIDC トークンが抽出される**

このPRでは項目 2 と 3 の経路を遮断する。

## 変更内容

- **`release.yml` の publish ジョブから `cache: "pnpm"` を削除。** リリース頻度は低くキャッシュの恩恵は小さい一方、`cache: "pnpm"` を有効にすると `setup-node` は `pnpm-lock.yaml` のハッシュからキャッシュキーを導出する。これにより悪意ある fork PR がキャッシュを汚染した場合、次の `release.yml` 実行（main 上）が汚染キャッシュを復元してから `pnpm install --frozen-lockfile && pnpm build && pnpm publish` を走らせるという経路が成立してしまう。キャッシュを使わなければこの経路自体が消える。あわせて、古い setup-node のキャッシュ不具合回避用だった `mkdir` ステップも不要になったため削除。
- **publish 以外のジョブから `id-token: write` を削除**（`test.yml`, `test-e2e.yml`, `lint.yml`, `license.yml`）。これらのジョブは OIDC を使わない。最小権限の原則に従い、`release.yml` の publish ジョブのみ `id-token: write` を残す（npm Trusted Publishing と provenance に必須）。

## Trusted Publishing を使っていてもなぜ重要か

Trusted Publishing なので長期 `NODE_AUTH_TOKEN` の窃取リスクはない。しかしキャッシュ汚染攻撃はトークンを盗む必要がない — release ランナー上で `pnpm install` / `pnpm build` 中に悪意あるコードを実行させれば、`pnpm publish` がそのコードを正規の OIDC トークンで npm に公開してしまう。キャッシュを切ればこの連鎖が断たれる。

## テスト方針

- [ ] このPRで test, test-e2e, lint, license の各ワークフローを再実行し、権限を絞った状態でもパスすることを確認
- [ ] マージ後、次のリリースで publish 挙動にリグレッションがないか監視