### PR TITLE
chore(plugin-manifest-validator): sign release sync commits and fix README schema URL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,44 +73,64 @@ jobs:
             "packages/plugin-manifest-validator/README.md"
           )
 
-          additions=$(
-            for f in "${targets[@]}"; do
-              sed -i -E "s|(plugin-manifest-validator%40)[0-9]+\.[0-9]+\.[0-9]+|\1${new_version}|g" "$f"
-              if ! git diff --quiet -- "$f"; then
-                jq -n --arg path "$f" --arg content "$(base64 -w0 "$f")" \
-                  '{path: $path, contents: $content}'
-              fi
-            done | jq -s .
-          )
+          # release-please may force-push the release PR branch concurrently,
+          # which invalidates `expectedHeadOid`. Refresh the working tree from
+          # origin, re-apply the sed, and retry up to MAX_ATTEMPTS times.
+          MAX_ATTEMPTS=3
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            git fetch origin "$BRANCH"
+            git reset --hard "origin/${BRANCH}"
 
-          if [[ "$(jq 'length' <<<"$additions")" == "0" ]]; then
-            echo "URLs already point to ${new_version}; nothing to sync"
-            exit 0
-          fi
+            additions=$(
+              for f in "${targets[@]}"; do
+                sed -i -E "s|(plugin-manifest-validator%40)[0-9]+\.[0-9]+\.[0-9]+|\1${new_version}|g" "$f"
+                if ! git diff --quiet -- "$f"; then
+                  jq -n --arg path "$f" --arg content "$(base64 -w0 "$f")" \
+                    '{path: $path, contents: $content}'
+                fi
+              done | jq -s .
+            )
 
-          # `gh api graphql -F input=@file` sends the variable as a JSON
-          # *string*, which won't coerce to CreateCommitOnBranchInput!.
-          # Build the full {query, variables} body and pass via --input.
-          jq -n \
-            --arg query 'mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { url } } }' \
-            --arg repo "$REPO_NWO" \
-            --arg branch "$BRANCH" \
-            --arg msg "chore: sync plugin-manifest-validator schema URLs to ${new_version}" \
-            --arg oid "$(git rev-parse HEAD)" \
-            --argjson additions "$additions" \
-            '{
-              query: $query,
-              variables: {
-                input: {
-                  branch: {repositoryNameWithOwner: $repo, branchName: $branch},
-                  message: {headline: $msg},
-                  fileChanges: {additions: $additions},
-                  expectedHeadOid: $oid
+            if [[ "$(jq 'length' <<<"$additions")" == "0" ]]; then
+              echo "URLs already point to ${new_version}; nothing to sync"
+              exit 0
+            fi
+
+            # `gh api graphql -F input=@file` sends the variable as a JSON
+            # *string*, which won't coerce to CreateCommitOnBranchInput!.
+            # Build the full {query, variables} body and pass via --input.
+            jq -n \
+              --arg query 'mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { url } } }' \
+              --arg repo "$REPO_NWO" \
+              --arg branch "$BRANCH" \
+              --arg msg "chore: sync plugin-manifest-validator schema URLs to ${new_version}" \
+              --arg oid "$(git rev-parse HEAD)" \
+              --argjson additions "$additions" \
+              '{
+                query: $query,
+                variables: {
+                  input: {
+                    branch: {repositoryNameWithOwner: $repo, branchName: $branch},
+                    message: {headline: $msg},
+                    fileChanges: {additions: $additions},
+                    expectedHeadOid: $oid
+                  }
                 }
-              }
-            }' > "${RUNNER_TEMP}/sync-request.json"
+              }' > "${RUNNER_TEMP}/sync-request.json"
 
