### PR TITLE
feat(dts-gen): add missing kintone JS API type definitions

### DIFF
--- a/packages/dts-gen/kintone.d.ts
+++ b/packages/dts-gen/kintone.d.ts
@@ -85,6 +85,43 @@ declare namespace kintone {
     ): Promise<any>;
   }
 
+  function getUserPreference(): Promise<UserPreference>;
+  function isUsersAndSystemAdministrator(): Promise<boolean>;
+  function getAvailableServices(): Promise<AvailableServices>;
+  function getDomain(): Promise<KintoneDomain>;
+  function getAvailableApiTypes(): Promise<KintoneApiType[]>;
+  function isAccessWithClientCertificateAuthentication(): Promise<boolean>;
+  function isMobileApp(): Promise<boolean>;
+  function isMobilePage(): Promise<boolean>;
+  function isRevampedUI(): Promise<boolean>;
+  function getPageType(): Promise<PageTypeResult>;
+  function showConfirmDialog(
+    config: ConfirmDialogConfig,
+  ): Promise<ConfirmDialogResult>;
+  function createDialog(config: CreateDialogConfig): Promise<Dialog>;
+  function showNotification(
+    type: NotificationType,
+    message: string,
+  ): Promise<void>;
+  function showLoading(state: "VISIBLE" | "HIDDEN"): Promise<void>;
+  function buildPageUrl(
+    page: PageType,
+    params: BuildPageUrlParams,
+  ): Promise<string>;
+  function setKeyboardShortcuts(
+    config: boolean | Partial<Record<ShortcutName, boolean>>,
+  ): Promise<void>;
+  function getKeyboardShortcuts(): Promise<
+    Partial<Record<ShortcutName, boolean>>
+  >;
+
+  namespace user {
+    function getOrganizations(code?: string): Promise<OrganizationMembership[]>;
+    function getGroups(code?: string): Promise<KintoneGroup[]>;
+    function getCustomFields(code?: string): Promise<KintoneCustomField[]>;
+    function getIcons(params: { users: string[] }): Promise<KintoneUserIcon[]>;
+  }
+
   namespace app {
     function getFieldElements(fieldCode: string): HTMLElement[] | null;
     function getHeaderMenuSpaceElement(): HTMLElement | null;
@@ -95,6 +132,51 @@ declare namespace kintone {
     function getQueryCondition(): string | null;
     function getRelatedRecordsTargetAppId(fieldCode: string): string | null;
 
+    function get(): Promise<AppInfo>;
+    function getFormFields(): Promise<any>;
+    function getFormLayout(): Promise<any>;
+    function isTestEnvironment(): Promise<boolean>;
+    function isMaintenanceMode(): Promise<boolean>;
+    function showDescription(state: "OPEN" | "CLOSED"): Promise<void>;
+    function getDescriptionDisplayState(): Promise<
+      "OPEN" | "CLOSED" | "HIDDEN"
+    >;
+    function getIcons(apps: number[]): Promise<AppIcon[]>;
+    function getView(): Promise<RecordListView>;
+    function getViews(): Promise<View[]>;
+    function getReports(): Promise<Report[]>;
+    function getStatus(): Promise<any>;
+    function getCategories(): Promise<Categories>;
+    function getPermissions(): Promise<AppPermissions>;
+    function showAddRecordButton(state: DisplayState): Promise<void>;
+    function getAddRecordButtonDisplayState(): Promise<DisplayState>;
+    function showAppSettingsButton(state: DisplayState): Promise<void>;
+    function getAppSettingsButtonDisplayState(): Promise<DisplayState>;
+    function showOptionsButton(state: DisplayState): Promise<void>;
+    function getOptionsButtonDisplayState(): Promise<DisplayState>;
+    function showFilterButton(state: DisplayState): Promise<void>;
+    function getFilterButtonDisplayState(): Promise<DisplayState>;
+    function showReportButton(state: DisplayState): Promise<void>;
+    function getReportButtonDisplayState(): Promise<DisplayState>;
+    function showViewAndReportSelector(state: DisplayState): Promise<void>;
+    function getViewAndReportSelectorDisplayState(): Promise<DisplayState>;
+    function showViewSelectorItems(
+      config: Record<string, DisplayState>,
+    ): Promise<void>;
+    function getViewSelectorItemsDisplayState(): Promise<
+      Record<string, DisplayState>
+    >;
+    function showReportSelectorItems(
+      config: Record<string, DisplayState>,
+    ): Promise<void>;
+    function getReportSelectorItemsDisplayState(): Promise<
+      Record<string, DisplayState>
+    >;
+    function setRecordListStyle(
+      config: RecordListStyleConfig | "DEFAULT",
+    ): Promise<void>;
+    function getRecordListStyle(): Promise<RecordListStyleResult>;
+
     namespace record {
       function getId(): number | null;
       function get(): any | null;
@@ -104,10 +186,65 @@ declare namespace kintone {
       function getSpaceElement(id: string): HTMLElement | null;
       function setFieldShown(fieldCode: string, isShown: boolean): void;
       function setGroupFieldOpen(fieldCode: string, isOpen: boolean): void;
+
+      function isGroupFieldOpen(fieldCode: string): Promise<boolean>;
+      function getPermissions(): Promise<RecordPermissions>;
+      function getFieldPermissions(): Promise<
+        Record<string, { readField: boolean; editField: boolean }>
+      >;
+      function getStatusHistory(
+        offset?: number,
+        limit?: number,
+      ): Promise<StatusHistoryEntry[]>;
+      function getStatusActions(): Promise<StatusAction[]>;
+      function getAssignees(): Promise<Assignee[]>;
+      function getActions(): Promise<Array<{ name: string; id: string }>>;
+      function isFieldVisible(fieldCode: string): Promise<boolean>;
+      function showEditRecordButton(state: DisplayState): Promise<void>;
+      function getEditRecordButtonDisplayState(): Promise<DisplayState>;
+      function showDuplicateRecordButton(state: DisplayState): Promise<void>;
+      function getDuplicateRecordButtonDisplayState(): Promise<DisplayState>;
+      function showPager(state: DisplayState): Promise<void>;
+      function getPagerDisplayState(): Promise<DisplayState>;
+      function showSideBar(state: SideBarDisplayState): Promise<void>;
+      function getSideBarDisplayState(): Promise<SideBarDisplayState>;
+      function showChangeAssigneeButton(state: DisplayState): Promise<void>;
+      function getChangeAssigneeButtonDisplayState(): Promise<DisplayState>;
+      function showActionButton(
+        action: string,
+        state: DisplayState,
+      ): Promise<void>;
+      function getActionButtonDisplayState(
+        action: string,
+      ): Promise<DisplayState>;
+      function showStatusActionButton(
+        action: string,
+        state: DisplayState,
+      ): Promise<void>;
+      function getStatusActionButtonDisplayState(
+        action: string,
+      ): Promise<DisplayState>;
+      function setFieldStyle(
+        fieldCode: string,
+        config: FieldStyleConfig | "DEFAULT",
+      ): Promise<void>;
+      function getFieldStyle(fieldCode: string): Promise<FieldStyleResult>;
     }
   }
 
   namespace mobile {
+    function showNotification(
+      type: NotificationType,
+      message: string,
+    ): Promise<void>;
+    function showLoading(state: "VISIBLE" | "HIDDEN"): Promise<void>;
+    function showConfirmBottomSheet(
+      config: ConfirmBottomSheetConfig,
+    ): Promise<ConfirmDialogResult>;
+    function createBottomSheet(
+      config: CreateBottomSheetConfig,
+    ): Promise<BottomSheet>;
+
     namespace app {
       function getFieldElements(fieldCode: string): HTMLElement[] | null;
       function getHeaderSpaceElement(): HTMLElement | null;
@@ -117,6 +254,45 @@ declare namespace kintone {
       function getQueryCondition(): string | null;
       function getRelatedRecordsTargetAppId(fieldCode: string): string | null;
 
+      function get(): Promise<AppInfo>;
+      function getFormFields(): Promise<any>;
+      function getFormLayout(): Promise<any>;
+      function isTestEnvironment(): Promise<boolean>;
+      function isMaintenanceMode(): Promise<boolean>;
+      function getIcons(apps: number[]): Promise<AppIcon[]>;
+      function getView(): Promise<RecordListView>;
+      function getViews(): Promise<View[]>;
+      function getReports(): Promise<Report[]>;
+      function getStatus(): Promise<any>;
+      function getCategories(): Promise<Categories>;
+      function getPermissions(): Promise<AppPermissions>;
+      function showAddRecordButton(state: DisplayState): Promise<void>;
+      function getAddRecordButtonDisplayState(): Promise<DisplayState>;
+      function showOptionsButton(state: DisplayState): Promise<void>;
+      function getOptionsButtonDisplayState(): Promise<DisplayState>;
+      function showFilterButton(state: DisplayState): Promise<void>;
+      function getFilterButtonDisplayState(): Promise<DisplayState>;
+      function showViewSelector(state: DisplayState): Promise<void>;
+      function getViewSelectorDisplayState(): Promise<DisplayState>;
+      function showViewSelectorItems(
+        config: Record<string, DisplayState>,
+      ): Promise<void>;
+      function getViewSelectorItemsDisplayState(): Promise<
+        Record<string, DisplayState>
+      >;
+      function showReportSelector(state: DisplayState): Promise<void>;
+      function getReportSelectorDisplayState(): Promise<DisplayState>;
+      function showReportSelectorItems(
+        config: Record<string, DisplayState>,
+      ): Promise<void>;
+      function getReportSelectorItemsDisplayState(): Promise<
+        Record<string, DisplayState>
+      >;
+      function setRecordListStyle(
+        config: RecordListStyleConfig | "DEFAULT",
+      ): Promise<void>;
+      function getRecordListStyle(): Promise<RecordListStyleResult>;
+
       namespace record {
         function getId(): number | null;
         function get(): any | null;
@@ -125,6 +301,42 @@ declare namespace kintone {
         function getSpaceElement(id: string): HTMLElement | null;
         function setFieldShown(fieldCode: string, isShown: boolean): void;
         function setGroupFieldOpen(fieldCode: string, isOpen: boolean): void;
+
+        function isGroupFieldOpen(fieldCode: string): Promise<boolean>;
+        function getPermissions(): Promise<RecordPermissions>;
+        function getFieldPermissions(): Promise<
+          Record<string, { readField: boolean; editField: boolean }>
+        >;
+        function getStatusHistory(
+          offset?: number,
+          limit?: number,
+        ): Promise<StatusHistoryEntry[]>;
+        function getStatusActions(): Promise<StatusAction[]>;
+        function getAssignees(): Promise<Assignee[]>;
+        function isFieldVisible(fieldCode: string): Promise<boolean>;
+        function showEditRecordButton(state: DisplayState): Promise<void>;
+        function getEditRecordButtonDisplayState(): Promise<DisplayState>;
+        function showPager(state: DisplayState): Promise<void>;
+        function getPagerDisplayState(): Promise<DisplayState>;
+        function showActionButton(
+          action: string,
+          state: DisplayState,
+        ): Promise<void>;
+        function getActionButtonDisplayState(
+          action: string,
+        ): Promise<DisplayState>;
+        function showStatusActionButton(
+          action: string,
+          state: DisplayState,
+        ): Promise<void>;
+        function getStatusActionButtonDisplayState(
+          action: string,
+        ): Promise<DisplayState>;
+        function setFieldStyle(
+          fieldCode: string,
+          config: FieldStyleConfig | "DEFAULT",
+        ): Promise<void>;
+        function getFieldStyle(fieldCode: string): Promise<FieldStyleResult>;
       }
     }
 
@@ -199,9 +411,22 @@ declare namespace kintone {
   }
 
   namespace space {
+    function get(): Promise<SpaceInfo>;
+    function getPermissions(): Promise<SpacePermissions>;
+
     namespace portal {
       function getContentSpaceElement(): HTMLElement | null;
     }
+  }
+
+  namespace system {
+    function getAvailableFeatures(): Promise<AvailableFeatures>;
+    function getPermissions(): Promise<SystemPermissions>;
+  }
+
+  namespace license {
+    function isTrial(): Promise<boolean>;
+    function getSubscriptionPlan(): Promise<SubscriptionPlan>;
   }
 
   interface LoginUser {
@@ -223,6 +448,423 @@ declare namespace kintone {
   function getUiVersion(): 1 | 2;
 
   const $PLUGIN_ID: string;
+
+  // ---- Shared types ----
+
+  type DisplayState = "VISIBLE" | "HIDDEN";
+  type SideBarDisplayState = "CLOSED" | "COMMENTS" | "HISTORY" | "HIDDEN";
+  type ConfirmDialogResult = "OK" | "CANCEL" | "CLOSE";
+  type NotificationType = "ERROR" | "SUCCESS" | "INFO";
+  type SubscriptionPlan = "STANDARD" | "WIDE";
+  type KintoneApiType = "CORE" | "WIDE";
+  type ShortcutName =
+    | "SHOW_RECORD"
+    | "FOCUS_SEARCH_BOX"
+    | "SHORTCUTS_HELP"
+    | "CREATE_RECORD"
+    | "EDIT_RECORD"
+    | "NEXT_RECORD"
+    | "PREVIOUS_RECORD"
+    | "NEXT_PAGE"
+    | "PREVIOUS_PAGE"
+    | "CANCEL_EDITING"
+    | "SHOW_VIEW"
+    | "SHOW_FILTER"
+    | "SAVE_RECORD";
+  type PageType =
+    | "APP_INDEX"
+    | "APP_CREATE"
+    | "APP_DETAIL"
+    | "APP_EDIT"
+    | "APP_PRINT"
+    | "APP_REPORT"
+    | "APP_INDEX_MOBILE"
+    | "APP_CREATE_MOBILE"
+    | "APP_DETAIL_MOBILE"
+    | "APP_EDIT_MOBILE"
+    | "APP_REPORT_MOBILE"
+    | "PORTAL_TOP"
+    | "PORTAL_TOP_MOBILE"
+    | "SPACE_PORTAL"
+    | "SPACE_THREAD"
+    | "SPACE_PORTAL_MOBILE"
+    | "SPACE_THREAD_MOBILE"
+    | "PEOPLE_TOP"
+    | "PEOPLE_TOP_MOBILE"
+    | "MESSAGE_TOP"
+    | "MESSAGE_TOP_MOBILE"
+    | "SEARCH_TOP"
+    | "SEARCH_TOP_MOBILE"
+    | "NOTIFICATION_TOP"
+    | "APP_MARKETPLACE_TOP"
+    | "APP_MARKETPLACE_CATEGORY"
+    | "APP_MARKETPLACE_SEARCH"
+    | "APP_MARKETPLACE_DETAIL"
+    | "APP_SETTINGS_PLUGIN_SETTINGS";
+
+  // ---- Interfaces ----
+
+  interface UserPreference {
+    timeFormat: "TWELVE" | "TWENTY_FOUR";
+    desktopNotifications: {
+      enabled: boolean;
+    };
+    emailNotifications: {
+      enabled: boolean;
+      condition: "TO_ME" | "ALL";
+      format: "HTML" | "TEXT";
+    };
+  }
+
+  interface OrganizationMembership {
+    organization: {
+      id: string;
+      code: string;
+      name: string;
+      primary: boolean;
+    };
+    title: {
+      id: string;
+      code: string;
+      name: string;
+    } | null;
+  }
+
+  interface KintoneGroup {
+    id: string;
+    code: string;
+    name: string;
+  }
+
+  interface KintoneCustomField {
+    code: string;
+    name: string;
+    type: "SINGLE_LINE_TEXT" | "USER_SELECT";
+    value: string | { code: string; name: string };
+    visibility: "PUBLIC" | "PRIVATE";
+  }
+
+  interface KintoneUserIcon {
+    user: string;
+    url: string;
+  }
+
+  interface AvailableServices {
+    garoon: boolean;
+    office: boolean;
+    mailwise: boolean;
+  }
+
+  interface KintoneDomain {
+    subdomain: string;
+    baseDomain: "cybozu.com" | "cybozu.cn" | "kintone.com";
+  }
+
+  interface PageTypeResult {
+    type:
+      | "APP"
+      | "PORTAL"
+      | "SPACE"
+      | "PEOPLE"
+      | "MESSAGE"
+      | "SEARCH"
+      | "NOTIFICATION"
+      | "APP_MARKETPLACE"
+      | "APP_SETTINGS";
+    page: PageType;
+  }
+
+  interface ConfirmDialogConfig {
+    title?: string;
+    body?: string;
+    showOkButton?: boolean;
+    okButtonText?: string;
+    showCancelButton?: boolean;
+    cancelButtonText?: string;
+    showCloseButton?: boolean;
+  }
+
+  interface ConfirmBottomSheetConfig {
+    title?: string;
+    body?: string;
+    showOkButton?: boolean;
+    okButtonText?: string;
+    showCancelButton?: boolean;
+    cancelButtonText?: string;
+    showCloseButton?: boolean;
+  }
+
+  type DialogCloseResult = "OK" | "CANCEL" | "CLOSE" | "FUNCTION";
+
+  interface CreateDialogConfig {
+    title?: string;
+    body?: Element;
+    showOkButton?: boolean;
+    okButtonText?: string;
+    showCancelButton?: boolean;
+    cancelButtonText?: string;
+    showCloseButton?: boolean;
+    beforeClose?: (
+      action: "OK" | "CANCEL" | "CLOSE",
+    ) => boolean | void | Promise<boolean | void>;
+  }
+
+  interface Dialog {
+    show(): Promise<DialogCloseResult>;
+    close(): void;
+  }
+
+  interface CreateBottomSheetConfig {
+    title?: string;
+    body?: Element;
+    showOkButton?: boolean;
+    okButtonText?: string;
+    showCancelButton?: boolean;
+    cancelButtonText?: string;
+    showCloseButton?: boolean;
+    beforeClose?: (
+      action: "OK" | "CANCEL" | "CLOSE",
+    ) => boolean | void | Promise<boolean | void>;
+  }
+
+  interface BottomSheet {
+    show(): Promise<DialogCloseResult>;
+    close(): void;
+  }
+
+  interface BuildPageUrlParams {
+    appId?: string;
+    recordId?: string;
+    viewId?: string;
+    reportId?: string;
+    spaceId?: string;
+    threadId?: string;
+    userCode?: string;
+  }
+
+  interface AppInfo {
+    id: string;
+    name: string;
+    description: string;
+    code: string | null;
+    numberPrecision: {
+      digits: number;
+      decimalPlaces: number;
+      roundingMode: "HALF_EVEN" | "UP" | "DOWN";
+    };
+    enableComments: boolean;
+    enableThumbnails: boolean;
+    enableChangeHistory: boolean;
+    enableInlineRecordEditing: boolean;
+    createdAt: string;
+    creator: { code: string; name: string };
+    modifiedAt: string;
+    modifier: { code: string; name: string };
+    spaceId: string | null;
+    revision: string;
+  }
+
+  interface AppIcon {
+    app: number;
+    url: string;
+  }
+
+  interface RecordListView {
+    type: "LIST" | "CALENDAR" | "CUSTOM";
+    builtinType?: "ASSIGNEE" | "ALL";
+    name: string;
+    id: string;
+    fields?: string[];
+    date?: string;
+    title?: string;
+    html?: string;
+    pager?: boolean;
+    device?: "DESKTOP" | "ANY";
+    filterCond: string;
+    sort: string;
+  }
+
+  interface View {
+    type: "LIST" | "CALENDAR" | "CUSTOM";
+    builtinType?: "ASSIGNEE" | "ALL";
+    name: string;
+    id: string;
+  }
+
+  interface Report {
+    name: string;
+    id: string;
+    chartType:
+      | "BAR"
+      | "COLUMN"
+      | "PIE"
+      | "LINE"
+      | "PIVOT_TABLE"
+      | "TABLE"
+      | "AREA"
+      | "SPLINE"
+      | "SPLINE_AREA";
+    periodicReport: boolean;
+  }
+
+  interface AppPermissions {
+    addRecord: boolean;
+    editApp: boolean;
+  }
+
+  interface Categories {
+    enabled: boolean;
+    categories: Record<
+      string,
+      {
+        name: string;
+        index: string;
+        children: Record<string, any>;
+      }
+    >;
+  }
+
+  interface RecordPermissions {
+    editRecord: boolean;
+    deleteRecord: boolean;
+  }
+
+  interface StatusHistoryEntry {
+    changedAt: string;
+    assignees: Array<{ code: string; name: string }>;
+    status: string;
+  }
+
+  interface StatusAction {
+    name: string;
+    nextStatus: {
+      name: string;
+      type: "ONE" | "ALL" | "ANY";
+      assignees: Array<{ code: string; name: string }>;
+    };
+  }
+
+  interface Assignee {
+    assignee: { code: string; name: string };
+    action: string | null;
+  }
+
+  interface FieldStyleConfig {
+    content?:
+      | {
+          backgroundColor?: string;
+          color?: string;
+          fontWeight?: "normal" | "bold";
+          textDecoration?: "none" | "underline" | "line-through";
+          borderColor?: string;
+        }
+      | "DEFAULT";
+    background?: { backgroundColor?: string } | "DEFAULT";
+    label?:
+      | {
+          color?: string;
+          fontWeight?: "normal" | "bold";
+          textDecoration?: "none" | "underline" | "line-through";
+        }
+      | "DEFAULT";
+  }
+
+  interface FieldStyleResult {
+    content: {
+      backgroundColor: string;
+      color: string;
+      fontWeight: string;
+      textDecoration: string;
+      borderColor: string;
+    };
+    background: {
+      backgroundColor: string;
+    };
+    label: {
+      color: string;
+      fontWeight: string;
+      textDecoration: string;
+    };
+  }
+
+  interface RecordListStyleConfig {
+    header?:
+      | Array<{
+          columnType?: "FIELD" | "ACTION";
+          column?: string;
+          content?:
+            | { color?: string; fontWeight?: string; textDecoration?: string }
+            | "DEFAULT";
+          background?: { backgroundColor?: string } | "DEFAULT";
+        }>
+      | "DEFAULT";
+    body?:
+      | Array<{
+          recordId?: string;
+          style?:
+            | Array<{
+                columnType?: "FIELD" | "ACTION";
+                column?: string;
+                content?:
+                  | {
+                      color?: string;
+                      fontWeight?: string;
+                      textDecoration?: string;
+                      backgroundColor?: string;
+                      borderColor?: string;
+                    }
+                  | "DEFAULT";
+                background?: { backgroundColor?: string } | "DEFAULT";
+              }>
+            | "DEFAULT";
+        }>
+      | "DEFAULT";
+  }
+
+  interface RecordListStyleResult {
+    header: Array<{
+      columnType: "FIELD" | "ACTION";
+      column: string;
+      content: { color: string; fontWeight: string; textDecoration: string };
+      background: { backgroundColor: string };
+    }>;
+    body: Array<{
+      recordId: string;
+      style: Array<{
+        columnType: "FIELD" | "ACTION";
+        column: string;
+        content: {
+          color: string;
+          fontWeight: string;
+          textDecoration: string;
+          backgroundColor: string;
+          borderColor: string;
+        };
+        background: { backgroundColor: string };
+      }>;
+    }>;
+  }
+
+  interface SpaceInfo {
+    id: string;
+    name: string;
+    isGuest: boolean;
+  }
+
+  interface SpacePermissions {
+    administration: boolean;
+  }
+
+  interface AvailableFeatures {
+    space: { enabled: boolean };
+    guestSpace: { enabled: boolean };
+    people: { enabled: boolean };
+    message: { enabled: boolean };
+  }
+
+  interface SystemPermissions {
+    administration: boolean;
+  }
 
   namespace fieldTypes {
     interface SingleLineText {


### PR DESCRIPTION
## Why

`kintone.d.ts` in `packages/dts-gen` is manually maintained and has fallen significantly behind the JS API published on the [Cybozu Developer Network](https://cybozu.dev/ja/kintone/docs/js-api/). A cross-reference against the full Cybozu Developer Network JS API index found 90 documented pages with no corresponding type definition (mobile counterparts pushed the real gap well beyond 90 individual functions).

## What

Added type definitions for all missing APIs, cross-checked page by page against the Cybozu Developer Network to confirm exact function names, namespaces, and PC/mobile availability:

- `kintone.*`: `getUserPreference`, `isUsersAndSystemAdministrator`, `getAvailableServices`, `getDomain`, `getAvailableApiTypes`, `isAccessWithClientCertificateAuthentication`, `isMobileApp`, `isMobilePage`, `isRevampedUI`, `getPageType`, `showConfirmDialog`, `createDialog`, `showNotification`, `showLoading`, `buildPageUrl`, `setKeyboardShortcuts`, `getKeyboardShortcuts`
- `kintone.user.*` (new namespace): `getOrganizations`, `getGroups`, `getCustomFields`, `getIcons`
- `kintone.app.*`: `get`, `getFormFields`, `getFormLayout`, `isTestEnvironment`, `isMaintenanceMode`, `showDescription`, `getDescriptionDisplayState`, `getIcons`, `getView`, `getViews`, `getReports`, `getStatus`, `getCategories`, `getPermissions`, and the show/get-display-state button pairs for add-record / app-settings / options / filter / report / view-and-report-selector / view-selector-items / report-selector-items, plus `setRecordListStyle` / `getRecordListStyle`
- `kintone.app.record.*`: `isGroupFieldOpen`, `getPermissions`, `getFieldPermissions`, `getStatusHistory`, `getStatusActions`, `getAssignees`, `getActions`, `isFieldVisible`, and the show/get-display-state pairs for edit-record / duplicate-record / pager / side-bar / change-assignee / action-button / status-action-button, plus `setFieldStyle` / `getFieldStyle`
- `kintone.space.*`: `get`, `getPermissions`
- `kintone.system.*` (new namespace): `getAvailableFeatures`, `getPermissions`
- `kintone.license.*` (new namespace): `isTrial`, `getSubscriptionPlan`
- `kintone.mobile.*`: mirrors of all the above where the Cybozu Developer Network documents a separate mobile-only or mobile-mirrored signature (`showNotification`, `showLoading`, `showConfirmBottomSheet`, `createBottomSheet`, and the `mobile.app.*` / `mobile.app.record.*` mirrors)

Type precision: simple types (`boolean`/`string`/literal unions) and structurally simple response objects are typed precisely; large free-form objects that mirror the REST API response shape (`getFormFields`, `getFormLayout`, `getStatus`) are typed as `any`, consistent with the existing style in this file.

## How to test

```sh
cd packages/dts-gen
pnpm lint:prettier
pnpm test
```

The new definitions were cross-checked against the full Cybozu Developer Network JS API index and verified with a standalone `tsc` compile check.

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
