### PR TITLE
ci: use pull_request instead of pull_request_target

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-  - pull_request_target
+  - pull_request
 
 jobs:
   triage:

--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -1,7 +1,7 @@
 name: "Lint PR"
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited


### PR DESCRIPTION
## Why

`pull_request_target` runs in the context of the base repository (with write-scoped secrets), which is risky when combined with PRs from forks. This PR drops `pull_request_target` in favor of `pull_request`.

## What

- `.github/workflows/lint_pr.yml`: `pull_request_target` → `pull_request`
- `.github/workflows/labeler.yml`: `pull_request_target` → `pull_request`

Note on `labeler.yml`: it requires `pull-requests: write`. Under `pull_request`, PRs from forks get a read-only `GITHUB_TOKEN`, so auto-labeling on fork PRs may stop working. This is an accepted trade-off in favor of the security change. `lint_pr.yml` only needs read access, so it is unaffected.

## How to test

After this PR is opened, confirm that the Actions triggered by the `pull_request` event run as expected (PR title lint / labeler).

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed \`pnpm lint\` and \`pnpm test\` on the root directory.