### PR TITLE
chore: extend generator test timeout to 600s for Windows CI

### DIFF
--- a/packages/create-plugin/vitest.generator.config.ts
+++ b/packages/create-plugin/vitest.generator.config.ts
@@ -4,8 +4,8 @@ export default defineConfig({
   test: {
     include: ["src/__tests__/generator.test.ts"],
     environment: "node",
-    testTimeout: 300000,
-    hookTimeout: 300000,
+    testTimeout: 600000,
+    hookTimeout: 600000,
     globals: true,
   },
 });


### PR DESCRIPTION
## Why

`packages/create-plugin`'s `generator.test.ts` (minimum template) intermittently hits `Test timed out in 300000ms` on Windows / Node.js 24.x CI.

Example: https://github.com/kintone/js-sdk/actions/runs/26856622898/job/79202604342

The test runs `npm install` -> `npm run lint` -> `npm run build` against the generated plugin project, which is slow on Windows CI and flakily exceeds the 5-minute boundary. The same test's `hookTimeout` was previously extended in #3743 for the same reason.

## What

- Extend `testTimeout` / `hookTimeout` in `vitest.generator.config.ts` from 300000ms to 600000ms.

This is a CI timeout adjustment, not a code defect.

## How to test

- Re-run the `test` workflow on Windows / Node.js 24.x and confirm `pnpm test:ci` for `@kintone/create-plugin` passes without timing out.

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.