-          gh api graphql --input "${RUNNER_TEMP}/sync-request.json"
+            if gh api graphql --input "${RUNNER_TEMP}/sync-request.json" 2> "${RUNNER_TEMP}/sync-error.log"; then
+              exit 0
+            fi
+
+            cat "${RUNNER_TEMP}/sync-error.log"
+            if grep -q "Expected.*head.*oid" "${RUNNER_TEMP}/sync-error.log" && [[ "$attempt" -lt "$MAX_ATTEMPTS" ]]; then
+              echo "expectedHeadOid mismatch on attempt ${attempt}; refreshing and retrying"
+              continue
+            fi
+            echo "createCommitOnBranch failed on attempt ${attempt}. current branch tip:"
+            gh api "repos/${REPO_NWO}/branches/${BRANCH}" --jq '.commit.sha' || true
+            exit 1
+          done
 
   publish:
     name: Publish to npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,12 @@ jobs:
         with:
           token: ${{ steps.create-iat.outputs.token }}
 
-      # release-please's extra-files cannot replace a version substring inside
-      # a URL (jsonpath replaces the whole field), so patch the release PR
-      # directly whenever release-please creates/updates it.
+      # release-please's extra-files cannot reliably replace a version
+      # substring embedded in a URL: the inline regex greedy-matches
+      # "%40<digits>" and strips the encoded "@", and the jsonpath strategy
+      # replaces the whole field. Patch the release PR directly via the
+      # GraphQL createCommitOnBranch mutation so the resulting commit is
+      # server-side signed (verified).
       - name: Resolve release PR branch
         id: sync-prep
         if: ${{ steps.release.outputs.pr }}
@@ -53,25 +56,51 @@ jobs:
           token: ${{ steps.create-iat.outputs.token }}
           path: _sync
 
-      - name: Sync plugin-manifest-validator examples/manifest.json
+      - name: Sync plugin-manifest-validator schema URLs
         if: ${{ steps.release.outputs.pr }}
         working-directory: _sync
+        env:
+          GH_TOKEN: ${{ steps.create-iat.outputs.token }}
+          BRANCH: ${{ steps.sync-prep.outputs.branch }}
+          REPO_NWO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          target="packages/plugin-manifest-validator/examples/manifest.json"
           new_version=$(jq -r '."packages/plugin-manifest-validator"' .release-please-manifest.json)
+          targets=(
+            "packages/plugin-manifest-validator/examples/manifest.json"
+            "packages/plugin-manifest-validator/README.md"
+          )
 
-          sed -i -E "s|(plugin-manifest-validator%40)[0-9]+\.[0-9]+\.[0-9]+|\1${new_version}|g" "$target"
+          additions='[]'
+          for f in "${targets[@]}"; do
+            sed -i -E "s|(plugin-manifest-validator%40)[0-9]+\.[0-9]+\.[0-9]+|\1${new_version}|g" "$f"
+            if ! git diff --quiet -- "$f"; then
+              additions=$(jq --arg path "$f" --arg content "$(base64 -w0 "$f")" \
+                '. + [{path: $path, contents: $content}]' <<<"$additions")
+            fi
+          done
 
-          if git diff --quiet -- "$target"; then
-            echo "URL already points to ${new_version}; nothing to sync"
+          if [[ "$(jq 'length' <<<"$additions")" == "0" ]]; then
+            echo "URLs already point to ${new_version}; nothing to sync"
             exit 0
           fi
 
-          git -c user.name="release-please-bot" \
-              -c user.email="release-please-bot@users.noreply.github.com" \
-              commit -am "chore: sync examples/manifest.json to @kintone/plugin-manifest-validator@${new_version}"
-          git push
+          jq -n \
+            --arg repo "$REPO_NWO" \
+            --arg branch "$BRANCH" \
+            --arg msg "chore: sync plugin-manifest-validator schema URLs to ${new_version}" \
+            --arg oid "$(git rev-parse HEAD)" \
+            --argjson additions "$additions" \
+            '{
+              branch: {repositoryNameWithOwner: $repo, branchName: $branch},
+              message: {headline: $msg},
+              fileChanges: {additions: $additions},
+              expectedHeadOid: $oid
+            }' > "${RUNNER_TEMP}/sync-input.json"
+
+          gh api graphql \
+            -F input=@"${RUNNER_TEMP}/sync-input.json" \
+            -f query='mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { url } } }'
 
   publish:
     name: Publish to npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,17 @@ jobs:
       - run: npm install -g npm@latest
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
+      - name: DEBUG working tree state before publish
+        run: |
+          echo "::group::git status"
+          git status
+          echo "::endgroup::"
+          echo "::group::git diff"
+          git diff
+          echo "::endgroup::"
+          echo "::group::git diff --stat"
+          git diff --stat
+          echo "::endgroup::"
       - run: pnpm -r publish --access public --registry https://registry.npmjs.org/
         env:
           NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,7 @@ jobs:
       # digits of the version. The jsonpath strategy meanwhile replaces
       # the whole field. Patch the release PR directly via the GraphQL
       # createCommitOnBranch mutation so the resulting commit is signed
