### PR TITLE
feat(plugin-manifest-validator): restructure permissions to array of {permission, scope?}

### DIFF
--- a/packages/plugin-manifest-validator/manifest-schema.d.ts
+++ b/packages/plugin-manifest-validator/manifest-schema.d.ts
@@ -69,7 +69,7 @@ export interface KintonePluginManifestJson {
   sandbox?: boolean;
   allowed_hosts?: string[];
   permissions?: {
-    js_api?: string[];
-    rest_api?: string[];
-  };
+    permission: string;
+    scope?: string;
+  }[];
 }

--- a/packages/plugin-manifest-validator/manifest-schema.json
+++ b/packages/plugin-manifest-validator/manifest-schema.json
@@ -394,21 +394,17 @@
       }
     },
     "permissions": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "js_api": {
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["permission"],
+        "properties": {
+          "permission": {
             "type": "string",
             "minLength": 1
-          }
-        },
-        "rest_api": {
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
+          },
+          "scope": {
             "type": "string",
             "minLength": 1
           }

--- a/packages/plugin-manifest-validator/src/__tests__/index.ts
+++ b/packages/plugin-manifest-validator/src/__tests__/index.ts
@@ -586,7 +586,7 @@ describe("validator", () => {
           json({
             sandbox: true,
             allowed_hosts: [],
-            permissions: {},
+            permissions: [],
           }),
         ),
         { valid: true, errors: null, warnings: null },
@@ -676,70 +676,115 @@ describe("validator", () => {
   });
 
   describe("permissions", () => {
-    it("accepts js_api and rest_api arrays", () => {
+    it("accepts an array of permission entries with and without scope", () => {
       assert.deepStrictEqual(
         validator(
           json({
-            permissions: {
-              js_api: ["app:read", "network:connect"],
-              rest_api: ["app_record:read", "file:write"],
-            },
+            permissions: [
+              { permission: "app:read" },
+              { permission: "network:connect" },
+              { permission: "app_record:read", scope: "self" },
+            ],
           }),
         ),
         { valid: true, errors: null, warnings: null },
       );
     });
 
-    it("accepts empty arrays", () => {
-      assert.deepStrictEqual(
-        validator(json({ permissions: { js_api: [], rest_api: [] } })),
-        { valid: true, errors: null, warnings: null },
+    it("accepts an empty array", () => {
+      assert.deepStrictEqual(validator(json({ permissions: [] })), {
+        valid: true,
+        errors: null,
+        warnings: null,
+      });
+    });
+
+    it("rejects the legacy object form", () => {
+      const actual = validator(
+        json({
+          permissions: {
+            js_api: ["app:read"],
+            rest_api: ["app_record:read"],
+          },
+        } as Record<string, any>),
+      );
+      assert(actual.valid === false);
+      assert(
+        actual.errors?.some(
+          (e) => e.keyword === "type" && e.instancePath === "/permissions",
+        ),
       );
     });
 
-    it("rejects unknown property", () => {
+    it("requires the permission property", () => {
       const actual = validator(
-        json({ permissions: { unknown: [] } } as Record<string, any>),
+        json({ permissions: [{ scope: "self" }] } as Record<string, any>),
+      );
+      assert(actual.valid === false);
+      assert(
+        actual.errors?.some(
+          (e) =>
+            e.keyword === "required" &&
+            e.instancePath === "/permissions/0" &&
+            (e.params as { missingProperty?: string }).missingProperty ===
+              "permission",
+        ),
+      );
+    });
+
+    it("rejects an empty permission string", () => {
+      const actual = validator(json({ permissions: [{ permission: "" }] }));
+      assert(actual.valid === false);
+      assert(
+        actual.errors?.some(
+          (e) =>
+            e.keyword === "minLength" &&
+            e.instancePath === "/permissions/0/permission",
+        ),
+      );
+    });
+
+    it("rejects an empty scope string", () => {
+      const actual = validator(
+        json({ permissions: [{ permission: "app:read", scope: "" }] }),
+      );
+      assert(actual.valid === false);
+      assert(
+        actual.errors?.some(
+          (e) =>
+            e.keyword === "minLength" &&
+            e.instancePath === "/permissions/0/scope",
+        ),
+      );
+    });
+
+    it("rejects unknown properties on an entry", () => {
+      const actual = validator(
+        json({
+          permissions: [{ permission: "app:read", unknown: true }],
+        } as Record<string, any>),
       );
       assert(actual.valid === false);
       assert(
         actual.errors?.some(
           (e) =>
             e.keyword === "additionalProperties" &&
-            e.instancePath === "/permissions",
+            e.instancePath === "/permissions/0",
         ),
       );
     });
 
-    it("rejects non-string entries", () => {
+    it("rejects non-object entries", () => {
       const actual = validator(
-        json({ permissions: { js_api: [123] } } as Record<string, any>),
+        json({ permissions: ["app:read"] } as Record<string, any>),
       );
       assert(actual.valid === false);
       assert(
         actual.errors?.some(
-          (e) =>
-            e.keyword === "type" && e.instancePath === "/permissions/js_api/0",
+          (e) => e.keyword === "type" && e.instancePath === "/permissions/0",
         ),
       );
     });
-
-    it.each(["js_api", "rest_api"] as const)(
-      "rejects duplicated entries in %s",
-      (key) => {
-        const actual = validator(
-          json({ permissions: { [key]: ["app:read", "app:read"] } }),
-        );
-        assert(actual.valid === false);
-        assert(
-          actual.errors?.some(
-            (e) =>
-              e.keyword === "uniqueItems" &&
-              e.instancePath === `/permissions/${key}`,
-          ),
-        );
-      },
-    );
   });
 
   describe("validate required properties", () => {


### PR DESCRIPTION
## Why

The `permissions` field distinguished `js_api` and `rest_api` and grouped permission strings under them. We want to flatten that distinction and let each permission optionally carry a `scope`, so the manifest can express per-permission scoping going forward.

## What

Restructure the manifest `permissions` field from the object form `{ js_api?: string[], rest_api?: string[] }` to an array of `{ permission: string, scope?: string }`.

- `manifest-schema.json`: `permissions` is now `type: array`; each item is an object with a required `permission` (string, `minLength: 1`) and an optional `scope` (string, `minLength: 1`), with `additionalProperties: false`. No `uniqueItems` / enum constraints for now (the `permission` / `scope` vocabulary is still under design).
- `sandbox: true` still requires `allowed_hosts` and `permissions`.
- `manifest-schema.d.ts`: regenerated to the new shape.

This is a **breaking change** to the manifest schema (object → array); semver major.

## How to test

- `pnpm --filter @kintone/plugin-manifest-validator test` → 113 passed, including a case asserting the legacy object form is now rejected.
- `pnpm --filter @kintone/plugin-manifest-validator build` → OK.

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
