### PR TITLE
chore(ci): remove debug step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,17 +184,6 @@ jobs:
       - run: npm install -g npm@latest
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
-      - name: DEBUG working tree state before publish
-        run: |
-          echo "::group::git status"
-          git status
-          echo "::endgroup::"
-          echo "::group::git diff"
-          git diff
-          echo "::endgroup::"
-          echo "::group::git diff --stat"
-          git diff --stat
-          echo "::endgroup::"
       - run: pnpm -r publish --access public --registry https://registry.npmjs.org/
         env:
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Why

The "DEBUG working tree state before publish" step was added temporarily to investigate the `ERR_PNPM_GIT_UNCLEAN` failure in the publish job. PR #3789 (`fix(ci): keep working tree clean when Takumi Guard configures registry`) addressed the root cause by keeping the tracked `.npmrc` untouched and configuring the registry via user-scoped config files. The debug step is no longer needed.

## What

Remove the `DEBUG working tree state before publish` step from `.github/workflows/release.yml`.

## How to test

- Verify the change is limited to removing the debug step in the publish job.
- The next release run will exercise the workflow end-to-end.

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.