-      # by GitHub server-side (verified). The commit author becomes the
-      # App identity used for `create-github-app-token`, not the prior
-      # hardcoded `release-please-bot`.
+      # by GitHub server-side (verified).
       - name: Resolve release PR branch
         id: sync-prep
         if: ${{ steps.release.outputs.pr }}
@@ -75,14 +73,15 @@ jobs:
             "packages/plugin-manifest-validator/README.md"
           )
 
-          additions='[]'
-          for f in "${targets[@]}"; do
-            sed -i -E "s|(plugin-manifest-validator%40)[0-9]+\.[0-9]+\.[0-9]+|\1${new_version}|g" "$f"
-            if ! git diff --quiet -- "$f"; then
-              additions=$(jq --arg path "$f" --arg content "$(base64 -w0 "$f")" \
-                '. + [{path: $path, contents: $content}]' <<<"$additions")
-            fi
-          done
+          additions=$(
+            for f in "${targets[@]}"; do
+              sed -i -E "s|(plugin-manifest-validator%40)[0-9]+\.[0-9]+\.[0-9]+|\1${new_version}|g" "$f"
+              if ! git diff --quiet -- "$f"; then
+                jq -n --arg path "$f" --arg content "$(base64 -w0 "$f")" \
+                  '{path: $path, contents: $content}'
+              fi
+            done | jq -s .
+          )
 
           if [[ "$(jq 'length' <<<"$additions")" == "0" ]]; then
             echo "URLs already point to ${new_version}; nothing to sync"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,15 @@ jobs:
           token: ${{ steps.create-iat.outputs.token }}
 
       # release-please's extra-files cannot reliably replace a version
-      # substring embedded in a URL: the inline regex greedy-matches
-      # "%40<digits>" and strips the encoded "@", and the jsonpath strategy
-      # replaces the whole field. Patch the release PR directly via the
-      # GraphQL createCommitOnBranch mutation so the resulting commit is
-      # server-side signed (verified).
+      # substring embedded in a URL: the default version regex
+      # `[0-9]+\.[0-9]+\.[0-9]+` has no boundary anchor, so it consumes
+      # the `40` of an encoded `%40` (URL-encoded `@`) as the leading
+      # digits of the version. The jsonpath strategy meanwhile replaces
+      # the whole field. Patch the release PR directly via the GraphQL
+      # createCommitOnBranch mutation so the resulting commit is signed
+      # by GitHub server-side (verified). The commit author becomes the
+      # App identity used for `create-github-app-token`, not the prior
+      # hardcoded `release-please-bot`.
       - name: Resolve release PR branch
         id: sync-prep
         if: ${{ steps.release.outputs.pr }}
@@ -85,22 +89,29 @@ jobs:
             exit 0
           fi
 
+          # `gh api graphql -F input=@file` sends the variable as a JSON
+          # *string*, which won't coerce to CreateCommitOnBranchInput!.
+          # Build the full {query, variables} body and pass via --input.
           jq -n \
+            --arg query 'mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { url } } }' \
             --arg repo "$REPO_NWO" \
             --arg branch "$BRANCH" \
             --arg msg "chore: sync plugin-manifest-validator schema URLs to ${new_version}" \
             --arg oid "$(git rev-parse HEAD)" \
             --argjson additions "$additions" \
             '{
