### PR TITLE
ci: stop running push-triggered CI on renovate branches

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - "renovate/**"
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - "renovate/**"
   pull_request:
 
 jobs:


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

The `test` and `lint` workflows are triggered by both `push` (on `main` and `renovate/**`) and `pull_request`. Since Renovate always opens a PR for its branches, every commit on a renovate branch runs the same CI twice: once for the push event and once for the pull_request event. Renovate PRs account for most CI runs in this repository, so this duplication roughly doubles the CI workload for no additional signal.

## What

Remove `renovate/**` from the `push` trigger of `test.yml` and `lint.yml`. Renovate PRs are still fully covered by the `pull_request` trigger, and pushes to `main` keep running CI as before.

Renovate's automerge in this repository is PR-based (`automergeType` defaults to `"pr"`; the shared `cybozu/renovate-config` only uses branch automerge for the CircleCI manager), so it relies on PR checks and does not need push-triggered runs. If branch automerge is ever enabled for npm, the push trigger would need to be restored.

## How to test

This is a trigger-only change and cannot be exercised locally:

- Verified the YAML with Prettier and confirmed no other workflow references `renovate/**` (`grep -rn renovate .github/workflows/`)
- After merging, renovate branches should show a single CI run per commit (pull_request only)

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.