### PR TITLE
fix(plugin-manifest-validator): migrate dev environment to ESM

### DIFF
--- a/packages/plugin-manifest-validator/babel.config.js
+++ b/packages/plugin-manifest-validator/babel.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-  presets: [
-    ["@babel/preset-env", { targets: { node: "current" } }],
-    "@babel/preset-typescript",
-  ],
-  plugins: ["babel-plugin-replace-ts-export-assignment"]
-};

--- a/packages/plugin-manifest-validator/package.json
+++ b/packages/plugin-manifest-validator/package.json
@@ -18,6 +18,7 @@
     "name": "Cybozu, Inc.",
     "url": "https://cybozu.co.jp"
   },
+  "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "files": [
@@ -28,9 +29,10 @@
   "scripts": {
     "prebuild": "pnpm clean",
     "build": "tsc --build --force",
-    "postbuild": "pnpm gen-dts",
+    "postbuild": "run-s gen-dts gen-cjs-pkg",
     "clean": "rimraf dist",
     "fix": "pnpm lint --fix",
+    "gen-cjs-pkg": "tsx script/write-cjs-pkg.ts",
     "gen-dts": "tsx script/generate-dts.ts",
     "lint": "eslint src --max-warnings 0",
     "start": "pnpm build --watch",

--- a/packages/plugin-manifest-validator/script/write-cjs-pkg.ts
+++ b/packages/plugin-manifest-validator/script/write-cjs-pkg.ts
@@ -1,0 +1,11 @@
+import { writeFileSync } from "node:fs";
+
+// This package is authored as ESM ("type": "module"), but its build output in
+// dist/ is emitted as CommonJS (tsconfig keeps module: commonjs). Drop a
+// package.json marker so Node treats dist/ as CommonJS regardless of the ESM
+// root, keeping `require()` working for CJS consumers such as
+// @kintone/plugin-packer on Node < 22.
+writeFileSync(
+  "dist/package.json",
+  `${JSON.stringify({ type: "commonjs" }, null, 2)}\n`,
+);

--- a/packages/plugin-manifest-validator/script/write-cjs-pkg.ts
+++ b/packages/plugin-manifest-validator/script/write-cjs-pkg.ts
@@ -1,10 +1,13 @@
-import { writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 
 // This package is authored as ESM ("type": "module"), but its build output in
 // dist/ is emitted as CommonJS (tsconfig keeps module: commonjs). Drop a
 // package.json marker so Node treats dist/ as CommonJS regardless of the ESM
 // root, keeping `require()` working for CJS consumers such as
 // @kintone/plugin-packer on Node < 22.
+// Ensure dist/ exists so this also works when run on its own (not just as the
+// postbuild step after tsc has created it).
+mkdirSync("dist", { recursive: true });
 writeFileSync(
   "dist/package.json",
   `${JSON.stringify({ type: "commonjs" }, null, 2)}\n`,

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - "packages/**"
   - "!**/lib/**"
   - "!**/esm/**"
+  - "!**/dist/**"
   - "!**/templates/**"
 
 minimumReleaseAge: 1440


### PR DESCRIPTION
## Why

Align `@kintone/plugin-manifest-validator` with the kintone frontend tech standard by making its development environment ESM, while keeping the published output as CommonJS so existing consumers are unaffected.

## What

- Add `"type": "module"` so the package is authored and tooled as ESM.
- Keep the build output in `dist/` as CommonJS (tsconfig stays `module: commonjs`). A generated `dist/package.json` marker (`{"type":"commonjs"}`, written by `script/write-cjs-pkg.ts`) lets Node treat the emitted output as CJS even under the ESM root, so CJS consumers such as `@kintone/plugin-packer` keep working with `require()` on Node < 22.
- Remove dead `babel.config.js` (CJS, leftover from the jest era; unused since the vitest migration and would break under `"type": "module"`).

## How to test

- `pnpm build` / `pnpm test` / `pnpm lint`
- Verified the consumer `@kintone/plugin-packer` still builds and its tests pass against this change.