-              branch: {repositoryNameWithOwner: $repo, branchName: $branch},
-              message: {headline: $msg},
-              fileChanges: {additions: $additions},
-              expectedHeadOid: $oid
-            }' > "${RUNNER_TEMP}/sync-input.json"
+              query: $query,
+              variables: {
+                input: {
+                  branch: {repositoryNameWithOwner: $repo, branchName: $branch},
+                  message: {headline: $msg},
+                  fileChanges: {additions: $additions},
+                  expectedHeadOid: $oid
+                }
+              }
+            }' > "${RUNNER_TEMP}/sync-request.json"
 
-          gh api graphql \
-            -F input=@"${RUNNER_TEMP}/sync-input.json" \
-            -f query='mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { url } } }'
+          gh api graphql --input "${RUNNER_TEMP}/sync-request.json"
 
   publish:
     name: Publish to npm

--- a/packages/plugin-manifest-validator/README.md
+++ b/packages/plugin-manifest-validator/README.md
@@ -61,13 +61,9 @@ let manifest: KintonePluginManifestJson;
 When you are configuring your project, you would better set the $schema property. This property should point to a schema file that validates your manifest.
 We recommend setting the $schema property to the following URI in your manifest.json:
 
-<!-- x-release-please-start-version -->
-
 ```
 https://raw.githubusercontent.com/kintone/js-sdk/%40kintone/plugin-manifest-validator%4011.1.1/packages/plugin-manifest-validator/manifest-schema.json
 ```
-
-<!-- x-release-please-end -->
 
 Note: Add or update the $schema property at the top of the manifest.json.
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -31,8 +31,7 @@
     },
     "packages/plugin-manifest-validator": {
       "package-name": "@kintone/plugin-manifest-validator",
-      "component": "@kintone/plugin-manifest-validator",
-      "extra-files": ["README.md"]
+      "component": "@kintone/plugin-manifest-validator"
     },
     "packages/plugin-packer": {
       "package-name": "@kintone/plugin-packer",


### PR DESCRIPTION
## Why

The release workflow has two issues we want to fix at the source rather than patching each release PR by hand:

1. The "sync examples/manifest.json" step uses `git commit && git push`, so the resulting commit is unsigned (verified ✗).
2. release-please's inline version regex `[0-9]+\.[0-9]+\.[0-9]+` has no boundary anchor, so the URL-encoded `@` (`%40`) in the README schema URL gets consumed as part of the version (e.g. `plugin-manifest-validator%4011.1.1` → `plugin-manifest-validator%11.2.0` on the next bump). The existing release PR #3770 already shows this broken state.

Separately, the most recent release run (#25645679117) failed with `ERR_PNPM_GIT_UNCLEAN` on `@kintone/plugin-manifest-validator@11.2.0` in the publish job. We need diagnostics before we can fix that one.

## What

- Replace the workflow's `git commit && git push` sync step with `gh api graphql createCommitOnBranch`, so GitHub signs the commit server-side (verified ✓).
- Include `packages/plugin-manifest-validator/README.md` in the same sync step, with an anchored regex `(plugin-manifest-validator%40)[0-9]+\.[0-9]+\.[0-9]+` so `%40` is no longer eaten as a version digit.
- Remove the `x-release-please-*` markers from the README and drop the now-unused `extra-files: ["README.md"]` from `release-please-config.json`. The workflow sync step becomes the single source of truth for that URL.
- Add a temporary debug step that dumps `git status` / `git diff` right before `pnpm -r publish` in the publish job, to investigate the `ERR_PNPM_GIT_UNCLEAN` failure. This commit should be reverted once we have a diagnosis.

Follow-up: after this merges, close PR #3770 and let release-please regenerate it from main — the new branch will be created from the corrected README.

## How to test

- Visual review of the workflow YAML.
- On the next release run, confirm the sync step rewrites `%40<digits>` in both `examples/manifest.json` and `README.md` without mangling `%40`, and that the resulting commit is verified.
- Inspect the new debug step's output on the next publish run to identify what dirties the working tree.

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required. (workflow-only change; validated on next release run)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.