### PR TITLE
fix(plugin-manifest-validator): remove allowed_domains from Manifest v1

### DIFF
--- a/packages/plugin-manifest-validator/manifest-schema.d.ts
+++ b/packages/plugin-manifest-validator/manifest-schema.d.ts
@@ -68,10 +68,6 @@ export interface KintonePluginManifestJson {
   };
   sandbox?: boolean;
   allowed_hosts?: string[];
-  /**
-   * Cross-domain access scope inside cybozu products. Defaults to "SELF".
-   */
-  allowed_domains?: "SELF" | "ANY";
   permissions?: {
     js_api?: string[];
     rest_api?: string[];

--- a/packages/plugin-manifest-validator/manifest-schema.json
+++ b/packages/plugin-manifest-validator/manifest-schema.json
@@ -393,11 +393,6 @@
         "anyOf": [{ "const": "*" }, { "format": "uri" }]
       }
     },
-    "allowed_domains": {
-      "type": "string",
-      "description": "Cross-domain access scope inside cybozu products. Defaults to \"SELF\".",
-      "enum": ["SELF", "ANY"]
-    },
     "permissions": {
       "type": "object",
       "additionalProperties": false,

--- a/packages/plugin-manifest-validator/src/__tests__/index.ts
+++ b/packages/plugin-manifest-validator/src/__tests__/index.ts
@@ -675,51 +675,6 @@ describe("validator", () => {
     });
   });
 
-  describe("allowed_domains", () => {
-    it.each(["SELF", "ANY"])("accepts enum value: %s", (value) => {
-      assert.deepStrictEqual(validator(json({ allowed_domains: value })), {
-        valid: true,
-        errors: null,
-        warnings: null,
-      });
-    });
-
-    it("rejects unknown enum value", () => {
-      const actual = validator(json({ allowed_domains: "OTHERS" }));
-      assert(actual.valid === false);
-      assert(
-        actual.errors?.some(
-          (e) => e.keyword === "enum" && e.instancePath === "/allowed_domains",
-        ),
-      );
-    });
-
-    it("rejects non-string", () => {
-      const actual = validator(
-        json({ allowed_domains: 1 } as Record<string, any>),
-      );
-      assert(actual.valid === false);
-      assert(
-        actual.errors?.some(
-          (e) => e.keyword === "type" && e.instancePath === "/allowed_domains",
-        ),
-      );
-    });
-
-    it("does not require allowed_domains when sandbox is true", () => {
-      assert.deepStrictEqual(
-        validator(
-          json({
-            sandbox: true,
-            allowed_hosts: [],
-            permissions: {},
-          }),
-        ),
-        { valid: true, errors: null, warnings: null },
-      );
-    });
-  });
-
   describe("permissions", () => {
     it("accepts js_api and rest_api arrays", () => {
       assert.deepStrictEqual(


### PR DESCRIPTION
## Why

Follow-up to #3759, which introduced `sandbox` / `allowed_hosts` / `allowed_domains` / `permissions` on Manifest v1. The kintone backend decided to drop `allowedDomains` from the spec, so the validator side removes `allowed_domains` accordingly to keep the schema aligned with what kintone actually accepts.

## What

Remove `allowed_domains` from `@kintone/plugin-manifest-validator` Manifest v1:

- `manifest-schema.json`: drop the `allowed_domains` property definition.
- `manifest-schema.d.ts`: drop `allowed_domains` from the generated type.
- `src/__tests__/index.ts`: drop the `allowed_domains` test cases.

`sandbox` / `allowed_hosts` / `permissions` are out of scope and remain.

## How to test

- `pnpm --filter @kintone/plugin-manifest-validator test`
- `pnpm --filter @kintone/plugin-manifest-validator build`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.